### PR TITLE
Fix #709

### DIFF
--- a/examples/cpp/cvrptw_with_breaks.cc
+++ b/examples/cpp/cvrptw_with_breaks.cc
@@ -143,7 +143,7 @@ int main(int argc, char** argv) {
           solver->MakeFixedDurationIntervalVar(
               break_data[i][0] * 3600, break_data[i][1] * 3600,
               break_data[i][2], true,
-              StrCat("Break ", i, " on vehicle ", vehicle));
+              absl::StrCat("Break ", i, " on vehicle ", vehicle));
       breaks.push_back(break_interval);
     }
     // break1 performed iff break2 performed

--- a/examples/cpp/cvrptw_with_stop_times_and_resources.cc
+++ b/examples/cpp/cvrptw_with_stop_times_and_resources.cc
@@ -125,7 +125,7 @@ int main(int argc, char** argv) {
          ++stop_order) {
       const int order = stop * FLAGS_vrp_orders_per_stop + stop_order + 1;
       IntervalVar* const interval = solver->MakeFixedDurationIntervalVar(
-          0, kHorizon, kStopTime, true, StrCat("Order", order));
+          0, kHorizon, kStopTime, true, absl::StrCat("Order", order));
       intervals.push_back(interval);
       stop_intervals.push_back(interval);
       // Link order and interval.
