### PR TITLE
Create nuget package (without native libs)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,6 @@ include $(OR_ROOT)makefiles/Makefile.cpp.mk
 include $(OR_ROOT)makefiles/Makefile.python.mk
 include $(OR_ROOT)makefiles/Makefile.java.mk
 include $(OR_ROOT)makefiles/Makefile.dotnet.mk
-# include $(OR_ROOT)makefiles/Makefile.csharp.mk
-# include $(OR_ROOT)makefiles/Makefile.fsharp.mk
 include $(OR_ROOT)makefiles/Makefile.archive.mk
 include $(OR_ROOT)makefiles/Makefile.install.mk
 

--- a/makefiles/Makefile.dotnet.mk
+++ b/makefiles/Makefile.dotnet.mk
@@ -368,9 +368,6 @@ dotnet: ortoolslibs csharp_dotnet fsharp_dotnet
 	$(SED) -i -e "s/<FileVersion>.*<\/FileVersion>/<FileVersion>$(OR_TOOLS_VERSION)<\/FileVersion>/" ortools$Sdotnet$S$(ORTOOLS_FSHARP_DLL_NAME)$S$(ORTOOLS_FSHARP_DLL_NAME).fsproj
 	"$(DOTNET_EXECUTABLE)" build -c Release -o $(BIN_DIR) ortools$Sdotnet$S$(ORTOOLS_DLL_NAME)$S$(ORTOOLS_DLL_NAME).csproj
 	"$(DOTNET_EXECUTABLE)" build -c Release -o $(BIN_DIR) ortools$Sdotnet$S$(ORTOOLS_FSHARP_DLL_NAME)$S$(ORTOOLS_FSHARP_DLL_NAME).fsproj
-	$(MKDIR_P) $(TEMP_DOTNET_DIR)
-	"$(DOTNET_EXECUTABLE)" publish -c Release -o "..$S..$S..$S$(TEMP_DOTNET_DIR)" -f netstandard2.0 ortools$Sdotnet$S$(ORTOOLS_DLL_NAME)$S$(ORTOOLS_DLL_NAME).csproj
-	"$(DOTNET_EXECUTABLE)" publish -c Release -o "..$S..$S..$S$(TEMP_DOTNET_DIR)" -f netstandard2.0 ortools$Sdotnet$S$(ORTOOLS_FSHARP_DLL_NAME)$S$(ORTOOLS_FSHARP_DLL_NAME).fsproj
 
 BUILT_LANGUAGES +=, dotnet \(netstandard2.0\)
 
@@ -385,7 +382,12 @@ NUGET_SRC = https://www.nuget.org/api/v2/package
 
 .PHONY: pkg_dotnet # Build Nuget Package
 pkg_dotnet:
-	$(warning Not Implemented)
+	$(MKDIR_P) $(TEMP_DOTNET_DIR)
+	"$(DOTNET_EXECUTABLE)" publish -c Release --no-dependencies --no-restore -o "..$S..$S..$S$(TEMP_DOTNET_DIR)" -f netstandard2.0 ortools$Sdotnet$S$(ORTOOLS_DLL_NAME)$S$(ORTOOLS_DLL_NAME).csproj
+	"$(DOTNET_EXECUTABLE)" publish -c Release --no-dependencies --no-restore -o "..$S..$S..$S$(TEMP_DOTNET_DIR)" -f netstandard2.0 ortools$Sdotnet$S$(ORTOOLS_FSHARP_DLL_NAME)$S$(ORTOOLS_FSHARP_DLL_NAME).fsproj
+	$(SED) -i -e "s/MMMM/$(CLR_ORTOOLS_DLL_NAME)/" ortools$Sdotnet$S$(ORTOOLS_NUSPEC_FILE)
+	$(SED) -i -e "s/VVVV/$(OR_TOOLS_VERSION)/" ortools$Sdotnet$S$(ORTOOLS_NUSPEC_FILE)
+	$(NUGET_EXECUTABLE) pack ortools$Sdotnet$S$(ORTOOLS_NUSPEC_FILE)
 
 .PHONY: pkg_dotnet-upload # Upload Nuget Package
 pkg_dotnet-upload: nuget_archive

--- a/ortools/dotnet/OrTools.nuspec
+++ b/ortools/dotnet/OrTools.nuspec
@@ -9,12 +9,14 @@
     <description>.NET wrapper for the Operations Research Tools project</description>
     <copyright>Copyright 2018 Google, Inc</copyright>
     <tags>Operations Research Math Linear Constraint Programming C# F# .NETStandard</tags>
+    <references>
+      <reference file="Google.OrTools.dll" />
+      <reference file="Google.OrTools.FSharp.dll" />
+    </references>
   </metadata>
   <files>
-    <file src="../../lib/*.*" target="lib/netstandard2.0"/>
-    <file src="../../bin/Google.Protobuf.dll" target="lib/netstandard2.0"/>
-    <file src="OrTools/bin/Release/netstandard2.0/*.*" target="lib/netstandard2.0"/>
-    <file src="OrTools.FSharp/bin/Release/netstandard2.0/Google.OrTools.FSharp.*" target="lib/netstandard2.0"/>
+    <file src="../../examples/dotnet/**" target="examples" exclude="**/obj/**;**/bin/**"/>
+    <file src="../../temp_dotnet/**" target="lib"/>
     <file src="../../LICENSE-2.0.txt"/>
   </files>
 </package>


### PR DESCRIPTION
@Mizux I am unsure how you plan to package the native libraries for each operating system. This target will create the package for dotnet only. Once the native library installation is decided we can add it as a dependency to this package.