### PR TITLE
Fix comments of the SequenceVar Rank functions

### DIFF
--- a/ortools/constraint_solver/constraint_solver.h
+++ b/ortools/constraint_solver/constraint_solver.h
@@ -4615,11 +4615,11 @@ class SequenceVar : public PropagationBaseObject {
   // of all currently unranked interval vars.
   void RankNotFirst(int index);
 
-  // Ranks the index_th interval var first of all unranked interval
+  // Ranks the index_th interval var last of all unranked interval
   // vars. After that, it will no longer be considered ranked.
   void RankLast(int index);
 
-  // Indicates that the index_th interval var will not be ranked first
+  // Indicates that the index_th interval var will not be ranked last
   // of all currently unranked interval vars.
   void RankNotLast(int index);
 


### PR DESCRIPTION
Make comments regarding RankLast and RankNotLast coherent, they had the RankFirst and RankNotFirst descriptions.

I know it's a small change, but I've seen a few of this mismatched comments and decided I should give it a go and do something about it :)

I can't recall which others had the same error as these ones, but I'll be on the lookout for them.