### PR TITLE
Fix on make thirdparty fail for swigwin

### DIFF
--- a/makefiles/Makefile.third_party.win
+++ b/makefiles/Makefile.third_party.win
@@ -349,7 +349,7 @@ dependencies\install\swigwin-$(SWIG_TAG)\swig.exe: dependencies\archives\swigwin
 	tools\touch.exe dependencies\install\swigwin-$(SWIG_TAG)\swig.exe
 
 dependencies\archives\swigwin-$(SWIG_TAG).zip:
-	tools\wget -P dependencies\archives http://prdownloads.sourceforge.net/swig/swigwin-$(SWIG_TAG).zip
+	tools\wget -P dependencies\archives --no-check-certificate http://prdownloads.sourceforge.net/swig/swigwin-$(SWIG_TAG).zip
 
 # Install glpk if needed.
 install_glpk: $(GLPK_TARGET)


### PR DESCRIPTION
Make thirdparty fails as download of swigwin fails. Certification check was cause of the failure.  Added  --no-check-certificate parameter to wget for solving the problem.