### PR TITLE
fix for CMAKE_PLATFORM if no CMAKE_SUFFIX is set

### DIFF
--- a/makefiles/Makefile.port
+++ b/makefiles/Makefile.port
@@ -140,12 +140,17 @@ ifeq ("$(SYSTEM)","win")
   PORT = VisualStudio$(VISUAL_STUDIO_YEAR)-$(PTRLENGTH)bit
   VS_RELEASE = v$(VISUAL_STUDIO_MAJOR)0
   VS_COMTOOLS = $(VISUAL_STUDIO_MAJOR)0
-  CMAKE_PLATFORM = "Visual Studio $(VISUAL_STUDIO_MAJOR) $(VISUAL_STUDIO_YEAR) $(CMAKE_SUFFIX)"
+ 
+  ifeq ("$(CMAKE_SUFFIX)","")
+    CMAKE_PLATFORM = "Visual Studio $(VISUAL_STUDIO_MAJOR) $(VISUAL_STUDIO_YEAR)"
+  else
+    CMAKE_PLATFORM = "Visual Studio $(VISUAL_STUDIO_MAJOR) $(VISUAL_STUDIO_YEAR) $(CMAKE_SUFFIX)"
+  endif
 
   # Third party specific
   CBC_PLATFORM = $(CBC_PLATFORM_PREFIX)-$(VS_RELEASE)-Release
   SCIP_MAKEFILE = \# SCIP not compiled
-g
+
   # Java specific
   SELECTED_JDK_DEF = WINDOWS_JDK_DIR = \# Please define JDK root.
 endif


### PR DESCRIPTION
This fix allowed build ortools in win x86.

Before thit fiix CMAKE_PLATFORM in x86 has one empty space:
"Visual Studio 12 2013 " 
and generates error:
"cmake  Could not create named generator Visual Studio 12 2013 "
