### PR TITLE
Two compiler errors. One in revised_simplex, one in sat_constraint

### DIFF
--- a/src/flatzinc/sat_constraint.cc
+++ b/src/flatzinc/sat_constraint.cc
@@ -125,8 +125,8 @@ class SatPropagator : public Constraint {
 #endif
     const bool new_value = vars_[index]->Value() != 0;
     sat::Literal literal(var, new_value);
-    if (sat_.Assignment().IsVariableAssigned(var)) {
-      if (sat_.Assignment().IsLiteralTrue(literal)) {
+    if (sat_.Assignment().VariableIsAssigned(var)) {
+      if (sat_.Assignment().LiteralIsTrue(literal)) {
 #ifdef SAT_DEBUG
         FZDLOG << " - literal = " << literal.SignedValue()
                << " already processed" << FZENDL;

--- a/src/glop/revised_simplex.cc
+++ b/src/glop/revised_simplex.cc
@@ -32,6 +32,7 @@
 #include "lp_data/lp_utils.h"
 #include "lp_data/matrix_utils.h"
 #include "util/fp_utils.h"
+#include <functional>
 
 DEFINE_bool(simplex_display_numbers_as_fractions, false,
             "Display numbers as fractions.");


### PR DESCRIPTION
Revised simplex doesn't build under VS2013 without a reference to <functional> (function not a member of std error.)
src/flatzinc/sat_constraint method stubs didn't exist. Not a compilable set of code. Looked like a renaming issue. I suspect this is because the fz compile may be untested for releases.