### PR TITLE
Adding binder links for exploring notebooks in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Status](https://travis-ci.org/google/or-tools.svg?branch=master)](https://travis
 [![Build status](https://ci.appveyor.com/api/projects/status/9hyykkcm8sh3ua6x?svg=true)](https://ci.appveyor.com/project/lperron/or-tools-98u1n)
 [![PyPI version](https://badge.fury.io/py/ortools.svg)](https://badge.fury.io/py/ortools)
 [![NuGet version](https://badge.fury.io/nu/Google.OrTools.svg)](https://badge.fury.io/nu/Google.OrTools)
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/google/or-tools/master)
 
 Google's software suite for combinatorial optimization.
 

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,0 +1,2 @@
+ortools
+matplotlib


### PR DESCRIPTION
A simple badge to let users run the or-tools python package easily in binder
To start jupyter
https://mybinder.org/v2/gh/kmader/or-tools/patch-1
To start a specific notebook
https://mybinder.org/v2/gh/kmader/or-tools/patch-1?filepath=examples%2Fnotebook%2Fgate_scheduling_sat.ipynb
