### PR TITLE
Check for F# compiler before compilation only when target is called

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ include $(OR_ROOT)makefiles/Makefile.cpp.mk
 include $(OR_ROOT)makefiles/Makefile.python.mk
 include $(OR_ROOT)makefiles/Makefile.java.mk
 include $(OR_ROOT)makefiles/Makefile.csharp.mk
-#include $(OR_ROOT)makefiles/Makefile.fsharp.mk
+include $(OR_ROOT)makefiles/Makefile.fsharp.mk
 include $(OR_ROOT)makefiles/Makefile.archive.mk
 include $(OR_ROOT)makefiles/Makefile.install.mk
 

--- a/makefiles/Makefile.fsharp.mk
+++ b/makefiles/Makefile.fsharp.mk
@@ -4,20 +4,18 @@ CLEAN_FILES=$(FSHARP_ORTOOLS_DLL_NAME).*
 
 # Check for required build tools
 ifeq ($(SYSTEM), win)
-  FSHARP_COMPILER:=fsc
-  FLAG_PREFIX:=/
+	FSHARP_COMPILER:=fsc
+	FLAG_PREFIX:=/
 else
-  FSHARP_COMPILER := fsharpc
-  FLAG_PREFIX:=--
+	FSHARP_COMPILER:=fsharpc
+	FLAG_PREFIX:=--
 endif
 
-EXECUTABLES = mono $(FSHARP_COMPILER)
-CHECK := $(foreach exec,$(EXECUTABLES),\
-        $(if $(shell which $(exec)),some string,$(error "Cannot find '$(exec)' command which is needed for build)))
+FSHARP_COMPILER_CHECK:=$(shell which $(FSHARP_COMPILER))
 
 # Check whether to build Debug or Release version
 ifeq (${FSHARP_DEBUG}, 1)
-  FSHARP_DEBUG = $(FLAG_PREFIX)debug
+	FSHARP_DEBUG = $(FLAG_PREFIX)debug
 endif
 
 # Check for key pair for strong naming
@@ -33,11 +31,13 @@ fsharp-help:
 	$(info Use one of the following targets:)
 	@grep "^.PHONY: .* #" $(CURDIR)/makefiles/Makefile.fsharp.mk | sed "s/\.PHONY: \(.*\) # \(.*\)/\1\t\2/" | expand -t20
 
-
 .PHONY: fsharp # Build F# OR-Tools. Set environment variable FSHARP_DEBUG=1 for debug symbols.
 fsharp:
+ifneq ($(FSHARP_COMPILER_CHECK),)
 	$(FSHARP_COMPILER) $(FLAG_PREFIX)target:library $(FLAG_PREFIX)out:bin$S$(FSHARP_ORTOOLS_DLL_NAME).dll $(FLAG_PREFIX)platform:anycpu $(FLAG_PREFIX)nocopyfsharpcore $(FLAG_PREFIX)lib:bin $(FLAG_PREFIX)reference:$(BASE_ORTOOLS_DLL_NAME).dll $(FSHARP_DEBUG) $(SIGNING_FLAGS) ortools$Sfsharp$S$(FSHARP_ORTOOLS_DLL_NAME).fsx
-
+else
+	$(error Cannot find '$(FSHARP_COMPILER)' command which is needed for build. Please make sure it is installed and in system path.)
+endif
 
 .PHONY: fsharp-clean # Clean output from previous build.
 fsharp-clean:


### PR DESCRIPTION
I didn't add it to the `all` target. This should now not exit immediately when processing the makefile.