### PR TITLE
Fixed missing include in local_search.cc that prevented make from succeeding

### DIFF
--- a/src/constraint_solver/local_search.cc
+++ b/src/constraint_solver/local_search.cc
@@ -17,6 +17,7 @@
 #include "base/hash.h"
 #include <iterator>
 #include <memory>
+#include <numeric>
 #include <set>
 #include <string>
 #include <utility>


### PR DESCRIPTION
The make all command was failing because a missing include for numeric, since iota is used later in the file as of the last merge. Adding a line to include numeric seems to have fixed the make all.