### PR TITLE
Initialize double variable target-bound to avoid "maybe-uninitialized" warning

### DIFF
--- a/src/glop/preprocessor.cc
+++ b/src/glop/preprocessor.cc
@@ -1008,7 +1008,7 @@ bool ForcingAndImpliedFreeConstraintPreprocessor::Run(LinearProgram* lp) {
       const Fractional lower = lp->variable_lower_bounds()[col];
       const Fractional upper = lp->variable_upper_bounds()[col];
       bool is_forced = false;
-      Fractional target_bound;
+      Fractional target_bound = 0.0;
       for (const SparseColumn::Entry e : column) {
         if (is_forcing_down[e.row()]) {
           const Fractional candidate = e.coefficient() < 0.0 ? lower : upper;


### PR DESCRIPTION
I am not sure if 0.0 is the right initialization value though. It is used a few lines below in a comparison with ```candidate```.