### PR TITLE
GLPK: Exclude src/proxy/main.c from the build. 

### DIFF
--- a/bazel/glpk.BUILD
+++ b/bazel/glpk.BUILD
@@ -5,7 +5,7 @@ cc_library(
         "glpk-4.52/src/*/*.c",
         "glpk-4.52/src/*.h",
         "glpk-4.52/src/*/*.h",
-    ]),
+    ], exclude = ["glpk-4.52/src/proxy/main.c"]),
     hdrs = [
         "glpk-4.52/src/glpk.h",
     ],


### PR DESCRIPTION
This results in two mains being defined (bazel happily accepts this in tests, for some reason).