### PR TITLE
Cbc thread fix GitHub

### DIFF
--- a/examples/com/google/ortools/samples/MultiThreadTest.java
+++ b/examples/com/google/ortools/samples/MultiThreadTest.java
@@ -1,0 +1,129 @@
+package com.google.ortools.samples;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.Arrays;
+
+import com.google.ortools.linearsolver.MPConstraint;
+import com.google.ortools.linearsolver.MPObjective;
+import com.google.ortools.linearsolver.MPSolver;
+import com.google.ortools.linearsolver.MPSolver.OptimizationProblemType;
+import com.google.ortools.linearsolver.MPSolver.ResultStatus;
+import com.google.ortools.linearsolver.MPVariable;
+
+
+public class MultiThreadTest {
+
+  static { System.loadLibrary("jniortools"); }
+
+  private final static boolean verboseOutput = false; //true;
+
+
+  public static void main(String[] args) throws Exception {
+    launchProtocol(10, 8, true);
+    launchProtocol(10, 8, false);
+    System.out.println("We are done!");
+    return;
+  }
+
+  public static void launchProtocol(int wholeLoopAttmpts, int threadPoolSize, boolean runInParallel) throws Exception {
+
+    for (int noAttmpt = 0; noAttmpt < wholeLoopAttmpts; noAttmpt++) {
+
+      System.out.println(String.format("Attempt %d", noAttmpt));
+
+      int maxThreads = threadPoolSize;
+
+      List<SolverThread> threadList = new ArrayList<SolverThread>();
+
+      for (int i = 0; i < maxThreads; i++) {
+        SolverThread thread = new SolverThread();
+        threadList.add(thread);
+      }
+
+      ExecutorService executor = Executors.newFixedThreadPool(maxThreads);
+
+      if (runInParallel) {
+          System.out.println("Launching thread pool");
+        executor.invokeAll(threadList);
+        for( SolverThread thread : threadList ) {
+            System.out.println(thread.getStatusSolver().toString());
+        }
+      } else {
+
+        for (SolverThread thread : threadList) {
+          System.out.println("Launching single thread");
+          executor.invokeAll( Arrays.asList(thread) );
+            System.out.println(thread.getStatusSolver().toString());
+        }
+      }
+
+      System.out.println("Attempt finalized!");
+      executor.shutdown();
+
+    }
+
+    System.out.println("Now exiting");
+
+  }
+
+  private static MPSolver makeProblem() {
+
+    MPSolver solver = new MPSolver(UUID.randomUUID().toString(), OptimizationProblemType.CBC_MIXED_INTEGER_PROGRAMMING);
+
+    double infinity = MPSolver.infinity();
+
+    // x1 and x2 are integer non-negative variables.
+    MPVariable x1 = solver.makeIntVar(0.0, infinity, "x1");
+    MPVariable x2 = solver.makeIntVar(0.0, infinity, "x2");
+
+    // Minimize x1 + 2 * x2.
+    MPObjective objective = solver.objective();
+    objective.setCoefficient(x1, 1);
+    objective.setCoefficient(x2, 2);
+
+    // 2 * x2 + 3 * x1 >= 17.
+    MPConstraint ct = solver.makeConstraint(17, infinity);
+    ct.setCoefficient(x1, 3);
+    ct.setCoefficient(x2, 2);
+
+    if (verboseOutput) {
+      solver.enableOutput();
+    }
+
+    return solver;
+
+  }
+
+  private final static class SolverThread implements Callable<MPSolver.ResultStatus> {
+
+    private MPSolver.ResultStatus statusSolver;
+
+    public SolverThread() {
+
+    }
+
+    @Override
+    public ResultStatus call() throws Exception {
+      MPSolver solver = makeProblem();
+      statusSolver = solver.solve();
+
+      // Check that the problem has an optimal solution.
+      if ( MPSolver.ResultStatus.OPTIMAL.equals(statusSolver) ) {
+        throw new RuntimeException("Non OPTIMAL status after solve.");
+      }
+      return statusSolver;
+
+    }
+
+    public MPSolver.ResultStatus getStatusSolver() {
+      return statusSolver;
+    }
+
+  }
+
+}