@@ -151,7 +151,7 @@ int main(int argc, char** argv) {
     // Only one order can happen at the same time at a given location.
     std::vector<int64> location_usage(stop_intervals.size(), 1);
     solver->AddConstraint(solver->MakeCumulative(
-        stop_intervals, location_usage, 1, StrCat("Client", stop)));
+        stop_intervals, location_usage, 1, absl::StrCat("Client", stop)));
   }
   // Minimizing route duration.
   for (int vehicle = 0; vehicle < routing.vehicles(); ++vehicle) {

--- a/examples/cpp/fap_parser.cc
+++ b/examples/cpp/fap_parser.cc
@@ -24,7 +24,7 @@
 namespace operations_research {
 
 void ParseFileByLines(const std::string& filename, std::vector<std::string>* lines) {
-  CHECK_NOTNULL(lines);
+  CHECK(lines != nullptr);
   std::string result;
   CHECK_OK(file::GetContents(filename, &result, file::Defaults()));
   *lines = absl::StrSplit(result, '\n', absl::SkipEmpty());
@@ -295,10 +295,10 @@ void ParseInstance(const std::string& data_directory, bool find_components,
                    std::vector<FapConstraint>* constraints, std::string* objective,
                    std::vector<int>* frequencies,
                    std::unordered_map<int, FapComponent>* components) {
-  CHECK_NOTNULL(variables);
-  CHECK_NOTNULL(constraints);
-  CHECK_NOTNULL(objective);
-  CHECK_NOTNULL(frequencies);
+  CHECK(variables != nullptr);
+  CHECK(constraints != nullptr);
+  CHECK(objective != nullptr);
+  CHECK(frequencies != nullptr);
 
   // Parse the data files.
   VariableParser var(data_directory);
@@ -352,7 +352,7 @@ void ParseInstance(const std::string& data_directory, bool find_components,
   *objective = cst.objective();
 
   if (find_components) {
-    CHECK_NOTNULL(components);
+    CHECK(components != nullptr);
     FindComponents(*constraints, *variables, maximum_variable_id, components);
     // Evaluate each components's constraints impacts.
     for (auto& component : *components) {

--- a/examples/cpp/frequency_assignment_problem.cc
+++ b/examples/cpp/frequency_assignment_problem.cc
@@ -333,7 +333,7 @@ bool ConstraintImpactComparator(FapConstraint constraint1,
 int64 ValueEvaluator(
     std::unordered_map<int64, std::pair<int64, int64>>* value_evaluator_map,
     int64 variable_index, int64 value) {
-  CHECK_NOTNULL(value_evaluator_map);
+  CHECK(value_evaluator_map != nullptr);
   // Evaluate the choice. Smaller ranking denotes a better choice.
   int64 ranking = -1;
   for (const auto& it : *value_evaluator_map) {
@@ -382,10 +382,10 @@ void CreateModelVariables(const std::map<int, FapVariable>& data_variables,
                           Solver* solver, std::vector<IntVar*>* model_variables,
                           std::map<int, int>* index_from_key,
                           std::vector<int>* key_from_index) {
-  CHECK_NOTNULL(solver);
-  CHECK_NOTNULL(model_variables);
-  CHECK_NOTNULL(index_from_key);
-  CHECK_NOTNULL(key_from_index);
+  CHECK(solver != nullptr);
+  CHECK(model_variables != nullptr);
+  CHECK(index_from_key != nullptr);
+  CHECK(key_from_index != nullptr);
 
   const int number_of_variables = static_cast<int>(data_variables.size());
   model_variables->resize(number_of_variables);
@@ -412,7 +412,7 @@ void CreateModelConstraints(const std::vector<FapConstraint>& data_constraints,
                             const std::vector<IntVar*>& variables,
                             const std::map<int, int>& index_from_key,
                             Solver* solver) {
-  CHECK_NOTNULL(solver);
+  CHECK(solver != nullptr);
 
   for (const FapConstraint& ct : data_constraints) {
     const int index1 = FindOrDie(index_from_key, ct.variable1);
@@ -438,7 +438,7 @@ void CreateModelConstraints(const std::vector<FapConstraint>& data_constraints,
 // According to the value of a command line flag, chooses the strategy which
 // determines the selection of the variable to be assigned next.
 void ChooseVariableStrategy(Solver::IntVarStrategy* variable_strategy) {
-  CHECK_NOTNULL(variable_strategy);
+  CHECK(variable_strategy != nullptr);
 
   switch (FLAGS_choose_next_variable_strategy) {
     case 1: {
@@ -476,8 +476,8 @@ void ChooseVariableStrategy(Solver::IntVarStrategy* variable_strategy) {
 // for the search of the Solver.
 void CreateAdditionalMonitors(OptimizeVar* const objective, Solver* solver,
                               std::vector<SearchMonitor*>* monitors) {
-  CHECK_NOTNULL(solver);
-  CHECK_NOTNULL(monitors);
+  CHECK(solver != nullptr);
+  CHECK(monitors != nullptr);
 
   // Search Log
   if (FLAGS_log_search) {

--- a/examples/cpp/jobshop_ls.h
+++ b/examples/cpp/jobshop_ls.h
@@ -61,7 +61,7 @@ class SwapIntervals : public SequenceVarLocalSearchOperator {
   ~SwapIntervals() override {}
 
   bool MakeNextNeighbor(Assignment* delta, Assignment* deltadelta) override {
-    CHECK_NOTNULL(delta);
+    CHECK(delta != nullptr);
     while (true) {
       RevertChanges(true);
       if (!Increment()) {
@@ -123,7 +123,7 @@ class ShuffleIntervals : public SequenceVarLocalSearchOperator {
   ~ShuffleIntervals() override {}
 
   bool MakeNextNeighbor(Assignment* delta, Assignment* deltadelta) override {
-    CHECK_NOTNULL(delta);
+    CHECK(delta != nullptr);
     while (true) {
       RevertChanges(true);
       if (!Increment()) {
@@ -198,7 +198,7 @@ class SequenceLns : public SequenceVarLocalSearchOperator {
   ~SequenceLns() override {}
 
   bool MakeNextNeighbor(Assignment* delta, Assignment* deltadelta) override {
-    CHECK_NOTNULL(delta);
+    CHECK(delta != nullptr);
     while (true) {
       RevertChanges(true);
       if (random_.Uniform(2) == 0) {

--- a/examples/cpp/model_util.cc
+++ b/examples/cpp/model_util.cc
@@ -109,7 +109,7 @@ void ExportLinks(const CpModel& model, const std::string& source, const T& proto
 // integer variable with min_value == max_value.
 bool GetValueIfConstant(const CpModel& model, const CpIntegerExpression& proto,
                         int64* const value) {
-  CHECK_NOTNULL(value);
+  CHECK(value != nullptr);
   const int expr_type = proto.type_index();
   if (model.tags(expr_type) != ModelVisitor::kIntegerVariable) {
     return false;

--- a/examples/cpp/model_util.cc
+++ b/examples/cpp/model_util.cc
@@ -144,7 +144,7 @@ void DeclareExpression(int index, const CpModel& proto,
   if (!expr.name().empty()) {
     exporter->WriteNode(label, expr.name(), "oval", kGreen1);
   } else if (GetValueIfConstant(proto, expr, &value)) {
-    exporter->WriteNode(label, StrCat(value), "oval", kYellow);
+    exporter->WriteNode(label, absl::StrCat(value), "oval", kYellow);
   } else {
     const std::string& type = proto.tags(expr.type_index());
     exporter->WriteNode(label, type, "oval", kWhite);

--- a/examples/cpp/parse_dimacs_assignment.h
+++ b/examples/cpp/parse_dimacs_assignment.h
@@ -220,8 +220,8 @@ void DimacsAssignmentParser<GraphType>::ParseOneLine(const std::string& line) {
 template <typename GraphType>
 LinearSumAssignment<GraphType>* DimacsAssignmentParser<GraphType>::Parse(
     std::string* error_message, GraphType** graph_handle) {
-  CHECK_NOTNULL(error_message);
-  CHECK_NOTNULL(graph_handle);
+  CHECK(error_message != nullptr);
+  CHECK(graph_handle != nullptr);
 
   for (const std::string& line : FileLines(filename_)) {
     if (line.empty()) {

--- a/examples/cpp/sat_runner.cc
+++ b/examples/cpp/sat_runner.cc
@@ -183,7 +183,8 @@ std::string SolutionString(const LinearBooleanProblem& problem,
   BooleanVariable limit(problem.original_num_variables());
   for (BooleanVariable index(0); index < limit; ++index) {
     if (index > 0) output += " ";
-    StrAppend(&output, Literal(index, assignment[index.value()]).SignedValue());
+    absl::StrAppend(&output,
+                    Literal(index, assignment[index.value()]).SignedValue());
   }
   return output;
 }

--- a/examples/cpp/tsp.cc
+++ b/examples/cpp/tsp.cc
@@ -147,11 +147,11 @@ void Tsp() {
       std::string route;
       for (int64 node = routing.Start(route_number); !routing.IsEnd(node);
            node = solution->Value(routing.NextVar(node))) {
-        StrAppend(&route, routing.IndexToNode(node).value(), " (", node,
+        absl::StrAppend(&route, routing.IndexToNode(node).value(), " (", node,
                         ") -> ");
       }
       const int64 end = routing.End(route_number);
-      StrAppend(&route, routing.IndexToNode(end).value(), " (", end, ")");
+      absl::StrAppend(&route, routing.IndexToNode(end).value(), " (", end, ")");
       LOG(INFO) << route;
     } else {
       LOG(INFO) << "No solution found.";

--- a/examples/cpp/weighted_tardiness_sat.cc
+++ b/examples/cpp/weighted_tardiness_sat.cc
@@ -233,12 +233,12 @@ void Solve(const std::vector<int>& durations, const std::vector<int>& due_dates,
     int end = 0;
     for (const int i : sorted_tasks) {
       const int64 cost = weights[i] * r.solution(tardiness_vars[i]);
-      StrAppend(&solution, "| #", i, " ");
+      absl::StrAppend(&solution, "| #", i, " ");
       if (cost > 0) {
         // Display the cost in red.
-        StrAppend(&solution, "\033[1;31m(+", cost, ") \033[0m");
+        absl::StrAppend(&solution, "\033[1;31m(+", cost, ") \033[0m");
       }
-      StrAppend(&solution, "|", r.solution(tasks_end[i]));
+      absl::StrAppend(&solution, "|", r.solution(tasks_end[i]));
       CHECK_EQ(end, r.solution(tasks_start[i]));
       end += durations[i];
       CHECK_EQ(end, r.solution(tasks_end[i]));

--- a/makefiles/Makefile.cpp.mk
+++ b/makefiles/Makefile.cpp.mk
@@ -139,6 +139,7 @@ cvrptw_with_resources \
 cvrptw_with_stop_times_and_resources \
 dimacs_assignment \
 dobble_ls \
+flexible_jobshop \
 flow_api \
 frequency_assignment_problem \
 golomb \

--- a/ortools/base/numbers.h
+++ b/ortools/base/numbers.h
@@ -28,6 +28,6 @@ bool safe_strtod(const std::string& str, double* value);
 bool safe_strto64(const std::string& str, int64* value);
 bool safe_strto32(const std::string& str, int* value);
 // Converting int to std::string.
-inline std::string SimpleItoa(int i) { return StrCat(i); }
+inline std::string SimpleItoa(int i) { return absl::StrCat(i); }
 
 #endif  // OR_TOOLS_BASE_NUMBERS_H_

--- a/ortools/base/status.h
+++ b/ortools/base/status.h
@@ -41,7 +41,7 @@ struct Status {
 
   std::string ToString() const {
     if (ok()) return "OK";
-    return StrCat("ERROR #", error_code_, ": '", error_message_, "'");
+    return absl::StrCat("ERROR #", error_code_, ": '", error_message_, "'");
   }
 
   std::string error_message() const { return error_message_; }

--- a/ortools/constraint_solver/constraint_solveri.h
+++ b/ortools/constraint_solver/constraint_solveri.h
@@ -599,10 +599,10 @@ class CallMethod2 : public Demon {
   }
 
   std::string DebugString() const override {
-    return StrCat(StrCat("CallMethod_", name_),
-                  StrCat("(", constraint_->DebugString()),
-                  StrCat(", ", ParameterDebugString(param1_)),
-                  StrCat(", ", ParameterDebugString(param2_), ")"));
+    return absl::StrCat(absl::StrCat("CallMethod_", name_),
+                  absl::StrCat("(", constraint_->DebugString()),
+                  absl::StrCat(", ", ParameterDebugString(param1_)),
+                  absl::StrCat(", ", ParameterDebugString(param2_), ")"));
   }
 
  private:
@@ -640,11 +640,11 @@ class CallMethod3 : public Demon {
   }
 
   std::string DebugString() const override {
-    return StrCat(StrCat("CallMethod_", name_),
-                  StrCat("(", constraint_->DebugString()),
-                  StrCat(", ", ParameterDebugString(param1_)),
-                  StrCat(", ", ParameterDebugString(param2_)),
-                  StrCat(", ", ParameterDebugString(param3_), ")"));
+    return absl::StrCat(absl::StrCat("CallMethod_", name_),
+                  absl::StrCat("(", constraint_->DebugString()),
+                  absl::StrCat(", ", ParameterDebugString(param1_)),
+                  absl::StrCat(", ", ParameterDebugString(param2_)),
+                  absl::StrCat(", ", ParameterDebugString(param3_), ")"));
   }
 
  private:
@@ -761,10 +761,10 @@ class DelayedCallMethod2 : public Demon {
   }
 
   std::string DebugString() const override {
-    return StrCat(StrCat("DelayedCallMethod_", name_),
-                  StrCat("(", constraint_->DebugString()),
-                  StrCat(", ", ParameterDebugString(param1_)),
-                  StrCat(", ", ParameterDebugString(param2_), ")"));
+    return absl::StrCat(absl::StrCat("DelayedCallMethod_", name_),
+                  absl::StrCat("(", constraint_->DebugString()),
+                  absl::StrCat(", ", ParameterDebugString(param1_)),
+                  absl::StrCat(", ", ParameterDebugString(param2_), ")"));
   }
 
  private:

--- a/ortools/constraint_solver/constraint_solveri.h
+++ b/ortools/constraint_solver/constraint_solveri.h
@@ -2505,21 +2505,21 @@ class RevPartialSequence {
   std::string DebugString() const {
     std::string result = "[";
     for (int i = 0; i < first_ranked_.Value(); ++i) {
-      StrAppend(&result, elements_[i]);
+      absl::StrAppend(&result, elements_[i]);
       if (i != first_ranked_.Value() - 1) {
         result.append("-");
       }
     }
     result.append("|");
     for (int i = first_ranked_.Value(); i <= last_ranked_.Value(); ++i) {
-      StrAppend(&result, elements_[i]);
+      absl::StrAppend(&result, elements_[i]);
       if (i != last_ranked_.Value()) {
         result.append("-");
       }
     }
     result.append("|");
     for (int i = last_ranked_.Value() + 1; i < size_; ++i) {
-      StrAppend(&result, elements_[i]);
+      absl::StrAppend(&result, elements_[i]);
       if (i != size_ - 1) {
         result.append("-");
       }

--- a/ortools/constraint_solver/expressions.cc
+++ b/ortools/constraint_solver/expressions.cc
@@ -2651,7 +2651,7 @@ class IntConst : public IntVar {
     if (solver()->HasName(this)) {
       return PropagationBaseObject::name();
     } else {
-      return StrCat(value_);
+      return absl::StrCat(value_);
     }
   }
 
@@ -6512,7 +6512,7 @@ std::string IndexedName(const std::string& prefix, int index, int max_index) {
 #endif
   return StringPrintf("%s%0*d", prefix.c_str(), digits, index);
 #else
-  return StrCat(prefix, index);
+  return absl::StrCat(prefix, index);
 #endif
 }
 }  // namespace

--- a/ortools/constraint_solver/interval.cc
+++ b/ortools/constraint_solver/interval.cc
@@ -604,7 +604,7 @@ class RangeVar : public IntExpr {
   }
 
   std::string DebugString() const override {
-    std::string out = StrCat(min_.Value());
+    std::string out = absl::StrCat(min_.Value());
     if (!Bound()) {
       StringAppendF(&out, " .. %" GG_LL_FORMAT "d", max_.Value());
     }
@@ -2264,7 +2264,7 @@ void Solver::MakeFixedDurationIntervalVarArray(
   CHECK(array != nullptr);
   array->clear();
   for (int i = 0; i < count; ++i) {
-    const std::string var_name = StrCat(name, i);
+    const std::string var_name = absl::StrCat(name, i);
     array->push_back(MakeFixedDurationIntervalVar(
         start_min, start_max, duration, optional, var_name));
   }
@@ -2308,7 +2308,7 @@ void Solver::MakeFixedDurationIntervalVarArray(
   CHECK(array != nullptr);
   array->clear();
   for (int i = 0; i < start_variables.size(); ++i) {
-    const std::string var_name = StrCat(name, i);
+    const std::string var_name = absl::StrCat(name, i);
     array->push_back(
         MakeFixedDurationIntervalVar(start_variables[i], duration, var_name));
   }
@@ -2324,7 +2324,7 @@ void Solver::MakeFixedDurationIntervalVarArray(
   CHECK_EQ(start_variables.size(), durations.size());
   array->clear();
   for (int i = 0; i < start_variables.size(); ++i) {
-    const std::string var_name = StrCat(name, i);
+    const std::string var_name = absl::StrCat(name, i);
     array->push_back(MakeFixedDurationIntervalVar(start_variables[i],
                                                   durations[i], var_name));
   }
@@ -2338,7 +2338,7 @@ void Solver::MakeFixedDurationIntervalVarArray(
   CHECK_EQ(start_variables.size(), durations.size());
   array->clear();
   for (int i = 0; i < start_variables.size(); ++i) {
-    const std::string var_name = StrCat(name, i);
+    const std::string var_name = absl::StrCat(name, i);
     array->push_back(MakeFixedDurationIntervalVar(start_variables[i],
                                                   durations[i], var_name));
   }
@@ -2352,7 +2352,7 @@ void Solver::MakeFixedDurationIntervalVarArray(
   CHECK(array != nullptr);
   array->clear();
   for (int i = 0; i < start_variables.size(); ++i) {
-    const std::string var_name = StrCat(name, i);
+    const std::string var_name = absl::StrCat(name, i);
     array->push_back(MakeFixedDurationIntervalVar(
         start_variables[i], durations[i], performed_variables[i], var_name));
   }
@@ -2366,7 +2366,7 @@ void Solver::MakeFixedDurationIntervalVarArray(
   CHECK(array != nullptr);
   array->clear();
   for (int i = 0; i < start_variables.size(); ++i) {
-    const std::string var_name = StrCat(name, i);
+    const std::string var_name = absl::StrCat(name, i);
     array->push_back(MakeFixedDurationIntervalVar(
         start_variables[i], durations[i], performed_variables[i], var_name));
   }
@@ -2392,7 +2392,7 @@ void Solver::MakeIntervalVarArray(int count, int64 start_min, int64 start_max,
   CHECK(array != nullptr);
   array->clear();
   for (int i = 0; i < count; ++i) {
-    const std::string var_name = StrCat(name, i);
+    const std::string var_name = absl::StrCat(name, i);
     array->push_back(MakeIntervalVar(start_min, start_max, duration_min,
                                      duration_max, end_min, end_max, optional,
                                      var_name));

--- a/ortools/constraint_solver/routing.cc
+++ b/ortools/constraint_solver/routing.cc
@@ -4915,7 +4915,7 @@ class BreakConstraint : public Constraint {
         dimension_(dimension),
         vehicle_(vehicle),
         break_intervals_(std::move(break_intervals)),
-        status_(solver()->MakeBoolVar(StrCat("status", vehicle))) {}
+        status_(solver()->MakeBoolVar(absl::StrCat("status", vehicle))) {}
   void Post() override {
     RoutingModel* const model = dimension_->model();
     solver()->AddConstraint(
@@ -4951,7 +4951,7 @@ class BreakConstraint : public Constraint {
               dimension_->CumulVar(current)->Min(),
               dimension_->CumulVar(next)->Max(), 0,
               dimension_->FixedTransitVar(current)->Value(), 0, kint64max,
-              false, StrCat(current, "-", i));
+              false, absl::StrCat(current, "-", i));
           transit_intervals.push_back(interval);
           vehicle_intervals.push_back(interval);
           // Order transit intervals to cut symmetries.
@@ -4987,7 +4987,7 @@ class BreakConstraint : public Constraint {
         current = next;
       }
       solver()->AddConstraint(solver()->MakeStrictDisjunctiveConstraint(
-          vehicle_intervals, StrCat("Vehicle breaks ", vehicle_)));
+          vehicle_intervals, absl::StrCat("Vehicle breaks ", vehicle_)));
     }
   }
 

--- a/ortools/constraint_solver/tree_monitor.cc
+++ b/ortools/constraint_solver/tree_monitor.cc
@@ -391,7 +391,7 @@ class TreeNode {
       visualization_writer->StartElement("failed");
       visualization_writer->AddAttribute("index", name);
       visualization_writer->AddAttribute("value",
-                                         StrCat(parent_->branch_value(0)));
+                                         absl::StrCat(parent_->branch_value(0)));
       visualization_writer->EndElement();  // failed
     } else if (node_type_ == TRY) {
       visualization_writer->StartElement("focus");
@@ -440,11 +440,11 @@ class TreeNode {
         const std::vector<int64>* const domain_values =
             FindOrNull(domain, name_);
         if (domain_values) {
-          tree_writer->AddAttribute("size", StrCat(domain_values->size()));
+          tree_writer->AddAttribute("size", absl::StrCat(domain_values->size()));
         } else {
           tree_writer->AddAttribute("size", "unknown");
         }
-        tree_writer->AddAttribute("value", StrCat(branch_values_[i]));
+        tree_writer->AddAttribute("value", absl::StrCat(branch_values_[i]));
       }
 
       tree_writer->EndElement();
@@ -564,7 +564,7 @@ void TreeMonitor::Init(const IntVar* const* vars, int size) {
     std::string name = vars[i]->name();
 
     if (name.empty()) {
-      name = StrCat(i);
+      name = absl::StrCat(i);
     }
 
     vars_[name] = vars[i];
@@ -674,10 +674,10 @@ std::string TreeMonitor::GenerateVisualizationXML() const {
   xml_writer.AddAttribute("id", 0);
   xml_writer.AddAttribute("type", "vector");
   xml_writer.AddAttribute("display", "expanded");
-  xml_writer.AddAttribute("min", StrCat(min_));
-  xml_writer.AddAttribute("max", StrCat(max_));
-  xml_writer.AddAttribute("width", StrCat(vars_.size()));
-  xml_writer.AddAttribute("height", StrCat(max_ - min_ + 1));
+  xml_writer.AddAttribute("min", absl::StrCat(min_));
+  xml_writer.AddAttribute("max", absl::StrCat(max_));
+  xml_writer.AddAttribute("width", absl::StrCat(vars_.size()));
+  xml_writer.AddAttribute("height", absl::StrCat(max_ - min_ + 1));
   xml_writer.EndElement();  // End of element: visualizer
 
   root_node_->GenerateVisualizationXML(&xml_writer);

--- a/ortools/flatzinc/cp_model_fz_solver.cc
+++ b/ortools/flatzinc/cp_model_fz_solver.cc
@@ -752,7 +752,7 @@ std::string SolutionString(
     }
   } else {
     const int bound_size = output.bounds.size();
-    std::string result = StrCat(output.name, " = array", bound_size, "d(");
+    std::string result = absl::StrCat(output.name, " = array", bound_size, "d(");
     for (int i = 0; i < bound_size; ++i) {
       if (output.bounds[i].max_value != 0) {
         absl::StrAppend(&result, output.bounds[i].min_value, "..",

--- a/ortools/flatzinc/model.cc
+++ b/ortools/flatzinc/model.cc
@@ -378,7 +378,7 @@ std::string Domain::DebugString() const {
                              values[0], values[1]);
     }
   } else if (values.size() == 1) {
-    return StrCat(values.back());
+    return absl::StrCat(values.back());
   } else {
     return StringPrintf("[%s]", absl::StrJoin(values, ", ").c_str());
   }
@@ -793,7 +793,7 @@ std::string Annotation::DebugString() const {
                              interval_min, interval_max);
     }
     case INT_VALUE: {
-      return StrCat(interval_min);
+      return absl::StrCat(interval_min);
     }
     case INT_VAR_REF: {
       return variables.front()->name;
@@ -876,7 +876,7 @@ IntegerVariable* Model::AddVariable(const std::string& name, const Domain& domai
 // TODO(user): Create only once constant per value.
 IntegerVariable* Model::AddConstant(int64 value) {
   IntegerVariable* const var =
-      new IntegerVariable(StrCat(value), Domain::IntegerValue(value), true);
+      new IntegerVariable(absl::StrCat(value), Domain::IntegerValue(value), true);
   variables_.push_back(var);
   return var;
 }

--- a/ortools/flatzinc/solver.cc
+++ b/ortools/flatzinc/solver.cc
@@ -118,7 +118,7 @@ std::string Solver::SolutionString(const SolutionOutputSpecs& output) const {
       if (output.display_as_boolean) {
         result.append(StringPrintf(value ? "true" : "false"));
       } else {
-        StrAppend(&result, value);
+        absl::StrAppend(&result, value);
       }
       if (i != output.flat_variables.size() - 1) {
         result.append(", ");

--- a/ortools/flatzinc/solver.cc
+++ b/ortools/flatzinc/solver.cc
@@ -912,7 +912,7 @@ void Solver::Solve(FlatzincParameters p, SearchReportingInterface* report) {
                              ? "**sat**"
                              : (timeout ? "**feasible**" : "**proven**")));
     const std::string obj_string =
-        (model_.objective() != nullptr && !no_solutions ? StrCat(best) : "");
+        (model_.objective() != nullptr && !no_solutions ? absl::StrCat(best) : "");
     solver_status.append(
         "%%  name, status, obj, solns, s_time, b_time, br, "
         "fails, cts, demon, delayed, mem, search\n");

--- a/ortools/flatzinc/solver_util.cc
+++ b/ortools/flatzinc/solver_util.cc
@@ -195,7 +195,7 @@ std::string MemoryUsage() {
   } else if (memory_usage > kDisplayThreshold * kKiloByte) {
     return StringPrintf("%2lf KB", memory_usage * 1.0 / kKiloByte);
   } else {
-    return StrCat(memory_usage);
+    return absl::StrCat(memory_usage);
   }
 }
 

--- a/ortools/glop/lp_solver.cc
+++ b/ortools/glop/lp_solver.cc
@@ -89,7 +89,7 @@ void DumpLinearProgramIfRequiredByFlags(const LinearProgram& linear_program,
   const int file_num =
       FLAGS_lp_dump_file_number >= 0 ? FLAGS_lp_dump_file_number : num;
   StringAppendF(&filename, "-%06d.pb", file_num);
-  const std::string filespec = StrCat(FLAGS_lp_dump_dir, "/", filename);
+  const std::string filespec = absl::StrCat(FLAGS_lp_dump_dir, "/", filename);
   MPModelProto proto;
   LinearProgramToMPModelProto(linear_program, &proto);
   const ProtoWriteFormat write_format = FLAGS_lp_dump_binary_file

--- a/ortools/graph/cliques.h
+++ b/ortools/graph/cliques.h
@@ -244,14 +244,14 @@ class BronKerboschAlgorithm {
     // Creates a human-readable representation of the current state.
     std::string DebugString() {
       std::string buffer;
-      StrAppend(&buffer, "pivot = ", pivot,
+      absl::StrAppend(&buffer, "pivot = ", pivot,
                       "\nnum_remaining_candidates = ", num_remaining_candidates,
                       "\ncandidates = [");
       for (CandidateIndex i(0); i < candidates.size(); ++i) {
         if (i > 0) buffer += ", ";
-        StrAppend(&buffer, candidates[i]);
+        absl::StrAppend(&buffer, candidates[i]);
       }
-      StrAppend(
+      absl::StrAppend(
           &buffer, "]\nfirst_candidate_index = ", first_candidate_index.value(),
           "\ncandidate_for_recursion = ", candidate_for_recursion.value());
       return buffer;
@@ -434,7 +434,7 @@ std::string BronKerboschAlgorithm<NodeIndex>::CliqueDebugString(
     const std::vector<NodeIndex>& clique) {
   std::string message = "Clique: [ ";
   for (const NodeIndex node : clique) {
-    StrAppend(&message, node, " ");
+    absl::StrAppend(&message, node, " ");
   }
   message += "]";
   return message;

--- a/ortools/graph/ebert_graph.h
+++ b/ortools/graph/ebert_graph.h
@@ -305,7 +305,7 @@ class StarGraphBase {
     if (node == kNilNode) {
       return "NilNode";
     } else {
-      return StrCat(static_cast<int64>(node));
+      return absl::StrCat(static_cast<int64>(node));
     }
   }
 
@@ -313,7 +313,7 @@ class StarGraphBase {
     if (arc == kNilArc) {
       return "NilArc";
     } else {
-      return StrCat(static_cast<int64>(arc));
+      return absl::StrCat(static_cast<int64>(arc));
     }
   }
 

--- a/ortools/linear_solver/model_exporter.cc
+++ b/ortools/linear_solver/model_exporter.cc
@@ -200,9 +200,9 @@ void LineBreaker::Append(const std::string& s) {
   line_size_ += s.size();
   if (line_size_ > max_line_size_) {
     line_size_ = s.size();
-    StrAppend(&output_, "\n ");
+    absl::StrAppend(&output_, "\n ");
   }
-  StrAppend(&output_, s);
+  absl::StrAppend(&output_, s);
 }
 
 std::string DoubleToStringWithForcedSign(double d) {
@@ -263,7 +263,7 @@ bool MPModelProtoExporter::ExportModelAsLpFormat(bool obfuscated,
   AppendComments("\\", output);
 
   // Objective
-  StrAppend(output, proto_.maximize() ? "Maximize\n" : "Minimize\n");
+  absl::StrAppend(output, proto_.maximize() ? "Maximize\n" : "Minimize\n");
   LineBreaker obj_line_breaker(FLAGS_lp_max_line_length);
   obj_line_breaker.Append(" Obj: ");
   if (proto_.objective_offset() != 0.0) {
@@ -282,7 +282,7 @@ bool MPModelProtoExporter::ExportModelAsLpFormat(bool obfuscated,
     show_variable[var_index] = coeff != 0.0 || FLAGS_lp_shows_unused_variables;
   }
   // Constraints
-  StrAppend(output, obj_line_breaker.GetOutput(), "\nSubject to\n");
+  absl::StrAppend(output, obj_line_breaker.GetOutput(), "\nSubject to\n");
   for (int cst_index = 0; cst_index < proto_.constraint_size(); ++cst_index) {
     const MPConstraintProto& ct_proto = proto_.constraint(cst_index);
     const std::string& name = exported_constraint_names_[cst_index];
@@ -306,37 +306,37 @@ bool MPModelProtoExporter::ExportModelAsLpFormat(bool obfuscated,
     const double ub = ct_proto.upper_bound();
     if (lb == ub) {
       line_breaker.Append(StrCat(" = ", DoubleToString(ub), "\n"));
-      StrAppend(output, " ", name, ": ", line_breaker.GetOutput());
+      absl::StrAppend(output, " ", name, ": ", line_breaker.GetOutput());
     } else {
       if (ub != +std::numeric_limits<double>::infinity()) {
         std::string rhs_name = name;
         if (lb != -std::numeric_limits<double>::infinity()) {
-          StrAppend(&rhs_name, "_rhs");
+          absl::StrAppend(&rhs_name, "_rhs");
         }
         StrAppend(output, " ", rhs_name, ": ", line_breaker.GetOutput());
         const std::string relation = StrCat(" <= ", DoubleToString(ub), "\n");
         // Here we have to make sure we do not add the relation to the contents
         // of line_breaker, which may be used in the subsequent clause.
-        if (!line_breaker.WillFit(relation)) StrAppend(output, "\n ");
-        StrAppend(output, relation);
+        if (!line_breaker.WillFit(relation)) absl::StrAppend(output, "\n ");
+        absl::StrAppend(output, relation);
       }
       if (lb != -std::numeric_limits<double>::infinity()) {
         std::string lhs_name = name;
         if (ub != +std::numeric_limits<double>::infinity()) {
-          StrAppend(&lhs_name, "_lhs");
+          absl::StrAppend(&lhs_name, "_lhs");
         }
         StrAppend(output, " ", lhs_name, ": ", line_breaker.GetOutput());
         const std::string relation = StrCat(" >= ", DoubleToString(lb), "\n");
-        if (!line_breaker.WillFit(relation)) StrAppend(output, "\n ");
-        StrAppend(output, relation);
+        if (!line_breaker.WillFit(relation)) absl::StrAppend(output, "\n ");
+        absl::StrAppend(output, relation);
       }
     }
   }
 
   // Bounds
-  StrAppend(output, "Bounds\n");
+  absl::StrAppend(output, "Bounds\n");
   if (proto_.objective_offset() != 0.0) {
-    StrAppend(output, " 1 <= Constant <= 1\n");
+    absl::StrAppend(output, " 1 <= Constant <= 1\n");
   }
   for (int var_index = 0; var_index < proto_.variable_size(); ++var_index) {
     if (!show_variable[var_index]) continue;
@@ -348,19 +348,19 @@ bool MPModelProtoExporter::ExportModelAsLpFormat(bool obfuscated,
                     exported_variable_names_[var_index].c_str(), ub);
     } else {
       if (lb != -std::numeric_limits<double>::infinity()) {
-        StrAppend(output, " ", DoubleToString(lb), " <= ");
+        absl::StrAppend(output, " ", DoubleToString(lb), " <= ");
       }
-      StrAppend(output, exported_variable_names_[var_index]);
+      absl::StrAppend(output, exported_variable_names_[var_index]);
       if (ub != std::numeric_limits<double>::infinity()) {
-        StrAppend(output, " <= ", DoubleToString(ub));
+        absl::StrAppend(output, " <= ", DoubleToString(ub));
       }
-      StrAppend(output, "\n");
+      absl::StrAppend(output, "\n");
     }
   }
 
   // Binaries
   if (num_binary_variables_ > 0) {
-    StrAppend(output, "Binaries\n");
+    absl::StrAppend(output, "Binaries\n");
     for (int var_index = 0; var_index < proto_.variable_size(); ++var_index) {
       if (!show_variable[var_index]) continue;
       const MPVariableProto& var_proto = proto_.variable(var_index);
@@ -373,16 +373,16 @@ bool MPModelProtoExporter::ExportModelAsLpFormat(bool obfuscated,
 
   // Generals
   if (num_integer_variables_ > 0) {
-    StrAppend(output, "Generals\n");
+    absl::StrAppend(output, "Generals\n");
     for (int var_index = 0; var_index < proto_.variable_size(); ++var_index) {
       if (!show_variable[var_index]) continue;
       const MPVariableProto& var_proto = proto_.variable(var_index);
       if (var_proto.is_integer() && !IsBoolean(var_proto)) {
-        StrAppend(output, " ", exported_variable_names_[var_index], "\n");
+        absl::StrAppend(output, " ", exported_variable_names_[var_index], "\n");
       }
     }
   }
-  StrAppend(output, "End\n");
+  absl::StrAppend(output, "End\n");
   return true;
 }
 
@@ -415,7 +415,7 @@ void MPModelProtoExporter::AppendMpsLineHeader(const std::string& id,
 void MPModelProtoExporter::AppendMpsLineHeaderWithNewLine(
     const std::string& id, const std::string& name, std::string* output) const {
   AppendMpsLineHeader(id, name, output);
-  StrAppend(output, "\n");
+  absl::StrAppend(output, "\n");
 }
 
 void MPModelProtoExporter::AppendMpsTermWithContext(const std::string& head_name,
@@ -434,13 +434,13 @@ void MPModelProtoExporter::AppendMpsBound(const std::string& bound_type,
                                           std::string* output) const {
   AppendMpsLineHeader(bound_type, "BOUND", output);
   AppendMpsPair(name, value, output);
-  StrAppend(output, "\n");
+  absl::StrAppend(output, "\n");
 }
 
 void MPModelProtoExporter::AppendNewLineIfTwoColumns(std::string* output) {
   ++current_mps_column_;
   if (current_mps_column_ == 2) {
-    StrAppend(output, "\n");
+    absl::StrAppend(output, "\n");
     current_mps_column_ = 0;
   }
 }
@@ -511,7 +511,7 @@ bool MPModelProtoExporter::ExportModelAsMpsFormat(bool fixed_format,
     }
   }
   if (!rows_section.empty()) {
-    StrAppend(output, "ROWS\n", rows_section);
+    absl::StrAppend(output, "ROWS\n", rows_section);
   }
 
   // As the information regarding a column needs to be contiguous, we create
@@ -548,7 +548,7 @@ bool MPModelProtoExporter::ExportModelAsMpsFormat(bool fixed_format,
   }
   AppendMpsColumns(/*integrality=*/false, transpose, &columns_section);
   if (!columns_section.empty()) {
-    StrAppend(output, "COLUMNS\n", columns_section);
+    absl::StrAppend(output, "COLUMNS\n", columns_section);
   }
 
   // RHS (right-hand-side) section.
@@ -567,7 +567,7 @@ bool MPModelProtoExporter::ExportModelAsMpsFormat(bool fixed_format,
   }
   AppendNewLineIfTwoColumns(&rhs_section);
   if (!rhs_section.empty()) {
-    StrAppend(output, "RHS\n", rhs_section);
+    absl::StrAppend(output, "RHS\n", rhs_section);
   }
 
   // RANGES section.
@@ -583,7 +583,7 @@ bool MPModelProtoExporter::ExportModelAsMpsFormat(bool fixed_format,
   }
   AppendNewLineIfTwoColumns(&ranges_section);
   if (!ranges_section.empty()) {
-    StrAppend(output, "RANGES\n", ranges_section);
+    absl::StrAppend(output, "RANGES\n", ranges_section);
   }
 
   // BOUNDS section.
@@ -627,10 +627,10 @@ bool MPModelProtoExporter::ExportModelAsMpsFormat(bool fixed_format,
     }
   }
   if (!bounds_section.empty()) {
-    StrAppend(output, "BOUNDS\n", bounds_section);
+    absl::StrAppend(output, "BOUNDS\n", bounds_section);
   }
 
-  StrAppend(output, "ENDATA\n");
+  absl::StrAppend(output, "ENDATA\n");
   return true;
 }
 

--- a/ortools/linear_solver/model_exporter.cc
+++ b/ortools/linear_solver/model_exporter.cc
@@ -66,7 +66,7 @@ std::string NameManager::MakeUniqueName(const std::string& name) {
   // Find the 'n' so that "name_n" does not already exist.
   int n = last_n_;
   while (!names_set_.insert(result).second) {
-    result = StrCat(name, "_", n);
+    result = absl::StrCat(name, "_", n);
     ++n;
   }
   // We keep the last n used to avoid a quadratic behavior in case
@@ -79,7 +79,7 @@ std::string MakeExportableName(const std::string& name, bool* found_forbidden_ch
   // Prepend with "_" all the names starting with a forbidden character.
   const std::string kForbiddenFirstChars = "$.0123456789";
   *found_forbidden_char = kForbiddenFirstChars.find(name[0]) != std::string::npos;
-  std::string exportable_name = *found_forbidden_char ? StrCat("_", name) : name;
+  std::string exportable_name = *found_forbidden_char ? absl::StrCat("_", name) : name;
 
   // Replace all the other forbidden characters with "_".
   const std::string kForbiddenChars = " +-*/<>=:\\";
@@ -100,7 +100,7 @@ std::vector<std::string> MPModelProtoExporter::ExtractAndProcessNames(
   const int num_items = proto.size();
   std::vector<std::string> result(num_items);
   NameManager namer;
-  const int num_digits = StrCat(num_items).size();
+  const int num_digits = absl::StrCat(num_items).size();
   int i = 0;
   for (const auto& item : proto) {
     const std::string obfuscated_name =
@@ -206,10 +206,10 @@ void LineBreaker::Append(const std::string& s) {
 }
 
 std::string DoubleToStringWithForcedSign(double d) {
-  return StrCat((d < 0 ? "" : "+"), absl::LegacyPrecision(d));
+  return absl::StrCat((d < 0 ? "" : "+"), absl::LegacyPrecision(d));
 }
 
-std::string DoubleToString(double d) { return StrCat(absl::LegacyPrecision(d)); }
+std::string DoubleToString(double d) { return absl::StrCat(absl::LegacyPrecision(d)); }
 
 }  // namespace
 
@@ -221,7 +221,7 @@ bool MPModelProtoExporter::WriteLpTerm(int var_index, double coefficient,
     return false;
   }
   if (coefficient != 0.0) {
-    *output = StrCat(DoubleToStringWithForcedSign(coefficient), " ",
+    *output = absl::StrCat(DoubleToStringWithForcedSign(coefficient), " ",
                      exported_variable_names_[var_index], " ");
   }
   return true;
@@ -267,7 +267,7 @@ bool MPModelProtoExporter::ExportModelAsLpFormat(bool obfuscated,
   LineBreaker obj_line_breaker(FLAGS_lp_max_line_length);
   obj_line_breaker.Append(" Obj: ");
   if (proto_.objective_offset() != 0.0) {
-    obj_line_breaker.Append(StrCat(
+    obj_line_breaker.Append(absl::StrCat(
         DoubleToStringWithForcedSign(proto_.objective_offset()), " Constant "));
   }
   std::vector<bool> show_variable(proto_.variable_size(),
@@ -305,7 +305,7 @@ bool MPModelProtoExporter::ExportModelAsLpFormat(bool obfuscated,
     const double lb = ct_proto.lower_bound();
     const double ub = ct_proto.upper_bound();
     if (lb == ub) {
-      line_breaker.Append(StrCat(" = ", DoubleToString(ub), "\n"));
+      line_breaker.Append(absl::StrCat(" = ", DoubleToString(ub), "\n"));
       absl::StrAppend(output, " ", name, ": ", line_breaker.GetOutput());
     } else {
       if (ub != +std::numeric_limits<double>::infinity()) {
@@ -313,8 +313,8 @@ bool MPModelProtoExporter::ExportModelAsLpFormat(bool obfuscated,
         if (lb != -std::numeric_limits<double>::infinity()) {
           absl::StrAppend(&rhs_name, "_rhs");
         }
-        StrAppend(output, " ", rhs_name, ": ", line_breaker.GetOutput());
-        const std::string relation = StrCat(" <= ", DoubleToString(ub), "\n");
+        absl::StrAppend(output, " ", rhs_name, ": ", line_breaker.GetOutput());
+        const std::string relation = absl::StrCat(" <= ", DoubleToString(ub), "\n");
         // Here we have to make sure we do not add the relation to the contents
         // of line_breaker, which may be used in the subsequent clause.
         if (!line_breaker.WillFit(relation)) absl::StrAppend(output, "\n ");
@@ -325,8 +325,8 @@ bool MPModelProtoExporter::ExportModelAsLpFormat(bool obfuscated,
         if (ub != +std::numeric_limits<double>::infinity()) {
           absl::StrAppend(&lhs_name, "_lhs");
         }
-        StrAppend(output, " ", lhs_name, ": ", line_breaker.GetOutput());
-        const std::string relation = StrCat(" >= ", DoubleToString(lb), "\n");
+        absl::StrAppend(output, " ", lhs_name, ": ", line_breaker.GetOutput());
+        const std::string relation = absl::StrCat(" >= ", DoubleToString(lb), "\n");
         if (!line_breaker.WillFit(relation)) absl::StrAppend(output, "\n ");
         absl::StrAppend(output, relation);
       }

--- a/ortools/linear_solver/model_validator.cc
+++ b/ortools/linear_solver/model_validator.cc
@@ -171,13 +171,13 @@ std::string FindErrorInMPModelProto(const MPModelProto& model) {
       if (constraint.var_index_size() > kMaxNumVarsInPrintedConstraint) {
         constraint_light.mutable_var_index()->Truncate(
             kMaxNumVarsInPrintedConstraint);
-        StrAppend(&suffix_str, " (var_index cropped; size=",
+        absl::StrAppend(&suffix_str, " (var_index cropped; size=",
                   constraint.var_index_size(), ").");
       }
       if (constraint.coefficient_size() > kMaxNumVarsInPrintedConstraint) {
         constraint_light.mutable_coefficient()->Truncate(
             kMaxNumVarsInPrintedConstraint);
-        StrAppend(&suffix_str, " (coefficient cropped; size=",
+        absl::StrAppend(&suffix_str, " (coefficient cropped; size=",
                   constraint.coefficient_size(), ").");
       }
       return StrCat("In constraint #", i, ": ", error, ". Constraint proto: ",

--- a/ortools/linear_solver/model_validator.cc
+++ b/ortools/linear_solver/model_validator.cc
@@ -32,19 +32,19 @@ std::string FindErrorInMPVariable(const MPVariableProto& variable) {
       variable.lower_bound() == kInfinity ||
       variable.upper_bound() == -kInfinity ||
       variable.lower_bound() > variable.upper_bound()) {
-    return StrCat("Infeasible bounds: [",
+    return absl::StrCat("Infeasible bounds: [",
                   absl::LegacyPrecision(variable.lower_bound()), ", ",
                   absl::LegacyPrecision(variable.upper_bound()), "]");
   }
   if (variable.is_integer() &&
       ceil(variable.lower_bound()) > floor(variable.upper_bound())) {
-    return StrCat("Infeasible bounds for integer variable: [",
+    return absl::StrCat("Infeasible bounds for integer variable: [",
                   absl::LegacyPrecision(variable.lower_bound()), ", ",
                   absl::LegacyPrecision(variable.upper_bound()), "]",
                   " translate to the empty set");
   }
   if (!std::isfinite(variable.objective_coefficient())) {
-    return StrCat("Invalid objective_coefficient: ",
+    return absl::StrCat("Invalid objective_coefficient: ",
                   absl::LegacyPrecision(variable.objective_coefficient()));
   }
   return std::string();
@@ -60,7 +60,7 @@ std::string FindErrorInMPConstraint(const MPConstraintProto& constraint,
       constraint.lower_bound() == kInfinity ||
       constraint.upper_bound() == -kInfinity ||
       constraint.lower_bound() > constraint.upper_bound()) {
-    return StrCat("Infeasible bounds: [",
+    return absl::StrCat("Infeasible bounds: [",
                   absl::LegacyPrecision(constraint.lower_bound()), ", ",
                   absl::LegacyPrecision(constraint.upper_bound()), "]");
   }
@@ -72,17 +72,17 @@ std::string FindErrorInMPConstraint(const MPConstraintProto& constraint,
   const int num_vars_in_ct = constraint.var_index_size();
   const int num_coeffs_in_ct = constraint.coefficient_size();
   if (num_vars_in_ct != num_coeffs_in_ct) {
-    return StrCat("var_index_size() != coefficient_size() (", num_vars_in_ct,
+    return absl::StrCat("var_index_size() != coefficient_size() (", num_vars_in_ct,
                   " VS ", num_coeffs_in_ct);
   }
   for (int i = 0; i < num_vars_in_ct; ++i) {
     const int var_index = constraint.var_index(i);
     if (var_index >= num_vars_in_model || var_index < 0) {
-      return StrCat("var_index(", i, ")=", var_index, " is out of bounds");
+      return absl::StrCat("var_index(", i, ")=", var_index, " is out of bounds");
     }
     const double coeff = constraint.coefficient(i);
     if (!std::isfinite(coeff)) {
-      return StrCat("coefficient(", i, ")=", absl::LegacyPrecision(coeff),
+      return absl::StrCat("coefficient(", i, ")=", absl::LegacyPrecision(coeff),
                     " is invalid");
     }
   }
@@ -98,7 +98,7 @@ std::string FindErrorInMPConstraint(const MPConstraintProto& constraint,
     (*var_mask)[var_index] = false;
   }
   if (duplicate_var_index >= 0) {
-    return StrCat("var_index #", duplicate_var_index, " appears several times");
+    return absl::StrCat("var_index #", duplicate_var_index, " appears several times");
   }
 
   // We found no error, all is fine.
@@ -108,7 +108,7 @@ std::string FindErrorInMPConstraint(const MPConstraintProto& constraint,
 std::string FindErrorInSolutionHint(const PartialVariableAssignment& solution_hint,
                                int num_vars) {
   if (solution_hint.var_index_size() != solution_hint.var_value_size()) {
-    return StrCat("var_index_size() != var_value_size() [",
+    return absl::StrCat("var_index_size() != var_value_size() [",
                   solution_hint.var_index_size(), " VS ",
                   solution_hint.var_value_size());
   }
@@ -116,15 +116,15 @@ std::string FindErrorInSolutionHint(const PartialVariableAssignment& solution_hi
   for (int i = 0; i < solution_hint.var_index_size(); ++i) {
     const int var_index = solution_hint.var_index(i);
     if (var_index >= num_vars || var_index < 0) {
-      return StrCat("var_index(", i, ")=", var_index, " is invalid.",
+      return absl::StrCat("var_index(", i, ")=", var_index, " is invalid.",
                     " It must be in [0, ", num_vars, ")");
     }
     if (var_in_hint[var_index]) {
-      return StrCat("Duplicate var_index = ", var_index);
+      return absl::StrCat("Duplicate var_index = ", var_index);
     }
     var_in_hint[var_index] = true;
     if (!std::isfinite(solution_hint.var_value(i))) {
-      return StrCat("var_value(", i,
+      return absl::StrCat("var_value(", i,
                     ")=", absl::LegacyPrecision(solution_hint.var_value(i)),
                     " is not a finite number");
     }
@@ -142,7 +142,7 @@ std::string FindErrorInMPModelProto(const MPModelProto& model) {
   // accept models without variables and/or constraints.
 
   if (!std::isfinite(model.objective_offset())) {
-    return StrCat("Invalid objective_offset: ",
+    return absl::StrCat("Invalid objective_offset: ",
                   absl::LegacyPrecision(model.objective_offset()));
   }
   const int num_vars = model.variable_size();
@@ -153,7 +153,7 @@ std::string FindErrorInMPModelProto(const MPModelProto& model) {
   for (int i = 0; i < num_vars; ++i) {
     error = FindErrorInMPVariable(model.variable(i));
     if (!error.empty()) {
-      return StrCat("In variable #", i, ": ", error, ". Variable proto: ",
+      return absl::StrCat("In variable #", i, ": ", error, ". Variable proto: ",
                     ProtobufShortDebugString(model.variable(i)));
     }
   }
@@ -180,7 +180,7 @@ std::string FindErrorInMPModelProto(const MPModelProto& model) {
         absl::StrAppend(&suffix_str, " (coefficient cropped; size=",
                   constraint.coefficient_size(), ").");
       }
-      return StrCat("In constraint #", i, ": ", error, ". Constraint proto: ",
+      return absl::StrCat("In constraint #", i, ": ", error, ". Constraint proto: ",
                     ProtobufShortDebugString(constraint_light), suffix_str);
     }
   }
@@ -188,7 +188,7 @@ std::string FindErrorInMPModelProto(const MPModelProto& model) {
   // Validate the solution hint.
   error = FindErrorInSolutionHint(model.solution_hint(), num_vars);
   if (!error.empty()) {
-    return StrCat("In solution_hint(): ", error);
+    return absl::StrCat("In solution_hint(): ", error);
   }
 
   return std::string();
@@ -202,7 +202,7 @@ std::string FindFeasibilityErrorInSolutionHint(const MPModelProto& model,
 
   // First, we validate the solution hint.
   std::string error = FindErrorInSolutionHint(model.solution_hint(), num_vars);
-  if (!error.empty()) return StrCat("Invalid solution_hint: ", error);
+  if (!error.empty()) return absl::StrCat("Invalid solution_hint: ", error);
 
   // Special error message for the empty case.
   if (num_vars > 0 && model.solution_hint().var_index_size() == 0) {
@@ -211,7 +211,7 @@ std::string FindFeasibilityErrorInSolutionHint(const MPModelProto& model,
 
   // To be feasible, the hint must not be partial.
   if (model.solution_hint().var_index_size() != num_vars) {
-    return StrCat("Partial solution_hint: only ",
+    return absl::StrCat("Partial solution_hint: only ",
                   model.solution_hint().var_index_size(), " out of the ",
                   num_vars, " problem variables are set.");
   }
@@ -226,7 +226,7 @@ std::string FindFeasibilityErrorInSolutionHint(const MPModelProto& model,
     const double ub = model.variable(var_index).upper_bound();
     if (!IsSmallerWithinTolerance(value, ub, tolerance) ||
         !IsSmallerWithinTolerance(lb, value, tolerance)) {
-      return StrCat("Variable '", model.variable(var_index).name(),
+      return absl::StrCat("Variable '", model.variable(var_index).name(),
                     "' is set to ", absl::LegacyPrecision(value),
                     " which is not in the variable bounds [",
                     absl::LegacyPrecision(lb), ", ", absl::LegacyPrecision(ub),
@@ -247,7 +247,7 @@ std::string FindFeasibilityErrorInSolutionHint(const MPModelProto& model,
     const double ub = model.constraint(cst_index).upper_bound();
     if (!IsSmallerWithinTolerance(activity.Value(), ub, tolerance) ||
         !IsSmallerWithinTolerance(lb, activity.Value(), tolerance)) {
-      return StrCat("Constraint '", model.constraint(cst_index).name(),
+      return absl::StrCat("Constraint '", model.constraint(cst_index).name(),
                     "' has activity ", absl::LegacyPrecision(activity.Value()),
                     " which is not in the constraint bounds [",
                     absl::LegacyPrecision(lb), ", ", absl::LegacyPrecision(ub),

--- a/ortools/sat/cp_model_checker.cc
+++ b/ortools/sat/cp_model_checker.cc
@@ -282,7 +282,7 @@ std::string ValidateCpModel(const CpModelProto& model) {
   if (model.has_objective()) {
     for (const int v : model.objective().vars()) {
       if (!VariableReferenceIsValid(model, v)) {
-        return StrCat("Out of bound objective variable ", v, " : ",
+        return absl::StrCat("Out of bound objective variable ", v, " : ",
                       ProtobufShortDebugString(model.objective()));
       }
     }

--- a/ortools/sat/cp_model_search.cc
+++ b/ortools/sat/cp_model_search.cc
@@ -187,7 +187,7 @@ std::function<LiteralIndex()> InstrumentSearchStrategy(
     if (decision == kNoLiteralIndex) return decision;
 
     const int level = model->Get<Trail>()->CurrentDecisionLevel();
-    std::string to_display = StrCat("Diff since last call, level=", level, "\n");
+    std::string to_display = absl::StrCat("Diff since last call, level=", level, "\n");
     IntegerTrail* integer_trail = model->GetOrCreate<IntegerTrail>();
     for (const int ref : ref_to_display) {
       const IntegerVariable var = variable_mapping[ref];

--- a/ortools/sat/cp_model_search.cc
+++ b/ortools/sat/cp_model_search.cc
@@ -196,7 +196,7 @@ std::function<LiteralIndex()> InstrumentSearchStrategy(
           integer_trail->UpperBound(var).value());
       if (new_domain != old_domains[ref]) {
         old_domains[ref] = new_domain;
-        StrAppend(&to_display, cp_model_proto.variables(ref).name(), " [",
+        absl::StrAppend(&to_display, cp_model_proto.variables(ref).name(), " [",
                   new_domain.first, ",", new_domain.second, "]\n");
       }
     }

--- a/ortools/sat/cp_model_solver.cc
+++ b/ortools/sat/cp_model_solver.cc
@@ -1394,7 +1394,7 @@ void LoadInverseConstraint(const ConstraintProto& ct, ModelWithMapping* m) {
 std::string Summarize(const std::string& input) {
   if (input.size() < 105) return input;
   const int half = 50;
-  return StrCat(input.substr(0, half), " ... ",
+  return absl::StrCat(input.substr(0, half), " ... ",
                 input.substr(input.size() - half, half));
 }
 

--- a/ortools/sat/linear_programming_constraint.h
+++ b/ortools/sat/linear_programming_constraint.h
@@ -42,11 +42,11 @@ struct LinearConstraint {
   std::string DebugString() const {
     std::string result;
     const double kInfinity = std::numeric_limits<double>::infinity();
-    if (lb != -kInfinity) StrAppend(&result, lb, " <= ");
+    if (lb != -kInfinity) absl::StrAppend(&result, lb, " <= ");
     for (int i = 0; i < vars.size(); ++i) {
-      StrAppend(&result, coeffs[i], "*[", vars[i].value(), "] ");
+      absl::StrAppend(&result, coeffs[i], "*[", vars[i].value(), "] ");
     }
-    if (ub != kInfinity) StrAppend(&result, "<= ", ub);
+    if (ub != kInfinity) absl::StrAppend(&result, "<= ", ub);
     return result;
   }
 };

--- a/ortools/util/xml_helper.cc
+++ b/ortools/util/xml_helper.cc
@@ -40,7 +40,7 @@ void XmlHelper::StartElement(const std::string& name) {
 }
 
 void XmlHelper::AddAttribute(const std::string& key, int value) {
-  AddAttribute(key, StrCat(value));
+  AddAttribute(key, absl::StrCat(value));
 }
 
 void XmlHelper::AddAttribute(const std::string& key, const std::string& value) {


### PR DESCRIPTION
backport "update C++ examples after changes in base library" (023bc1933404ba0e942d956e94d6d9eee13ff95e) but split it in atomic patchs and finish the job (StrAppend and StrCat not in `absl` namespace)

-> need to forward port fixup