### PR TITLE
Docker image to build manylinux1 wheels

### DIFF
--- a/tools/docker/Makefile
+++ b/tools/docker/Makefile
@@ -42,7 +42,8 @@ pypi3: \
 	debian-9-pypi3 \
 	ubuntu-14.04-pypi3 \
 	ubuntu-16.04-pypi3 \
-	ubuntu-17.04-pypi3
+	ubuntu-17.04-pypi3 \
+	manylinux1-pypi3
 
 test: \
 	centos-7-test \
@@ -156,4 +157,4 @@ manylinux1-image:
 	docker build -f manylinux1.Dockerfile -t or-tools-manylinux1-image .
 
 manylinux1-pypi3: export manylinux1-image
-	docker run -w /root/or-tools -v `pwd`/export:/export or-tools-manylinux1-image:latest /bin/bash -c "/root/build-manylinux1.sh /root /export"
+	docker run -v `pwd`/export:/export or-tools-manylinux1-image:latest /bin/bash -c "/root/build-manylinux1.sh /root /export"

--- a/tools/docker/Makefile
+++ b/tools/docker/Makefile
@@ -157,4 +157,4 @@ manylinux1-image:
 	docker build -f manylinux1.Dockerfile -t or-tools-manylinux1-image .
 
 manylinux1-pypi3: export manylinux1-image
-	docker run -v `pwd`/export:/export or-tools-manylinux1-image:latest /bin/bash -c "/root/build-manylinux1.sh /root /export"
+	docker run -v `pwd`/export:/export or-tools-manylinux1-image:latest /bin/bash -c "/root/build/build-manylinux1.sh /root/src /root/build /export"

--- a/tools/docker/Makefile
+++ b/tools/docker/Makefile
@@ -8,7 +8,8 @@ images: \
 	ubuntu-16.04-image \
 	ubuntu-17.04-image \
 	centos-7-image \
-	debian-9-image
+	debian-9-image \
+	manylinux1-image
 
 images-no-cache: \
 	ubuntu-14.04-image-no-cache \
@@ -148,3 +149,11 @@ centos-7-test: export centos-7-image
 
 centos-7-pypi: export centos-7-image
 	docker run -w /root/or-tools -v `pwd`/export:/export or-tools-centos-7-image:latest /bin/bash -c "git pull; make clean; make python -j 5; make test_python; PYPI_OS=-centos-7 make pypi_export python_examples_archive; cp *.tar.gz /export"
+
+# manylinux1 images
+
+manylinux1-image:
+	docker build -f manylinux1.Dockerfile -t or-tools-manylinux1-image .
+
+manylinux1-pypi3: export manylinux1-image
+	docker run -w /root/or-tools -v `pwd`/export:/export or-tools-manylinux1-image:latest /bin/bash -c "/root/build-manylinux1.sh /root /export"

--- a/tools/docker/Makefile.python.mk.patch
+++ b/tools/docker/Makefile.python.mk.patch
@@ -1,0 +1,55 @@
+diff --git a/makefiles/Makefile.python.mk b/makefiles/Makefile.python.mk
+index 61d0be945..979479a54 100755
+--- a/makefiles/Makefile.python.mk
++++ b/makefiles/Makefile.python.mk
+@@ -1,4 +1,4 @@
+-.PHONY : python install_python_modules pypi_archive pyinit pycp pyalgorithms pygraph pylp
++.PHONY : python install_python_modules pypi_archive pypi_archive_dir pyinit pycp pyalgorithms pygraph pylp
+ 
+ # Python support using SWIG
+ 
+@@ -247,9 +247,23 @@ PYPI_ARCHIVE_TEMP_DIR = temp-python$(PYTHON_VERSION)
+ 
+ OR_TOOLS_PYTHON_GEN_SCRIPTS = $(wildcard src/gen/ortools/*/*.py) $(wildcard src/gen/ortools/*/*.cc)
+ 
+-pypi_archive: python $(PYPI_ARCHIVE_TEMP_DIR)
++# Stages all the files needed to build the python package.
++pypi_archive_dir: python $(PYPI_ARCHIVE_TEMP_DIR)
+ 
+-$(PYPI_ARCHIVE_TEMP_DIR) : $(OR_TOOLS_PYTHON_GEN_SCRIPTS) $(PATCHELF)
++# Patches the archive files to be able to build a pypi package.
++# Graft libortools if needed and set RPATHs.
++pypi_archive: pypi_archive_dir $(PATCHELF)
++ifneq ($(PLATFORM),win)
++	cp lib/libortools.$(LIB_SUFFIX) $(PYPI_ARCHIVE_TEMP_DIR)/ortools/ortools
++ifeq ($(PLATFORM),MACOSX)
++	tools/fix_python_libraries_on_mac.sh $(PYPI_ARCHIVE_TEMP_DIR)
++endif
++ifeq ($(PLATFORM),LINUX)
++	tools/fix_python_libraries_on_linux.sh $(PYPI_ARCHIVE_TEMP_DIR)
++endif
++endif
++
++$(PYPI_ARCHIVE_TEMP_DIR) : $(OR_TOOLS_PYTHON_GEN_SCRIPTS)
+ 	-$(DELREC) $(PYPI_ARCHIVE_TEMP_DIR)
+ 	$(MKDIR) $(PYPI_ARCHIVE_TEMP_DIR)
+ 	$(MKDIR) $(PYPI_ARCHIVE_TEMP_DIR)$Sortools
+@@ -300,18 +314,10 @@ else
+ 	cp lib/_pywraplp.$(SWIG_LIB_SUFFIX) $(PYPI_ARCHIVE_TEMP_DIR)/ortools/ortools/linear_solver
+ 	cp lib/_pywrapgraph.$(SWIG_LIB_SUFFIX) $(PYPI_ARCHIVE_TEMP_DIR)/ortools/ortools/graph
+ 	cp lib/_pywrapknapsack_solver.$(SWIG_LIB_SUFFIX) $(PYPI_ARCHIVE_TEMP_DIR)/ortools/ortools/algorithms
+-	cp lib/libortools.$(LIB_SUFFIX) $(PYPI_ARCHIVE_TEMP_DIR)/ortools/ortools
+ 	$(SED) -i -e 's/\.dll/\.so/' $(PYPI_ARCHIVE_TEMP_DIR)/ortools/setup.py
+ 	$(SED) -i -e 's/DELETEWIN //g' $(PYPI_ARCHIVE_TEMP_DIR)/ortools/setup.py
+ 	$(SED) -i -e '/DELETEUNIX/d' $(PYPI_ARCHIVE_TEMP_DIR)/ortools/setup.py
+ 	$(SED) -i -e 's/DLL/$(LIB_SUFFIX)/g' $(PYPI_ARCHIVE_TEMP_DIR)/ortools/setup.py
+-	-rm $(PYPI_ARCHIVE_TEMP_DIR)/ortools/setup.py-e
+-ifeq ($(PLATFORM),MACOSX)
+-	tools/fix_python_libraries_on_mac.sh $(PYPI_ARCHIVE_TEMP_DIR)
+-endif
+-ifeq ($(PLATFORM),LINUX)
+-	tools/fix_python_libraries_on_linux.sh $(PYPI_ARCHIVE_TEMP_DIR)
+-endif
+ endif
+ 
+ pypi_upload: pypi_archive