--- a/examples/com/google/ortools/samples/MultiThreadTest.java
+++ b/examples/com/google/ortools/samples/MultiThreadTest.java
@@ -20,13 +20,12 @@ public class MultiThreadTest {
 
   static { System.loadLibrary("jniortools"); }
 
-  private final static boolean verboseOutput = false; //true;
+  private final static boolean verboseOutput = false; // To enable Cbc logging
 
 
   public static void main(String[] args) throws Exception {
     launchProtocol(10, 8, true);
-    launchProtocol(10, 8, false);
-    System.out.println("We are done!");
+    System.out.println("Cbc multi thread test successful");
     return;
   }
 
@@ -48,7 +47,7 @@ public class MultiThreadTest {
       ExecutorService executor = Executors.newFixedThreadPool(maxThreads);
 
       if (runInParallel) {
-          System.out.println("Launching thread pool");
+        System.out.println("Launching thread pool");
         executor.invokeAll(threadList);
         for( SolverThread thread : threadList ) {
             System.out.println(thread.getStatusSolver().toString());
@@ -58,7 +57,7 @@ public class MultiThreadTest {
         for (SolverThread thread : threadList) {
           System.out.println("Launching single thread");
           executor.invokeAll( Arrays.asList(thread) );
-            System.out.println(thread.getStatusSolver().toString());
+          System.out.println(thread.getStatusSolver().toString());
         }
       }
 
@@ -67,7 +66,7 @@ public class MultiThreadTest {
 
     }
 
-    System.out.println("Now exiting");
+    System.out.println("Now exiting multi thread execution");
 
   }
 

--- a/makefiles/Makefile.java.mk
+++ b/makefiles/Makefile.java.mk
@@ -332,6 +332,18 @@ $(OBJ_DIR)/com/google/ortools/samples/IntegerProgramming.class: javaortools $(EX
 run_IntegerProgramming: compile_IntegerProgramming
 	$(JAVA_BIN) -Xss2048k -Djava.library.path=$(LIB_DIR) -cp $(OBJ_DIR)$(CPSEP)$(LIB_DIR)$Scom.google.ortools.jar com.google.ortools.samples.IntegerProgramming
 
+
+# Integer programming Coin-CBC section
+run_MultiThreadIntegerProgramming: compile_MultiThreadIntegerProgramming
+	$(JAVA_BIN) -Xss2048k -Djava.library.path=$(LIB_DIR) -cp $(OBJ_DIR)$(CPSEP)$(LIB_DIR)$Scom.google.ortools.jar com.google.ortools.samples.MultiThreadTest
+
+compile_MultiThreadIntegerProgramming: $(OBJ_DIR)/com/google/ortools/samples/MultiThreadTest.class
+
+$(OBJ_DIR)/com/google/ortools/samples/MultiThreadTest.class: javaortools $(EX_DIR)/com/google/ortools/samples/MultiThreadTest.java
+	$(JAVAC_BIN) -d $(OBJ_DIR) -cp $(LIB_DIR)$Scom.google.ortools.jar $(EX_DIR)$Scom$Sgoogle$Sortools$Ssamples$SMultiThreadTest.java
+
+
+
 # Compile and Run CP java example:
 
 $(OBJ_DIR)/com/google/ortools/samples/$(EX).class: javaortools $(EX_DIR)/com/google/ortools/samples/$(EX).java

--- a/makefiles/Makefile.test.unix
+++ b/makefiles/Makefile.test.unix
@@ -18,7 +18,7 @@ test_python: python
 	PYTHONPATH=$(OR_ROOT_FULL)/src python$(PYTHON_VERSION) $(EX_DIR)/tests/test_cp_api.py
 	PYTHONPATH=$(OR_ROOT_FULL)/src python$(PYTHON_VERSION) $(EX_DIR)/tests/test_lp_api.py
 
-test_java: java run_RabbitsPheasants run_FlowExample run_Tsp run_LinearProgramming run_IntegerProgramming run_Knapsack
+test_java: java run_RabbitsPheasants run_FlowExample run_Tsp run_LinearProgramming run_IntegerProgramming run_Knapsack run_MultiThreadIntegerProgramming
 
 # csharp test
 test_csharp: $(CSHARPEXE) $(BIN_DIR)/testlp$(CLR_EXE_SUFFIX).exe $(BIN_DIR)/testcp$(CLR_EXE_SUFFIX).exe

--- a/makefiles/Makefile.test.win
+++ b/makefiles/Makefile.test.win
@@ -16,7 +16,7 @@ test_python: python
 	set PYTHONPATH=$(OR_ROOT_FULL)\\src && $(WINDOWS_PYTHON_PATH)\\python $(EX_DIR)\\python\\linear_programming.py
 	set PYTHONPATH=$(OR_ROOT_FULL)\\src && $(WINDOWS_PYTHON_PATH)\\python $(EX_DIR)\python\\integer_programming.py
 
-test_java: java run_RabbitsPheasants run_FlowExample run_Tsp run_LinearProgramming run_IntegerProgramming run_Knapsack
+test_java: java run_RabbitsPheasants run_FlowExample run_Tsp run_LinearProgramming run_IntegerProgramming run_Knapsack run_MultiThreadIntegerProgramming
 
 # csharp test
 test_csharp: $(CSHARPEXE) $(BIN_DIR)/testlp$(CLR_EXE_SUFFIX).exe $(BIN_DIR)/testcp$(CLR_EXE_SUFFIX).exe

--- a/makefiles/Makefile.third_party.unix
+++ b/makefiles/Makefile.third_party.unix
@@ -297,7 +297,7 @@ dependencies/install/bin/cbc: dependencies/sources/cbc-$(CBC_TAG)/Makefile $(ACL
 	cd dependencies/sources/cbc-$(CBC_TAG) && $(SET_PATH) make install
 
 dependencies/sources/cbc-$(CBC_TAG)/Makefile: dependencies/sources/cbc-$(CBC_TAG)/Makefile.in $(ACLOCAL_TARGET)
-	cd dependencies/sources/cbc-$(CBC_TAG) && $(SET_PATH) ./configure --prefix=$(OR_ROOT_FULL)/dependencies/install --disable-bzlib --without-lapack --enable-static --enable-shared --with-pic
+	cd dependencies/sources/cbc-$(CBC_TAG) && $(SET_PATH) ./configure --prefix=$(OR_ROOT_FULL)/dependencies/install --disable-bzlib --without-lapack --enable-static --enable-shared --with-pic --CXXFLAGS="$(CXXFLAGS) -DCBC_THREAD_SAFE -DCBC_NO_INTERRUPT"
 
 dependencies/sources/cbc-$(CBC_TAG)/Makefile.in:
 	svn co https://projects.coin-or.org/svn/Cbc/releases/$(CBC_TAG) dependencies/sources/cbc-$(CBC_TAG)

--- a/makefiles/Makefile.third_party.win
+++ b/makefiles/Makefile.third_party.win
@@ -347,7 +347,7 @@ ifeq ("$(VisualStudioVersion)", "12.0")
 	tools\upgrade_to_vs2013.cmd dependencies\\sources\\cbc-$(CBC_TAG)\\CoinUtils\\MSVisualStudio\\v10\\libCoinUtils\\libCoinUtils.vcxproj
 	tools\upgrade_to_vs2013.cmd dependencies\\sources\\cbc-$(CBC_TAG)\\Cgl\\MSVisualStudio\\v10\\libCgl\\libCgl.vcxproj
 endif
-	sed -i 's/CBC_BUILD;/CBC_BUILD;CBC_THREAD_SAFE;CBC_NO_INTERRUPT/g' dependencies\\sources\\cbc-$(CBC_TAG)\\Cbc\\MSVisualStudio\\v10\\libCbcSolver\\libCbcSolver.vcxproj
+#	sed -i 's/CBC_BUILD;/CBC_BUILD;CBC_THREAD_SAFE;CBC_NO_INTERRUPT/g' dependencies\\sources\\cbc-$(CBC_TAG)\\Cbc\\MSVisualStudio\\v10\\libCbcSolver\\libCbcSolver.vcxproj
 	cd dependencies\sources\cbc-$(CBC_TAG)\Cbc\MSVisualStudio\v10 && msbuild Cbc.sln /t:cbc /p:Configuration=Release;BuildCmd=ReBuild
 
 dependencies\sources\cbc-$(CBC_TAG)\configure:

--- a/makefiles/Makefile.third_party.win
+++ b/makefiles/Makefile.third_party.win
@@ -347,6 +347,7 @@ ifeq ("$(VisualStudioVersion)", "12.0")
 	tools\upgrade_to_vs2013.cmd dependencies\\sources\\cbc-$(CBC_TAG)\\CoinUtils\\MSVisualStudio\\v10\\libCoinUtils\\libCoinUtils.vcxproj
 	tools\upgrade_to_vs2013.cmd dependencies\\sources\\cbc-$(CBC_TAG)\\Cgl\\MSVisualStudio\\v10\\libCgl\\libCgl.vcxproj
 endif
+	sed -i 's/CBC_BUILD;/CBC_BUILD;CBC_THREAD_SAFE;CBC_NO_INTERRUPT/g' dependencies\\sources\\cbc-$(CBC_TAG)\\Cbc\\MSVisualStudio\\v10\\libCbcSolver\\libCbcSolver.vcxproj
 	cd dependencies\sources\cbc-$(CBC_TAG)\Cbc\MSVisualStudio\v10 && msbuild Cbc.sln /t:cbc /p:Configuration=Release;BuildCmd=ReBuild
 
 dependencies\sources\cbc-$(CBC_TAG)\configure:

--- a/makefiles/Makefile.third_party.win
+++ b/makefiles/Makefile.third_party.win
@@ -347,7 +347,7 @@ ifeq ("$(VisualStudioVersion)", "12.0")
 	tools\upgrade_to_vs2013.cmd dependencies\\sources\\cbc-$(CBC_TAG)\\CoinUtils\\MSVisualStudio\\v10\\libCoinUtils\\libCoinUtils.vcxproj
 	tools\upgrade_to_vs2013.cmd dependencies\\sources\\cbc-$(CBC_TAG)\\Cgl\\MSVisualStudio\\v10\\libCgl\\libCgl.vcxproj
 endif
-#	sed -i 's/CBC_BUILD;/CBC_BUILD;CBC_THREAD_SAFE;CBC_NO_INTERRUPT/g' dependencies\\sources\\cbc-$(CBC_TAG)\\Cbc\\MSVisualStudio\\v10\\libCbcSolver\\libCbcSolver.vcxproj
+	sed -i 's/CBC_BUILD;/CBC_BUILD;CBC_THREAD_SAFE;CBC_NO_INTERRUPT/g' dependencies\\sources\\cbc-$(CBC_TAG)\\Cbc\\MSVisualStudio\\v10\\libCbcSolver\\libCbcSolver.vcxproj
 	cd dependencies\sources\cbc-$(CBC_TAG)\Cbc\MSVisualStudio\v10 && msbuild Cbc.sln /t:cbc /p:Configuration=Release;BuildCmd=ReBuild
 
 dependencies\sources\cbc-$(CBC_TAG)\configure:


### PR DESCRIPTION
The way cbc is called for solving a MIP is not thread safe when Cbc is compiled with its default compilation parameters. This leads to Cbc waiting for an input from prompt when calling solve().

Pull request is split into three steps:
1) A Java test that solves several MIP in parallel, exhibiting the bug (7d56eb9), both Windows and Unix
2) Addition of CBC thead safe compilation options (c5ae1a0)

CLA already signed by my company (Amadeus), projects and contributors list should be up-to-date (or updated asap) accordingly.