### PR TITLE
Make DecisionVisitor a director type in Java bindings

### DIFF
--- a/ortools/constraint_solver/java/constraint_solver.i
+++ b/ortools/constraint_solver/java/constraint_solver.i
@@ -113,6 +113,7 @@ import com.google.ortools.constraintsolver.SearchLimitParameters;
 
 %feature("director") operations_research::DecisionBuilder;
 %feature("director") operations_research::Decision;
+%feature("director") operations_research::DecisionVisitor;
 %feature("director") operations_research::SearchMonitor;
 %feature("director") operations_research::SymmetryBreaker;
 


### PR DESCRIPTION
This allows inspecting Decision objects from SearchMonitor callbacks in Java.