### PR TITLE
Don't use deprecated method SetVehicleFixedCost

### DIFF
--- a/examples/python/cvrptw_plot.py
+++ b/examples/python/cvrptw_plot.py
@@ -652,7 +652,7 @@ def main():
 
     # Set vehicle costs for each vehicle, not homogenious.
     for veh in vehicles.vehicles:
-        routing.SetVehicleFixedCost(int(veh.index), veh.cost)
+        routing.SetFixedCostOfVehicle(veh.cost, int(veh.index))
 
     # Add a dimension for vehicle capacities
     null_capacity_slack = 0


### PR DESCRIPTION
On [routing.h](https://github.com/google/or-tools/blob/e1b7515c8e8ead5d3d3a1746c8bdbe0621ad292d/src/constraint_solver/routing.h#L947) there's a warning that `SetVehicleFixedCost` has been deprecated and shouldn't be used.