### PR TITLE
Fixed bug with calling RoutingModel()

### DIFF
--- a/examples/python/cvrptw.py
+++ b/examples/python/cvrptw.py
@@ -129,7 +129,7 @@ def main():
     # The number of nodes of the VRP is num_locations.
     # Nodes are indexed from 0 to num_locations - 1. By default the start of
     # a route is node 0.
-    routing = pywrapcp.RoutingModel(num_locations, num_vehicles, depot)
+    routing = pywrapcp.RoutingModel(num_locations, num_vehicles)
     search_parameters = pywrapcp.RoutingModel.DefaultSearchParameters()
 
     # Setting first solution heuristic: the


### PR DESCRIPTION
Sending three int arguments gives a NotImplementedError: Wrong number or type of arguments for overloaded function 'new_RoutingModel'.
I put it to two arguments, not specifying a depot, which works.
Probably want to consider changing the C/C++ prototype to accept a depot argument.