--- a/tools/docker/build-manylinux1.sh
+++ b/tools/docker/build-manylinux1.sh
@@ -127,10 +127,6 @@ do
     "${PYBIN}/virtualenv" -p "${PYBIN}/python" ${BUILD_ROOT}/${PYTAG}
     source ${BUILD_ROOT}/${PYTAG}/bin/activate
     pip install -U pip setuptools wheel
-    # Regen Makefile.local to detect python version
-    # cd "$SRC_ROOT"
-    # rm -f Makefile.local
-    # make Makefile.local
     # Build artifact
     export_manylinux_wheel "$SRC_ROOT" "$EXPORT_ROOT"
     # Ensure everything is clean (don't clean third_party anyway,

--- a/tools/docker/build-manylinux1.sh
+++ b/tools/docker/build-manylinux1.sh
@@ -176,7 +176,7 @@ do
     ###
     ### Wheel test
     ###
-    WHEEL_FILE=$(echo "${EXPORT_ROOT}"/*ortools-*-"${PYTAG}"-manylinux1-*.whl)
+    WHEEL_FILE=$(echo "${EXPORT_ROOT}"/*-"${PYTAG}"-*.whl)
     # Create and activate a new virtualenv
     "${PYBIN}/virtualenv" -p "${PYBIN}/python" "${BUILD_ROOT}/${PYTAG}-test"
     source "${BUILD_ROOT}/${PYTAG}-test/bin/activate"

--- a/tools/docker/build-manylinux1.sh
+++ b/tools/docker/build-manylinux1.sh
@@ -126,7 +126,7 @@ do
     "${PYBIN}/pip" install virtualenv
     "${PYBIN}/virtualenv" -p "${PYBIN}/python" ${BUILD_ROOT}/${PYTAG}
     source ${BUILD_ROOT}/${PYTAG}/bin/activate
-    pip install -U pip setuptools wheel
+    pip install -U pip setuptools wheel six  # six is needed by make test_python
     # Build artifact
     export_manylinux_wheel "$SRC_ROOT" "$EXPORT_ROOT"
     # Ensure everything is clean (don't clean third_party anyway,

--- a/tools/docker/build-manylinux1.sh
+++ b/tools/docker/build-manylinux1.sh
@@ -1,17 +1,78 @@
 #!/bin/bash
-# Build all the wheel artifacts for the platforms supported by manylinux1
-# and export them to the specified location.
+# Build all the wheel artifacts for the platforms supported by manylinux1 and
+# export them to the specified location.
 #
 # Arguments:
 #
-#   $1 the build process root directory. If not specified as argument,
-#      the env var BUILD_ROOT will be used. If not specified at all, a
-#      default location will be used.
+#   $1 the build process root directory. If not specified as argument, the
+#      env var BUILD_ROOT will be used. If not specified at all, a default
+#      location will be used.
 #
-#   $2 the artifacts export directory. If not specified as argument,
-#      the env var EXPORT_ROOT will be used. If not specified at all, a
-#      default location will be used.
+#   $2 the artifacts export directory. If not specified as argument, the env
+#      var EXPORT_ROOT will be used. If not specified at all, a default location
+#      will be used.
 set -e
+
+
+function contains_element () {
+    # Look for the presence of an element in an array. Echoes '0' if found,
+    # '1' otherwise.
+    # Arguments:
+    #   $1 the element to be searched
+    #   $2 the array to search into
+    local e match="$1"
+    shift
+    for e; do [[ "$e" == "$match" ]] && echo '0' && return; done
+    echo '1' && return
+}
+
+
+function export_manylinux_wheel {
+    # Build all the wheel artifacts assuming that the current 'python' command
+    # is the target interpreter. Please note that in order to have or-tools
+    # correctly detect the target python version, this function should be run in
+    # a virtualenv.
+    # Arguments:
+    #   $1 the or-tools sources root directory
+    #   $2 the artifacts export directory
+    if [ "$#" -ne 2 ]; then
+        echo "build_pypi_archives called with an illegal number of parameters"
+        exit 1  # TODO return error and check it outside
+    fi
+    local src_root="$1"
+    local export_root="$2"
+    # Build python bindings
+    cd "$src_root"
+    # We need to force this target, otherwise the protobuf stub will be missing
+    # (for the makefile, it exists even if previously generated for another
+    # platform)
+    make -B install_python_modules  # regenerates Makefile.local
+    make python
+    make test_python
+    make pypi_archive
+    # Build and repair wheels
+    cd temp-python*/ortools
+    python setup.py bdist_wheel
+    cd dist
+    auditwheel repair ./*.whl -w "$export_root"
+}
+
+
+function test_installed {
+    # Run all the specified test scripts using the current environment.
+    # Arguments:
+    #   $@ the test files to be tested
+    local testfiles=("${@}")
+    cd "$(mktemp -d)" # ensure we are not importing something from $PWD
+    for testfile in "${testfiles[@]}"
+    do
+        python "$testfile"
+    done
+}
+
+
+###############################################################################
+# Setup
 
 if [ -n "$1" ]; then BUILD_ROOT="$1"; fi
 if [ -n "$2" ]; then EXPORT_ROOT="$2"; fi
@@ -31,15 +92,15 @@ fi
 SRC_ROOT="${BUILD_ROOT}/or-tools"
 
 # Platforms to be ignored.
-# The build of Python 2.6.x bindings is known to be broken
-# (and 2.6 itself is deprecated).
+# The build of Python 2.6.x bindings is known to be broken (and 2.6 itself is
+# deprecated).
 SKIP_PLATFORMS=(
     cp26-cp26m
     cp26-cp26mu
 )
 
-# Python scripts to be used as tests for the installed wheel.
-# This list of files has been taken from 'test_python' make target.
+# Python scripts to be used as tests for the installed wheel. This list of files
+# has been taken from the 'test_python' make target.
 TESTS=(
     "${SRC_ROOT}/examples/python/hidato_table.py"
     "${SRC_ROOT}/examples/python/tsp.py"
@@ -54,62 +115,12 @@ TESTS=(
 echo "BUILD_ROOT=${BUILD_ROOT}"
 echo "SRC_ROOT=${SRC_ROOT}"
 echo "EXPORT_ROOT=${EXPORT_ROOT}"
-echo "SKIP_PLATFORMS=${SKIP_PLATFORMS[@]}"
-echo "TESTS=${TESTS[@]}"
+echo "SKIP_PLATFORMS=(${SKIP_PLATFORMS[*]})"
+echo "TESTS=(${TESTS[*]})"
 
-################################################################################
-
-function contains_element () {
-    # Look for the presence of an element in an array. Echoes '0' if found,
-    # '1' otherwise.
-    # Arguments:
-    #   $1 the element to be searched
-    #   $2 the array to search into
-    local e match="$1"
-    shift
-    for e; do [[ "$e" == "$match" ]] && echo '0' && return; done
-    echo '1' && return
-}
-
-function export_manylinux_wheel {
-    # Build all the wheel artifacts assuming that the current 'python'
-    # command is the target interpreter. Please note that in order to
-    # have or-tools correctly detect the target python version, this
-    # function should be run in a virtualenv.
-    # Arguments:
-    #   $1 the or-tools sources root directory
-    #   $2 the artifacts export directory
-    if [ "$#" -ne 2 ]; then
-        echo "build_pypi_archives called with an illegal number of parameters"
-        exit 1  # TODO return error and check it outside
-    fi
-    _SRC_ROOT="$1"
-    _EXPORT_ROOT="$2"
-    # Build
-    cd "$_SRC_ROOT"
-    # We need to force this target, otherwise the protobuf stub will be missing
-    # (for the makefile, it exists even if previously generated for another
-    # platform)
-    make -B install_python_modules  # regenerates Makefile.local
-    make python
-    make test_python
-    make pypi_archive
-    # Build and repair wheels
-    cd temp-python*/ortools
-    python setup.py bdist_wheel
-    cd dist
-    auditwheel repair *.whl -w "$_EXPORT_ROOT"
-}
-
-function test_installed {
-    cd $(mktemp -d) # ensure we are not importing something from $PWD
-    for testfile in "${TESTS[@]}"
-    do
-        python "$testfile"
-    done
-}
 
 ###############################################################################
