### PR TITLE
Fix missing return type in DebugString

### DIFF
--- a/src/flatzinc/model.cc
+++ b/src/flatzinc/model.cc
@@ -576,6 +576,10 @@ std::string FzAnnotation::DebugString() const {
     case STRING_VALUE: {
       return StringPrintf("\"%s\"", string_value_.c_str());
     }
+    default: {
+      LOG(FATAL) << "Unhandled case in DebugString " << static_cast<int>(type);
+      return "";
+    }
   }
 }
 

--- a/src/flatzinc/model.cc
+++ b/src/flatzinc/model.cc
@@ -319,6 +319,9 @@ std::string FzArgument::DebugString() const {
     }
     case VOID_ARGUMENT:
       return "VoidArgument";
+    default:
+      LOG(FATAL) << "Unhandled case in DebugString " << static_cast<int>(type);
+      return "";
   }
 }
 


### PR DESCRIPTION
To avoid warning about missing return type.