### PR TITLE
Deref demand instead of comparing the pointer adr.

### DIFF
--- a/src/constraint_solver/resource.cc
+++ b/src/constraint_solver/resource.cc
@@ -2151,7 +2151,7 @@ class VariableDemandCumulativeConstraint : public Constraint {
       }
       // Add to the useful_task vector if it may be performed and that it
       // actually consumes some of the resource.
-      if (interval->MayBePerformed() && original_task.demand > 0) {
+      if (interval->MayBePerformed() && *original_task.demand > 0) {
         Solver* const s = solver();
         IntervalVar* const original_interval = original_task.interval;
         IntervalVar* const interval =


### PR DESCRIPTION
De-reference the value of demand instead of comparing the pointer adr to zero. (If a pointer comparison to nullptr was intended, then this should use operator!=)