### PR TITLE
Integration into main makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ help:
 	@echo "  - C++: cc test_cc clean_cc"
 	@echo "  - Python: python test_python clean_python"
 	@echo "  - Java: java test_java clean_java"
-	@echo "  - .NET: csharp test_csharp clean_csharp "
+	@echo "  - .NET (CSharp): csharp test_csharp clean_csharp"
+	@echo "  - .NET (FSharp): fsharp fsharp-help fsharp-clean"
 	@echo "  - all: all test clean"
 	@echo "  - detect: detect_port detect_python detect_java detect_csharp"
 
@@ -55,6 +56,7 @@ include $(OR_ROOT)makefiles/Makefile.cpp.mk
 include $(OR_ROOT)makefiles/Makefile.python.mk
 include $(OR_ROOT)makefiles/Makefile.java.mk
 include $(OR_ROOT)makefiles/Makefile.csharp.mk
+include $(OR_ROOT)makefiles/Makefile.fsharp.mk
 include $(OR_ROOT)makefiles/Makefile.archive.mk
 include $(OR_ROOT)makefiles/Makefile.install.mk
 

--- a/examples/fsharp/README.md
+++ b/examples/fsharp/README.md
@@ -20,7 +20,7 @@ DYLD_FALLBACK_LIBRARY_PATH=lib mono bin/<example_file>.exe
 ## Compiling a standalone binary
 This command must be run from the root folder of the repository:
 ```shell
-fsharpc --target:library --out:bin/Google.OrTools.FSharp.dll --platform:anycpu --lib:bin -r:Google.OrTools.dll ortools/fsharp/Google.OrTools.FSharp.fsx
+fsharpc --target:library --out:bin/Google.OrTools.FSharp.dll --platform:anycpu --lib:bin --nocopyfsharpcore --keyfile:bin/keyfile.snk -r:Google.OrTools.dll ortools/fsharp/Google.OrTools.FSharp.fsx
 ```
 For debug information add the `--debug` flag. The library must be coupled with the `Google.OrTools.dll`. Once installed it can be used as follows:
 ```fsharp
@@ -38,5 +38,6 @@ let opts = SolverOpts.Default
 
 One can also use the makefile found in the root folder to accomplish the same task.
 ```shell
-make help -f makefiles/Makefiles.fsharp.mk
+make fsharp
 ```
+To see the targets type `make fsharp-help`. Note that a keyfile must exists in the `bin` folder as it will be used to sign the assembly.

--- a/makefiles/Makefile.fsharp.mk
+++ b/makefiles/Makefile.fsharp.mk
@@ -6,11 +6,9 @@ CLEAN_FILES=$(FSHARP_ORTOOLS_DLL_NAME).*
 ifeq ($(SYSTEM), win)
   FSHARP_COMPILER:=fsc
   FLAG_PREFIX:=/
-  SEP:=$(strip \\)
 else
   FSHARP_COMPILER := fsharpc
   FLAG_PREFIX:=--
-  SEP:=/
 endif
 
 EXECUTABLES = mono $(FSHARP_COMPILER)
@@ -18,24 +16,29 @@ CHECK := $(foreach exec,$(EXECUTABLES),\
         $(if $(shell which $(exec)),some string,$(error "Cannot find '$(exec)' command which is needed for build)))
 
 # Check whether to build Debug or Release version
-ifeq (${DEBUG}, 1)
-  DEBUG = --debug
+ifeq (${FSHARP_DEBUG}, 1)
+  FSHARP_DEBUG = $(FLAG_PREFIX)debug
+endif
+
+# Check for key pair for strong naming
+ifdef CLR_KEYFILE
+	SIGNING_FLAGS = $(FLAG_PREFIX)keyfile:$(CLR_KEYFILE)
 endif
 
 .PHONY: default
-default: help
+default: fsharp-help
 
-.PHONY: help # Generate list of targets with descriptions.
-help:
+.PHONY: fsharp-help # Generate list of targets with descriptions.
+fsharp-help:
 	$(info Use one of the following targets:)
-	@grep "^.PHONY: .* #" Makefile-fsharp | sed "s/\.PHONY: \(.*\) # \(.*\)/\1\t\2/" | expand -t20
+	@grep "^.PHONY: .* #" $(CURDIR)/makefiles/Makefile.fsharp.mk | sed "s/\.PHONY: \(.*\) # \(.*\)/\1\t\2/" | expand -t20
 
 
-.PHONY: fsharp-ortools # Build F# OR-Tools. Set environment variable DEBUG=1 to also build debug symbols.
-fsharp-ortools:
-	$(FSHARP_COMPILER) $(FLAG_PREFIX)target:library $(FLAG_PREFIX)out:bin$(SEP)$(FSHARP_ORTOOLS_DLL_NAME).dll $(FLAG_PREFIX)platform:anycpu $(FLAG_PREFIX)lib:bin $(FLAG_PREFIX)reference:$(BASE_ORTOOLS_DLL_NAME).dll $(DEBUG) ortools$(SEP)fsharp$(SEP)$(FSHARP_ORTOOLS_DLL_NAME).fsx
+.PHONY: fsharp # Build F# OR-Tools. Set environment variable FSHARP_DEBUG=1 for debug symbols.
+fsharp:
+	$(FSHARP_COMPILER) $(FLAG_PREFIX)target:library $(FLAG_PREFIX)out:bin$S$(FSHARP_ORTOOLS_DLL_NAME).dll $(FLAG_PREFIX)platform:anycpu $(FLAG_PREFIX)nocopyfsharpcore $(FLAG_PREFIX)lib:bin $(FLAG_PREFIX)reference:$(BASE_ORTOOLS_DLL_NAME).dll $(FSHARP_DEBUG) $(SIGNING_FLAGS) ortools$Sfsharp$S$(FSHARP_ORTOOLS_DLL_NAME).fsx
 
 
-.PHONY: fsharp-clean # Clean output from previous build
-clean:
-	@rm bin$(SEP)$(CLEAN_FILES)
+.PHONY: fsharp-clean # Clean output from previous build.
+fsharp-clean:
+	@rm bin$S$(CLEAN_FILES)


### PR DESCRIPTION
Add support to build F# library from main Makefile. Should use the existing keyfile for signing (since it depends on C# library).