### PR TITLE
Cast to float and avoid divide-by-zero errors in cvrptw.py

### DIFF
--- a/examples/python/cvrptw.py
+++ b/examples/python/cvrptw.py
@@ -352,7 +352,7 @@ class Customers():
                 tranit time from a to b.
         """
         def tranit_time_return(a, b):
-            return(self.distmat[a][b] / (speed_kmph / 60 ** 2))
+            return(self.distmat[a][b] / (speed_kmph * 1.0 / 60 ** 2))
 
         return tranit_time_return
 


### PR DESCRIPTION
Prevents the occurrences of errors like these
```shell
make DEBUG=-g rpy EX=cvrptw
Running python/cvrptw.py
examples/python/cvrptw.py:355: RuntimeWarning: divide by zero encountered in double_scalars
  return(self.distmat[a][b] / (speed_kmph / 60 ** 2))
Traceback (most recent call last):
  File "examples/python/cvrptw.py", line 737, in <module>
    main()
  File "examples/python/cvrptw.py", line 669, in main
    for cust in customers.customers:
OverflowError: cannot convert float infinity to integer
make: *** [rpy] Error 1
```
by making numerator float on multiplying by 1.0