### PR TITLE
#127 added check to see if cmake can be found on the path, before setting …

### DIFF
--- a/makefiles/Makefile.unix
+++ b/makefiles/Makefile.unix
@@ -218,7 +218,12 @@ endif  # LINUX
 ifeq ($(PLATFORM),MACOSX)
   CCC = clang++ -fPIC -std=c++11 -mmacosx-version-min=$(MAC_MIN_VERSION) -stdlib=libc++
   DYNAMIC_LD = ld -arch x86_64 -bundle -flat_namespace -undefined suppress -macosx_version_min $(MAC_MIN_VERSION) -lSystem -compatibility_version 1.0 -current_version $(OR_TOOLS_VERSION)
-  CMAKE = /Applications/CMake.app/Contents/bin/cmake
+  ifeq (, $(shell which cmake))
+    $(warning "no cmake in $(PATH), assuming it is in /Applications ")
+    CMAKE ?= /Applications/CMake.app/Contents/bin/cmake
+  endif
+  # CMAKE = /Applications/CMake.app/Contents/bin/cmake
+  
   JNI_LIB_EXT = jnilib
   ifeq ($(UNIX_MONO_DIR),)
     CSC = gmcs


### PR DESCRIPTION
…it to the cmake in Applications.

This fix to #127 and appears to work if cmake is installed with  Homebrew, and therefor already on the path. I have not tested it to see if still works as originally intended if cmake is in /Applications.  It also works if cmake is set on the command line such as `CMAKE=/usr/local/bin/cmake make third_party`
