### PR TITLE
Build Java libraries on macOS with Java 8 to improve compatibility.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,27 +31,27 @@ matrix:
       env: BUILDER=make DISTRO=native LANGUAGE=dotnet
 
     - os: osx
-      osx_image: xode9.4
+      osx_image: xcode9.4
       language: cpp
       compiler: clang
       env: BUILDER=make DISTRO=native LANGUAGE=cc
     - os: osx
-      osx_image: xode9.4
+      osx_image: xcode9.4
       language: cpp
       compiler: clang
       env: BUILDER=make DISTRO=native LANGUAGE=python2
     - os: osx
-      osx_image: xode9.4
+      osx_image: xcode9.4
       language: cpp
       compiler: clang
       env: BUILDER=make DISTRO=native LANGUAGE=python3
     - os: osx
-      osx_image: xode9.4
+      osx_image: xcode9.4
       language: cpp
       compiler: clang
       env: BUILDER=make DISTRO=native LANGUAGE=java
     - os: osx
-      osx_image: xode9.4
+      osx_image: xcode9.4
       language: cpp
       compiler: clang
       env: BUILDER=make DISTRO=native LANGUAGE=dotnet
@@ -68,25 +68,28 @@ matrix:
       env: BUILDER=cmake DISTRO=native
 
     - os: osx
-      osx_image: xode9.4
+      osx_image: xcode9.4
       language: cpp
       compiler: gcc
       env: BUILDER=cmake DISTRO=native
     - os: osx
-      osx_image: xode9.4
+      osx_image: xcode9.4
       language: cpp
       compiler: clang
       env: BUILDER=cmake DISTRO=native
 # Jobs too long
   allow_failures:
     - os: osx
-      osx_image: xode9.4
+      osx_image: xcode9.4
       language: cpp
       compiler: clang
       env: BUILDER=make DISTRO=native LANGUAGE=dotnet
 
 install:
   - ./.travis/install.sh
+
+before_script:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export JAVA_HOME=`/usr/libexec/java_home -v 1.8`; fi
 
 script:
   - ./.travis/script.sh

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -76,7 +76,8 @@ if [ "${BUILDER}" == make ]; then
 				brew upgrade python;
 				python3 -m pip install -q virtualenv wheel six;
 			elif [ "${LANGUAGE}" == java ]; then
-				brew cask install java;
+				brew tap caskroom/versions;
+				brew cask install java8;
 			elif [ "${LANGUAGE}" == dotnet ]; then
 				#brew install mono;
 				# Installer changes path but won't be picked up in current terminal session


### PR DESCRIPTION
The default "latest" JDK version coming from Homebrew is a moving target, and is presently using JDK 10.  The world at large is going to be at Java 8 for some time with early adopters leaping to 11.  So instead of grabbing the arbitrary latest version, pin at Java 8 to maximize compatiblity.  This should really be transitioned to a multi-release JAR, see #856, but for now align with the rest of or-tools build policies.