### PR TITLE
Add parameter passing to the CBC interface

### DIFF
--- a/ortools/linear_solver/cbc_interface.cc
+++ b/ortools/linear_solver/cbc_interface.cc
@@ -370,7 +370,10 @@ MPSolver::ResultStatus CBCInterface::Solve(const MPSolverParameters& param) {
   // through callCbc.
   model.setAllowableFractionGap(relative_mip_gap_);
   // NOTE: Trailing space is required to avoid buffer overflow in cbc.
-  int return_status = callCbc(solver_specific_parameters_ + " -solve ", model);
+  std::string call_string = " -solve ";
+  call_string = solver_specific_parameters_ + call_string;
+  int return_status = callCbc(call_string, model);
+
   const int kBadReturnStatus = 777;
   CHECK_NE(kBadReturnStatus, return_status);  // Should never happen according
                                               // to the CBC source

--- a/ortools/linear_solver/cbc_interface.cc
+++ b/ortools/linear_solver/cbc_interface.cc
@@ -27,6 +27,9 @@
 #include "ortools/base/timer.h"
 #include "ortools/base/port.h"
 #include "ortools/base/hash.h"
+
+#include "ortools/port/file.h"
+
 #include "ortools/linear_solver/linear_solver.h"
 
 #if defined(USE_CBC)
@@ -141,6 +144,8 @@ class CBCInterface : public MPSolverInterface {
   void SetScalingMode(int value) override;
   void SetLpAlgorithm(int value) override;
 
+  bool ReadParameterFile(const std::string& filename) override;
+  
   OsiClpSolverInterface osi_;
   // TODO(user): remove and query number of iterations directly from CbcModel
   int64 iterations_;
@@ -148,6 +153,7 @@ class CBCInterface : public MPSolverInterface {
   double best_objective_bound_;
   // Special way to handle the relative MIP gap parameter.
   double relative_mip_gap_;
+  std::string solver_specific_parameters_;
 };
 
 // ----- Solver -----
@@ -158,7 +164,8 @@ CBCInterface::CBCInterface(MPSolver* const solver)
       iterations_(0),
       nodes_(0),
       best_objective_bound_(-std::numeric_limits<double>::infinity()),
-      relative_mip_gap_(MPSolverParameters::kDefaultRelativeMipGap) {
+      relative_mip_gap_(MPSolverParameters::kDefaultRelativeMipGap),
+      solver_specific_parameters_("") {
   osi_.setStrParam(OsiProbName, solver_->name_);
   osi_.setObjSense(1);
 }
@@ -363,7 +370,7 @@ MPSolver::ResultStatus CBCInterface::Solve(const MPSolverParameters& param) {
   // through callCbc.
   model.setAllowableFractionGap(relative_mip_gap_);
   // NOTE: Trailing space is required to avoid buffer overflow in cbc.
-  int return_status = callCbc("-solve ", model);
+  int return_status = callCbc(solver_specific_parameters_ + " -solve ", model);
   const int kBadReturnStatus = 777;
   CHECK_NE(kBadReturnStatus, return_status);  // Should never happen according
                                               // to the CBC source
@@ -511,6 +518,10 @@ void CBCInterface::SetScalingMode(int value) {
 
 void CBCInterface::SetLpAlgorithm(int value) {
   SetUnsupportedIntegerParam(MPSolverParameters::LP_ALGORITHM);
+}
+
+bool CBCInterface::ReadParameterFile(const std::string& filename) {
+  return FileGetContents(filename, &solver_specific_parameters_).ok();
 }
 
 MPSolverInterface* BuildCBCInterface(MPSolver* const solver) {


### PR DESCRIPTION
Previously, CBCInterface does not read from solver-specific
parameters because there is no ReadParameterFile implemented.

This patch implements a ReadParameterFile that takes these
parameters, saves them in the CBCInterface instance, and passes
them to callCbc during Solve as additional arguments.

Tested to work with e.g. the "-threads" argument.

Addresses issue #57.