+# Main
 
 mkdir -p "${BUILD_ROOT}"
 mkdir -p "${EXPORT_ROOT}"
@@ -131,27 +142,25 @@ fi
 
 # TODO remove all patching, write Makefile targets for manylinux
 
-# Patch makefile, remove offending command
-# (the setup.py-e file doesn't exist)
+# Patch makefile, remove offending command (the setup.py-e file doesn't exist)
 cd "$SRC_ROOT"
-sed -i -e 's=-rm $(PYPI_ARCHIVE_TEMP_DIR)/ortools/setup.py-e==g' makefiles/Makefile.python.mk
+sed -i -e "s=-rm \$(PYPI_ARCHIVE_TEMP_DIR)/ortools/setup.py-e==g" makefiles/Makefile.python.mk
 
-# Patch makefile, remove manual libortools.so grafting
-# and RPATH setting. All of this stuff will be carried
-# out by auditwheel, otherwise we would end up with a
+# Patch makefile, remove manual libortools.so grafting and RPATH setting. All of
+# this stuff will be carried out by auditwheel, otherwise we would end up with a
 # broken manylinux wheel file
 cd "$SRC_ROOT"
-sed -i -e 's=cp lib/libortools=#=g' makefiles/Makefile.python.mk
-sed -i -e 's=tools/fix_python_libraries_on_linux.sh=#=g' makefiles/Makefile.python.mk
+sed -i -e "s=cp lib/libortools=#=g" makefiles/Makefile.python.mk
+sed -i -e "s=tools/fix_python_libraries_on_linux.sh=#=g" makefiles/Makefile.python.mk
 
