### PR TITLE
Fix swig C# marshaling for vector of NodeEvaluator2. 

### DIFF
--- a/ortools/constraint_solver/csharp/constraint_solver.i
+++ b/ortools/constraint_solver/csharp/constraint_solver.i
@@ -69,6 +69,10 @@ class LocalSearchPhaseParameters {
 };
 }  // namespace operations_research
 
+namespace swig_util {
+	class NodeEvaluator2;
+}
+
 struct FailureProtect {
   jmp_buf exception_buffer;
   void JumpBack() {
@@ -139,6 +143,9 @@ PROTECT_FROM_FAILURE(Solver::Fail(), arg1);
 %template(CpInt64Vector) std::vector<int64>;
 %template(CpIntVectorVector) std::vector<std::vector<int> >;
 %template(CpInt64VectorVector) std::vector<std::vector<int64> >;
+
+// This needs to be declared here as the camel case rename rule will cause collisions in the C# NodeEvaluator2Vector class.
+%template(NodeEvaluator2Vector) std::vector<::swig_util::NodeEvaluator2*>;
 
 %define CS_TYPEMAP_STDVECTOR_OBJECT(CTYPE, TYPE)
 SWIG_STD_VECTOR_ENHANCED(operations_research::CTYPE*);

--- a/ortools/constraint_solver/csharp/routing.i
+++ b/ortools/constraint_solver/csharp/routing.i
@@ -175,6 +175,20 @@ class NodeEvaluator2 : private ::operations_research::RoutingModel::NodeEvaluato
 %typemap(cstype) operations_research::RoutingModel::NodeEvaluator2* "NodeEvaluator2";
 %typemap(csin) operations_research::RoutingModel::NodeEvaluator2* "$descriptor(ResultCallback2<int64, RoutingNodeIndex, RoutingNodeIndex>*).getCPtr($csinput.DisownAndGetPermanentCallback())";
 
+// Typemaps for NodeEvaluator2 arrays in csharp.
+%typemap(cstype) std::vector<ResultCallback2<int64, RoutingNodeIndex, RoutingNodeIndex>*>& "NodeEvaluator2[]";
+%typemap(csin) std::vector<ResultCallback2<int64, RoutingNodeIndex, RoutingNodeIndex>*>& %{ NodeEvaluator2Vector.getCPtr(new NodeEvaluator2Vector($csinput)) %}
+%typemap(cscode) NodeEvaluator2Vector %{
+	public NodeEvaluator2Vector(NodeEvaluator2[] values) 
+		:this()
+	{
+        foreach (NodeEvaluator2 value in values) 
+		{
+            this.Add(element);
+        }
+    }
+%}
+
 %rename (AddDimensionAux) operations_research::RoutingModel::AddDimension;
 %rename (AddDimensionWithVehicleCapacityAux) operations_research::RoutingModel::AddDimensionWithVehicleCapacity;
 %rename (SetArcCostEvaluatorOfAllVehiclesAux) operations_research::RoutingModel::SetArcCostEvaluatorOfAllVehicles;


### PR DESCRIPTION
Allow for AddDimensionWithVehicleTransits to be used.