### PR TITLE
Build CBC with --enable-cbc-parallel option

### DIFF
--- a/makefiles/Makefile.third_party.unix.mk
+++ b/makefiles/Makefile.third_party.unix.mk
@@ -250,7 +250,7 @@ dependencies/install/bin/cbc: dependencies/sources/Cbc-$(CBC_TAG)/Makefile
 	cd dependencies/sources/Cbc-$(CBC_TAG) && $(SET_COMPILER) make -j 4 && $(SET_COMPILER) make install
 
 dependencies/sources/Cbc-$(CBC_TAG)/Makefile: dependencies/sources/Cbc-$(CBC_TAG)/Makefile.in
-	cd dependencies/sources/Cbc-$(CBC_TAG) && $(SET_COMPILER) ./configure --prefix=$(OR_ROOT_FULL)/dependencies/install --disable-bzlib --without-lapack --enable-static --with-pic ADD_CXXFLAGS="-w -DCBC_THREAD_SAFE -DCBC_NO_INTERRUPT $(MAC_VERSION)"
+	cd dependencies/sources/Cbc-$(CBC_TAG) && $(SET_COMPILER) ./configure --prefix=$(OR_ROOT_FULL)/dependencies/install --disable-bzlib --without-lapack --enable-static --with-pic --enable-cbc-parallel ADD_CXXFLAGS="-w -DCBC_THREAD_SAFE -DCBC_NO_INTERRUPT $(MAC_VERSION)"
 
 CBC_ARCHIVE:=https://www.coin-or.org/download/source/Cbc/Cbc-${CBC_TAG}.tgz
 


### PR DESCRIPTION
This enables multithreading support for 'unix' platforms and has
been tested to work on macOS.

However, project configs relating to Makefile.third_party.win.mk
have not been similarly modified.

Addresses issue #180.