### PR TITLE
trivial: add whitespace around error message

### DIFF
--- a/src/constraint_solver/expressions.cc
+++ b/src/constraint_solver/expressions.cc
@@ -1334,8 +1334,8 @@ class DomainIntVar : public IntVar {
   void SetValue(int64 v) override;
   bool Bound() const override { return (min_.Value() == max_.Value()); }
   int64 Value() const override {
-    CHECK_EQ(min_.Value(), max_.Value()) << "variable " << DebugString()
-                                         << "is not bound.";
+    CHECK_EQ(min_.Value(), max_.Value()) << " variable " << DebugString()
+                                         << " is not bound.";
     return min_.Value();
   }
   void RemoveValue(int64 v) override;
@@ -2854,7 +2854,7 @@ bool PlusCstDomainIntVar::Bound() const {
 
 int64 PlusCstDomainIntVar::Value() const {
   CHECK_EQ(domain_int_var()->min_.Value(), domain_int_var()->max_.Value())
-      << "variable is not bound";
+      << " variable is not bound";
   return domain_int_var()->min_.Value() + cst_;
 }
 
@@ -3403,7 +3403,7 @@ void TimesPosCstBoolVar::WhenRange(Demon* d) { boolean_var()->WhenRange(d); }
 
 int64 TimesPosCstBoolVar::Value() const {
   CHECK_NE(boolean_var()->RawValue(), BooleanVar::kUnboundBooleanVarValue)
-      << "variable is not bound";
+      << " variable is not bound";
   return boolean_var()->RawValue() * cst_;
 }
 


### PR DESCRIPTION
improve errors like this:
[13:26:57] src/constraint_solver/expressions.cc:1337: Check failed: (min_.Value()) == (max_.Value())variable XXX is not bound.
==>
[13:26:57] src/constraint_solver/expressions.cc:1337: Check failed: (min_.Value()) == (max_.Value()) variable XXX is not bound.