-# For each python platform provided by manylinux,
-# build, export and test artifacts.
+# For each python platform provided by manylinux, build, export and test
+# artifacts.
 for PYROOT in /opt/python/*
 do
     PYTAG=$(basename "$PYROOT")
     # Check for platforms to be skipped
     SKIP=$(contains_element "$PYTAG" "${SKIP_PLATFORMS[@]}")
-    if [ $SKIP -eq '0' ]
+    if [ "$SKIP" -eq '0' ]
     then
         echo "skipping deprecated platform $PYTAG"
         continue
@@ -182,8 +191,8 @@ do
     source "${BUILD_ROOT}/${PYTAG}-test/bin/activate"
     pip install -U pip setuptools wheel six
     # Install wheel and run tests
-    pip install --no-cache-dir $WHEEL_FILE
-    test_installed
+    pip install --no-cache-dir "$WHEEL_FILE"
+    test_installed "${TESTS[@]}"
     # Restore environment
     deactivate
 done

--- a/tools/docker/build-manylinux1.sh
+++ b/tools/docker/build-manylinux1.sh
@@ -58,6 +58,7 @@ function build_pypi_archives {
     ### cp -prv dependencies/install/lib64/* dependencies/install/lib/
     make install_python_modules
     make python
+    make test_python
     make pypi_archive
     # Build and repair wheels
     cd temp-python*/ortools

--- a/tools/docker/build-manylinux1.sh
+++ b/tools/docker/build-manylinux1.sh
@@ -3,16 +3,26 @@
 # export them to the specified location.
 #
 # Arguments:
+#   $1 the path of the or-tools sources.
+#   $2 the build process root directory. If not specified, a default location is
+#      used.
+#   $3 the artifacts export directory. If not specified, a default location is
+#      used.
 #
-#   $1 the build process root directory. If not specified as argument, the
-#      env var BUILD_ROOT will be used. If not specified at all, a default
-#      location will be used.
-#
-#   $2 the artifacts export directory. If not specified as argument, the env
-#      var EXPORT_ROOT will be used. If not specified at all, a default location
-#      will be used.
+# Environment variables:
+#   SKIP_PLATFORMS manylinux1 platforms (e.g.: cp26-cp26m) to be skipped.
+#   EXPORT_ROOT    if not specified at command line, this value is used as the
+#                  destination path for the wheels export.
+#   BUILD_ROOT     if not specified at command line, this value is used as the
+#                  root path for the build process.
 set -e
 
