### PR TITLE
Updated hash_map and hash_set to unordered_map and unordered_set for gcc.

### DIFF
--- a/src/base/int_type.h
+++ b/src/base/int_type.h
@@ -329,14 +329,14 @@ INT_TYPE_COMPARISON_OP(>=);  // NOLINT
 
 // Allows it to be used as a key to hashable containers.
 #if !defined(SWIG) && !defined(STLPORT) && !defined(_MSC_VER)
-namespace __gnu_cxx {
+namespace std {
 template <typename IntTypeName, typename ValueType>
 struct hash<IntType<IntTypeName, ValueType> > {
   size_t operator()(const IntType<IntTypeName, ValueType>& idx) const {
     return static_cast<size_t>(idx.value());
   }
 };
-}  // namespace __gnu_cxx
+} // namespace std
 #endif  // !defined(_MSC_VER) && !defined(SWIG) && !defined(STLPORT)
 
 #endif  // OR_TOOLS_BASE_INT_TYPE_H_


### PR DESCRIPTION
The hash_map and hash_set are deprecated and need to be replaced.
Tested with gcc 4.8.4. and gcc 4.9.3.
