### PR TITLE
Fix undefined function fabs

### DIFF
--- a/ortools/sat/boolean_problem.cc
+++ b/ortools/sat/boolean_problem.cc
@@ -234,12 +234,12 @@ void UseObjectiveForSatAssignmentPreference(const LinearBooleanProblem& problem,
   const LinearObjective& objective = problem.objective();
   double max_weight = 0;
   for (int i = 0; i < objective.literals_size(); ++i) {
-    max_weight = std::max(max_weight,
-                          fabs(static_cast<double>(objective.coefficients(i))));
+    double weight = std::fabs(static_cast<double>(objective.coefficients(i)));
+    max_weight = std::max(max_weight, weight);
   }
   for (int i = 0; i < objective.literals_size(); ++i) {
     const double weight =
-        fabs(static_cast<double>(objective.coefficients(i))) / max_weight;
+        std::fabs(static_cast<double>(objective.coefficients(i))) / max_weight;
     if (objective.coefficients(i) > 0) {
       solver->SetAssignmentPreference(Literal(objective.literals(i)).Negated(),
                                       weight);


### PR DESCRIPTION
- include cmath header
- use std::fabs

This commit fixes compilation of boolean_problem.cc on arch linux with configuration:
$ g++ -v
COLLECT_GCC=g++
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-pc-linux-gnu/6.2.1/lto-wrapper
Target: x86_64-pc-linux-gnu
Configured with: /build/gcc/src/gcc/configure --prefix=/usr --libdir=/usr/lib --libexecdir=/usr/lib --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=https://bugs.archlinux.org/ --enable-languages=c,c++,ada,fortran,go,lto,objc,obj-c++ --enable-shared --enable-threads=posix --enable-libmpx --with-system-zlib --with-isl --enable-__cxa_atexit --disable-libunwind-exceptions --enable-clocale=gnu --disable-libstdcxx-pch --disable-libssp --enable-gnu-unique-object --enable-linker-build-id --enable-lto --enable-plugin --enable-install-libiberty --with-linker-hash-style=gnu --enable-gnu-indirect-function --disable-multilib --disable-werror --enable-checking=release
Thread model: posix
gcc version 6.2.1 20160830 (GCC)