+DEFAULT_BUILD_ROOT="$HOME"
+DEFAULT_EXPORT_ROOT="${HOME}/export"
+
+function usage() {
+  echo "Usage: build-manylinux1.sh SRC_ROOT <BUILD_ROOT> <EXPORT_ROOT>"
+}
 
 function contains_element () {
     # Look for the presence of an element in an array. Echoes '0' if found,
@@ -25,7 +35,6 @@ function contains_element () {
     for e; do [[ "$e" == "$match" ]] && echo '0' && return; done
     echo '1' && return
 }
-
 
 function export_manylinux_wheel {
     # Build all the wheel artifacts assuming that the current 'python' command
@@ -49,14 +58,13 @@ function export_manylinux_wheel {
     make -B install_python_modules  # regenerates Makefile.local
     make python
     make test_python
-    make pypi_archive
+    make pypi_archive_dir
     # Build and repair wheels
     cd temp-python*/ortools
     python setup.py bdist_wheel
     cd dist
     auditwheel repair ./*.whl -w "$export_root"
 }
-
 
 function test_installed {
     # Run all the specified test scripts using the current environment.
@@ -70,34 +78,35 @@ function test_installed {
     done
 }
 
-
 ###############################################################################
 # Setup
 
-if [ -n "$1" ]; then BUILD_ROOT="$1"; fi
-if [ -n "$2" ]; then EXPORT_ROOT="$2"; fi
-
-if [ -z "$BUILD_ROOT" ]
-then
-    echo "\$BUILD_ROOT is not set, using default location: $HOME"
-    BUILD_ROOT="$HOME"
+if [ -z "$1" ]; then
+  (>&2 usage)
+  exit 1
 fi
 
-if [ -z "$EXPORT_ROOT" ]
-then
-    echo "\$EXPORT_ROOT is not set, using default location: ${HOME}/export"
-    EXPORT_ROOT="${HOME}/export"
+SRC_ROOT="$1";
+if [ -n "$2" ]; then BUILD_ROOT="$2"; fi
+if [ -n "$3" ]; then EXPORT_ROOT="$3"; fi
+
+if [ ! -d "$SRC_ROOT" ]; then
+    (>&2 echo "Can't find or-tools sources at the specified location: $SRC_ROOT")
+    exit 1
 fi
 
-SRC_ROOT="${BUILD_ROOT}/or-tools"
+if [ -z "$BUILD_ROOT" ]; then
+    (>&2 echo "\$BUILD_ROOT is not set, using default location: $DEFAULT_BUILD_ROOT")
+    BUILD_ROOT="$DEFAULT_BUILD_ROOT"
+fi
 
-# Platforms to be ignored.
-# The build of Python 2.6.x bindings is known to be broken (and 2.6 itself is
-# deprecated).
-SKIP_PLATFORMS=(
-    cp26-cp26m
-    cp26-cp26mu
-)
+if [ -z "$EXPORT_ROOT" ]; then
+    (>&2 echo "\$EXPORT_ROOT is not set, using default location: $DEFAULT_EXPORT_ROOT")
+    EXPORT_ROOT="$DEFAULT_EXPORT_ROOT"
+fi
+
+# Split SKIP_PLATFORMS string and put values into an array
+read -r -a SKIP <<< "$SKIP_PLATFORMS"
 
 # Python scripts to be used as tests for the installed wheel. This list of files
 # has been taken from the 'test_python' make target.
@@ -112,12 +121,13 @@ TESTS=(
     "${SRC_ROOT}/examples/tests/test_lp_api.py"
 )
 
-echo "BUILD_ROOT=${BUILD_ROOT}"
-echo "SRC_ROOT=${SRC_ROOT}"
-echo "EXPORT_ROOT=${EXPORT_ROOT}"
-echo "SKIP_PLATFORMS=(${SKIP_PLATFORMS[*]})"
-echo "TESTS=(${TESTS[*]})"
-
+(
+    >&2 echo "BUILD_ROOT=${BUILD_ROOT}"
+    >&2 echo "SRC_ROOT=${SRC_ROOT}"
+    >&2 echo "EXPORT_ROOT=${EXPORT_ROOT}"
+    >&2 echo "SKIP_PLATFORMS=( ${SKIP[*]} )"
+    >&2 echo "TESTS=( ${TESTS[*]} )"
+)
 
 ###############################################################################
 # Main
@@ -125,33 +135,12 @@ echo "TESTS=(${TESTS[*]})"
 mkdir -p "${BUILD_ROOT}"
 mkdir -p "${EXPORT_ROOT}"
 
-# Retrieve or-tools if needed
-if [ ! -d "$SRC_ROOT" ]
-then
-  echo "SRC_ROOT doesn't exist, retrieving source from: https://github.com/google/or-tools"
-  git clone https://github.com/google/or-tools "$SRC_ROOT"
-fi
-
 # Make third_party if needed
-if [ ! -f "${SRC_ROOT}/Makefile.local" ]
-then
-  echo "\${SRC_ROOT}/Makefile.local doesn't exist, building third_party"
+if [ ! -f "${SRC_ROOT}/Makefile.local" ]; then
+  (>&2 echo "\${SRC_ROOT}/Makefile.local doesn't exist, building third_party")
   cd "$SRC_ROOT"
   make third_party
 fi
-
-# TODO remove all patching, write Makefile targets for manylinux
-
-# Patch makefile, remove offending command (the setup.py-e file doesn't exist)
-cd "$SRC_ROOT"
-sed -i -e "s=-rm \$(PYPI_ARCHIVE_TEMP_DIR)/ortools/setup.py-e==g" makefiles/Makefile.python.mk
-
-# Patch makefile, remove manual libortools.so grafting and RPATH setting. All of
-# this stuff will be carried out by auditwheel, otherwise we would end up with a
-# broken manylinux wheel file
-cd "$SRC_ROOT"
-sed -i -e "s=cp lib/libortools=#=g" makefiles/Makefile.python.mk
-sed -i -e "s=tools/fix_python_libraries_on_linux.sh=#=g" makefiles/Makefile.python.mk
 
 # For each python platform provided by manylinux, build, export and test
 # artifacts.
@@ -159,10 +148,9 @@ for PYROOT in /opt/python/*
 do
     PYTAG=$(basename "$PYROOT")
     # Check for platforms to be skipped
-    SKIP=$(contains_element "$PYTAG" "${SKIP_PLATFORMS[@]}")
-    if [ "$SKIP" -eq '0' ]
-    then
-        echo "skipping deprecated platform $PYTAG"
+    _skip=$(contains_element "$PYTAG" "${SKIP[@]}")
+    if [ "$_skip" -eq '0' ]; then
+        (>&2 echo "skipping deprecated platform $PYTAG")
         continue
     fi
     ###
@@ -172,6 +160,7 @@ do
     PYBIN="${PYROOT}/bin"
     "${PYBIN}/pip" install virtualenv
     "${PYBIN}/virtualenv" -p "${PYBIN}/python" "${BUILD_ROOT}/${PYTAG}"
+    # shellcheck source=/dev/null
     source "${BUILD_ROOT}/${PYTAG}/bin/activate"
     pip install -U pip setuptools wheel six  # six is needed by make test_python
     # Build artifact
@@ -188,6 +177,7 @@ do
     WHEEL_FILE=$(echo "${EXPORT_ROOT}"/*-"${PYTAG}"-*.whl)
     # Create and activate a new virtualenv
     "${PYBIN}/virtualenv" -p "${PYBIN}/python" "${BUILD_ROOT}/${PYTAG}-test"
+    # shellcheck source=/dev/null
     source "${BUILD_ROOT}/${PYTAG}-test/bin/activate"
     pip install -U pip setuptools wheel six
     # Install wheel and run tests

--- a/tools/docker/build-manylinux1.sh
+++ b/tools/docker/build-manylinux1.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Build all the wheel artifacts for the platforms supported by manylinux1
-# and export them to the export location.
+# and export them to the specified location.
 #
 # Arguments:
 #
@@ -59,7 +59,7 @@ echo "TESTS=${TESTS[@]}"
 
 ################################################################################
 
-contains_element () {
+function contains_element () {
     # Look for the presence of an element in an array. Echoes '0' if found,
     # '1' otherwise.
     # Arguments:

--- a/tools/docker/build-manylinux1.sh
+++ b/tools/docker/build-manylinux1.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# Build all the wheel artifacts for the platforms supported by manylinux1
+# and export them to the export location.
+#
+# Arguments:
+#
+#   $1 the build process root directory. If not specified as argument,
+#      the env var BUILD_ROOT will be used. If not specified at all, a
+#      default location will be used.
+#
+#   $2 the artifacts export directory. If not specified as argument,
+#      the env var EXPORT_ROOT will be used. If not specified at all, a
+#      default location will be used.
+set -e
+
+if [ -n "$1" ]; then BUILD_ROOT="$1"; fi
+if [ -n "$2" ]; then EXPORT_ROOT="$2"; fi
+
+if [ -z "$BUILD_ROOT" ]
+then
+    echo "\$BUILD_ROOT is not set, using default location: $HOME"
+    BUILD_ROOT="$HOME"
+fi
+
+if [ -z "$EXPORT_ROOT" ]
+then
+    echo "\$EXPORT_ROOT is not set, using default location: ${HOME}/export"
+    EXPORT_ROOT="${HOME}/export"
+fi
+
+mkdir -p ${BUILD_ROOT}
+mkdir -p ${EXPORT_ROOT}
+
+echo "BUILD_ROOT=${BUILD_ROOT}"
+echo "EXPORT_ROOT=${EXPORT_ROOT}"
+
+################################################################################
+
+function build_pypi_archives {
+    # Build all the wheel artifacts assuming that the current 'python'
+    # command is the target interpreter. Please note that in order to
+    # have or-tools correctly detect the target python version, this
+    # function should be run in a virtualenv.
+    # Arguments:
+    #   $1 the or-tools sources root directory
+    #   $2 the artifacts export directory
+    if [ "$#" -ne 2 ]; then
+        echo "build_pypi_archives called with an illegal number of parameters"
+        exit 1  # TODO return error and check it outside
+    fi
+    _SRC_ROOT="$1"
+    _EXPORT_ROOT="$2"
+    # Build
+    cd "$_SRC_ROOT"
+    make third_party
+    ### Fix issue with or-tools makefile not looking for libraries where
+    ### protobuffer has been installed.
+    ### cp -prv dependencies/install/lib64/* dependencies/install/lib/
+    make install_python_modules
+    make python
+    make pypi_archive
+    # Build and repair wheels
+    cd temp-python*/ortools
+    python setup.py bdist_wheel
+    cd dist
+    auditwheel repair *.whl -w "$_EXPORT_ROOT"
+    # Ensure everything is clean
+    cd "$_SRC_ROOT"
+    make clean
+    make clean_third_party
+}
+
+###############################################################################
+
+# Retrieve or-tools, we are building the master
+cd "$BUILD_ROOT"
+git clone https://github.com/google/or-tools
+
+# TODO remove all patching, write Makefile targets for manylinux
+
+# Patch makefile, remove offending command
+# (the setup.py-e file doesn't exist)
+cd "$BUILD_ROOT/or-tools"
+sed -i -e 's=-rm $(PYPI_ARCHIVE_TEMP_DIR)/ortools/setup.py-e==g' makefiles/Makefile.python.mk
+
+# Patch makefile, remove manual libortools.so grafting
+# and RPATH setting. All of this stuff will be carried
+# out by auditwheel, otherwise we would end up with a
+# broken manylinux wheel
+cd "$BUILD_ROOT/or-tools"
+sed -i -e 's=cp lib/libortools=#=g' makefiles/Makefile.python.mk
+sed -i -e 's=tools/fix_python_libraries_on_linux.sh=#=g' makefiles/Makefile.python.mk
+
+# For each python platform provided by manylinux,
+# build and export artifact using a virtualenv
+cd "$BUILD_ROOT"
+for PYROOT in /opt/python/*
+do
+    PYTAG=$(basename "$PYROOT")
+    PYBIN="${PYROOT}/bin"
+    "${PYBIN}/pip" install virtualenv
+    "${PYBIN}/virtualenv" -p "${PYBIN}/python" ${BUILD_ROOT}/${PYTAG}
+    source ${BUILD_ROOT}/${PYTAG}/bin/activate
+    pip install -U pip setuptools
+    build_pypi_archives "$BUILD_ROOT/or-tools" "$EXPORT_ROOT"
+    deactivate
+done

--- a/tools/docker/build-manylinux1.sh
+++ b/tools/docker/build-manylinux1.sh
@@ -45,8 +45,8 @@ echo "SKIP_PLATFORMS=${SKIP_PLATFORMS[@]}"
 contains_element () {
   local e match="$1"
   shift
-  for e; do [[ "$e" == "$match" ]] && return 0; done
-  return 1
+  for e; do [[ "$e" == "$match" ]] && echo '0' && return; done
+  echo '1' && return
 }
 
 function export_manylinux_wheel {
@@ -115,8 +115,8 @@ for PYROOT in /opt/python/*
 do
     PYTAG=$(basename "$PYROOT")
     # Check for platforms to be skipped
-    contains_element $PYTAG "${SKIP_PLATFORMS[@]}"
-    if [ $? == 0 ]
+    skip=$(contains_element $PYTAG "${SKIP_PLATFORMS[@]}")
+    if [ $skip -eq '0' ]
     then
         echo "skipping deprecated platform $PYTAG"
         continue

--- a/tools/docker/build-manylinux1.sh
+++ b/tools/docker/build-manylinux1.sh
@@ -13,6 +13,9 @@
 #      default location will be used.
 set -e
 
+# Platforms to be ignored.
+# The build of Python 2.6.x bindings is known to be broken
+# (and 2.6 itself is deprecated).
 SKIP_PLATFORMS=( cp26-cp26m  cp26-cp26mu )
 
 if [ -n "$1" ]; then BUILD_ROOT="$1"; fi
@@ -43,10 +46,15 @@ echo "SKIP_PLATFORMS=${SKIP_PLATFORMS[@]}"
 ################################################################################
 
 contains_element () {
-  local e match="$1"
-  shift
-  for e; do [[ "$e" == "$match" ]] && echo '0' && return; done
-  echo '1' && return
+    # Look for the presence of an element in an array. Echoes '0' if found,
+    # '1' otherwise.
+    # Arguments:
+    #   $1 the element to be searched
+    #   $2 the array to search into
+    local e match="$1"
+    shift
+    for e; do [[ "$e" == "$match" ]] && echo '0' && return; done
+    echo '1' && return
 }
 
 function export_manylinux_wheel {

--- a/tools/docker/manylinux1.Dockerfile
+++ b/tools/docker/manylinux1.Dockerfile
@@ -32,6 +32,10 @@ RUN ./configure --prefix=/usr
 RUN make
 RUN make install
 
+RUN git clone https://github.com/google/or-tools /root/or-tools
+WORKDIR /root/or-tools
+RUN make third_party
+
 ADD build-manylinux1.sh /root
 
 WORKDIR /root

--- a/tools/docker/manylinux1.Dockerfile
+++ b/tools/docker/manylinux1.Dockerfile
@@ -1,20 +1,27 @@
 FROM quay.io/pypa/manylinux1_x86_64:latest
 
+ENV SRC_ROOT /root/src
+ENV BUILD_ROOT /root/build
+ENV EXPORT_ROOT /export
+ENV SRC_GIT_URL https://github.com/google/or-tools
+ENV SRC_GIT_BRANCH master
+# The build of Python 2.6.x bindings is known to be broken.
+ENV SKIP_PLATFORMS "cp26-cp26m cp26-cp26mu"
+
 RUN yum -y update && yum -y install \
-    yum-utils \
-    redhat-lsb \
-    git \
     autoconf \
-    libtool \
-    zlib-devel \
+    curl \
     gawk \
     gcc-c++ \
-    curl \
-    subversion \
+    git \
+    libtool \
     make \
+    patch \
     pcre-devel \
+    redhat-lsb \
+    subversion \
     which \
-    curl
+    zlib-devel
 
 # WARNING
 # We cannot use wget to download the needed packages due to a bug that leads
@@ -26,28 +33,36 @@ RUN yum -y update && yum -y install \
 # Note: 'wget --no-check-certificate' is not an option since we are building
 #       distribution binaries.
 
+RUN mkdir -p "$BUILD_ROOT"
+
 # Update cmake, the system shipped version is too old for or-tools.
-WORKDIR /root
-RUN curl --location-trusted --remote-name https://cmake.org/files/v3.8/cmake-3.8.2.tar.gz
+WORKDIR "$BUILD_ROOT"
+RUN curl --location-trusted --remote-name https://cmake.org/files/v3.8/cmake-3.8.2.tar.gz -o cmake-3.8.2.tar.gz
 RUN tar xzf cmake-3.8.2.tar.gz
-WORKDIR /root/cmake-3.8.2
+WORKDIR cmake-3.8.2
 RUN ./bootstrap --prefix=/usr
 RUN make
 RUN make install
 
 # Update swig, the system shipped version doesn't support PY3.
-WORKDIR /root
-RUN curl --location-trusted --remote-name https://downloads.sourceforge.net/project/swig/swig/swig-3.0.12/swig-3.0.12.tar.gz
+WORKDIR "$BUILD_ROOT"
+RUN curl --location-trusted --remote-name https://downloads.sourceforge.net/project/swig/swig/swig-3.0.12/swig-3.0.12.tar.gz -o swig-3.0.12.tar.gz
 RUN tar xzf swig-3.0.12.tar.gz
-WORKDIR /root/swig-3.0.12
+WORKDIR swig-3.0.12
 RUN ./configure --prefix=/usr
 RUN make
 RUN make install
 
-RUN git clone https://github.com/google/or-tools /root/or-tools
-WORKDIR /root/or-tools
+RUN git clone -b "$SRC_GIT_BRANCH" --single-branch "$SRC_GIT_URL" "$SRC_ROOT"
+WORKDIR "$SRC_ROOT"
 RUN make third_party
 
-ADD build-manylinux1.sh /root
+COPY build-manylinux1.sh "$BUILD_ROOT"
+RUN chmod ugo+x "${BUILD_ROOT}/build-manylinux1.sh"
 
-WORKDIR /root
+# TEMPORARY HACK
+# Patch Makefile.python.mk to add manylinux1 targets,
+# to be removed when changes are integrated into mainstream.
+COPY Makefile.python.mk.patch "$BUILD_ROOT"
+WORKDIR "$SRC_ROOT"
+RUN patch --force -p1 < "${BUILD_ROOT}/Makefile.python.mk.patch"

--- a/tools/docker/manylinux1.Dockerfile
+++ b/tools/docker/manylinux1.Dockerfile
@@ -3,7 +3,6 @@ FROM quay.io/pypa/manylinux1_x86_64:latest
 RUN yum -y update && yum -y install \
     yum-utils \
     redhat-lsb \
-    wget \
     git \
     autoconf \
     libtool \
@@ -14,10 +13,21 @@ RUN yum -y update && yum -y install \
     subversion \
     make \
     pcre-devel \
-    which
+    which \
+    curl
+
+# WARNING
+# We cannot use wget to download the following packages due to a bug that leads
+# to an incorrect checking of Server Alternate Name (SAN) property in the SSL
+# certificate and makes wget to fail with something like:
+#
+# ERROR: certificate common name `*.kitware.com' doesn't match requested host name `cmake.org'.
+#
+# Note: 'wget --no-check-certificate' is not an option since we are building
+#       distribution binaries.
 
 WORKDIR /root
-RUN wget --no-check-certificate https://cmake.org/files/v3.8/cmake-3.8.2.tar.gz
+RUN curl --location-trusted --remote-name https://cmake.org/files/v3.8/cmake-3.8.2.tar.gz
 RUN tar xzf cmake-3.8.2.tar.gz
 WORKDIR /root/cmake-3.8.2
 RUN ./bootstrap --prefix=/usr
@@ -25,7 +35,7 @@ RUN make
 RUN make install
 
 WORKDIR /root
-RUN wget --no-check-certificate https://downloads.sourceforge.net/project/swig/swig/swig-3.0.12/swig-3.0.12.tar.gz
+RUN curl --location-trusted --remote-name https://downloads.sourceforge.net/project/swig/swig/swig-3.0.12/swig-3.0.12.tar.gz
 RUN tar xzf swig-3.0.12.tar.gz
 WORKDIR /root/swig-3.0.12
 RUN ./configure --prefix=/usr

--- a/tools/docker/manylinux1.Dockerfile
+++ b/tools/docker/manylinux1.Dockerfile
@@ -1,0 +1,37 @@
+FROM quay.io/pypa/manylinux1_x86_64:latest
+
+RUN yum -y update && yum -y install \
+    yum-utils \
+    redhat-lsb \
+    wget \
+    git \
+    autoconf \
+    libtool \
+    zlib-devel \
+    gawk \
+    gcc-c++ \
+    curl \
+    subversion \
+    make \
+    pcre-devel \
+    which
+
+WORKDIR /root
+RUN wget --no-check-certificate https://cmake.org/files/v3.8/cmake-3.8.2.tar.gz
+RUN tar xzf cmake-3.8.2.tar.gz
+WORKDIR /root/cmake-3.8.2
+RUN ./bootstrap --prefix=/usr
+RUN make
+RUN make install
+
+WORKDIR /root
+RUN wget --no-check-certificate https://downloads.sourceforge.net/project/swig/swig/swig-3.0.12/swig-3.0.12.tar.gz
+RUN tar xzf swig-3.0.12.tar.gz
+WORKDIR /root/swig-3.0.12
+RUN ./configure --prefix=/usr
+RUN make
+RUN make install
+
+ADD build-manylinux1.sh /root
+
+WORKDIR /root

--- a/tools/docker/manylinux1.Dockerfile
+++ b/tools/docker/manylinux1.Dockerfile
@@ -17,7 +17,7 @@ RUN yum -y update && yum -y install \
     curl
 
 # WARNING
-# We cannot use wget to download the following packages due to a bug that leads
+# We cannot use wget to download the needed packages due to a bug that leads
 # to an incorrect checking of Server Alternate Name (SAN) property in the SSL
 # certificate and makes wget to fail with something like:
 #
@@ -26,6 +26,7 @@ RUN yum -y update && yum -y install \
 # Note: 'wget --no-check-certificate' is not an option since we are building
 #       distribution binaries.
 
+# Update cmake, the system shipped version is too old for or-tools.
 WORKDIR /root
 RUN curl --location-trusted --remote-name https://cmake.org/files/v3.8/cmake-3.8.2.tar.gz
 RUN tar xzf cmake-3.8.2.tar.gz
@@ -34,6 +35,7 @@ RUN ./bootstrap --prefix=/usr
 RUN make
 RUN make install
 
+# Update swig, the system shipped version doesn't support PY3.
 WORKDIR /root
 RUN curl --location-trusted --remote-name https://downloads.sourceforge.net/project/swig/swig/swig-3.0.12/swig-3.0.12.tar.gz
 RUN tar xzf swig-3.0.12.tar.gz


### PR DESCRIPTION
I'm using or-tools for a project, and the lack of linux wheels on PyPI makes the whole development and deployment process a real pain when you have to deal with multiple distros (and _obviously_ the production machine sits on the most ancient distro you can think of). This fork adds a docker image based on the [manylinux](https://github.com/pypa/manylinux) one (`quay.io/pypa/manylinux1_x86_64:latest`) and a [script](https://github.com/nazavode/or-tools/blob/master/tools/docker/build-manylinux1.sh) that, for each platform supported by `manylinux1`, builds, tests and exports binary wheels that are compliant with [PEP 513](https://www.python.org/dev/peps/pep-0513/). This has been tested with the current head (`6.3.4446`), the only thing that makes the whole process not reentrant is that the `quay.io/pypa/manylinux1_x86_64` docker image provides only the `latest` tag so any incompatible change that happens in there would break everything here, but for the sake of building portable wheels by hand looks fine to me.

### Usage

I've added a proper [target](https://github.com/nazavode/or-tools/blob/0f2ce6fb01376cdf984e161c13207fb3271f677e/tools/docker/Makefile#L159) to the `Makefile`, so in order to build and export all the `manylinux1` artifacts you need to:

```
$ cd tools/docker/
$ make manylinux1-pypi3
```

Out of the box, the target builds the following wheels:

```
$ ls -1 export/
ortools-6.3.4446-cp27-cp27m-manylinux1_x86_64.whl
ortools-6.3.4446-cp27-cp27mu-manylinux1_x86_64.whl
py3_ortools-6.3.4446-cp33-cp33m-manylinux1_x86_64.whl
py3_ortools-6.3.4446-cp34-cp34m-manylinux1_x86_64.whl
py3_ortools-6.3.4446-cp35-cp35m-manylinux1_x86_64.whl
py3_ortools-6.3.4446-cp36-cp36m-manylinux1_x86_64.whl
```

Python 2.6 (`cp26-cp26m` and `cp26-cp26mu`) is skipped by default due to some build problems (missing `Python.h` in some `Makefile` variable) but 2.6 is deprecated anyway, so I'm not looking into this. The list of platforms to be skipped is controlled by the [SKIP_PLATFORMS variable](https://github.com/nazavode/or-tools/blob/2e221ffc1d77da25e1dd914978d162e3a7f9bb1a/tools/docker/manylinux1.Dockerfile#L9).

### TODO

- [x]  I had to [patch](https://github.com/nazavode/or-tools/blob/0f2ce6fb01376cdf984e161c13207fb3271f677e/tools/docker/build-manylinux1.sh#L132-L145) the `makefiles/Makefile.python.mk` due to some errors and to disable the manual grafting of `libortools.so` and `RPATH` setting that are incompatible with the stuff that `auditwheel repair` does to a wheel. Probably it would be better to add a new target like `make pypi_archive` excluding the incompatible lines.
- [ ] Remove the `dummy_ortools_dependency.so` file from the wheels, I have to check but my initial guess is that it's not needed by portable wheels.