### PR TITLE
Use value of task.demand instead of comparing pointer adr to 0

### DIFF
--- a/src/constraint_solver/resource.cc
+++ b/src/constraint_solver/resource.cc
@@ -2151,7 +2151,7 @@ class VariableDemandCumulativeConstraint : public Constraint {
       }
       // Add to the useful_task vector if it may be performed and that it
       // actually consumes some of the resource.
-      if (interval->MayBePerformed() && original_task.demand > 0) {
+      if (interval->MayBePerformed() && original_task.demand->Value() > 0) {
         Solver* const s = solver();
         IntervalVar* const original_interval = original_task.interval;
         IntervalVar* const interval =


### PR DESCRIPTION
If a pointer comparison was intended, then this should use ```operator!=``` but at this point this would make little sense since we have already de-referenced ```task.demand``` before so it must be non-null.