### PR TITLE
Add Constraint return value to methods that were documented to return it

### DIFF
--- a/ortools/sat/python/cp_model.py
+++ b/ortools/sat/python/cp_model.py
@@ -705,6 +705,7 @@ class CpModel(object):
       for v in t:
         cp_model_helper.AssertIsInt64(v)
       model_ct.table.values.extend(t)
+    return ct
 
   def AddForbiddenAssignments(self, variables, tuples_list):
     """Adds AddForbiddenAssignments(variables, [tuples_list]).
@@ -732,8 +733,9 @@ class CpModel(object):
                        'array')
 
     index = len(self.__model.constraints)
-    self.AddAllowedAssignments(variables, tuples_list)
+    ct = self.AddAllowedAssignments(variables, tuples_list)
     self.__model.constraints[index].table.negated = True
+    return ct
 
   def AddAutomaton(self, transition_variables, starting_state, final_states,
                    transition_triples):
@@ -804,6 +806,7 @@ class CpModel(object):
       model_ct.automata.transition_tail.append(t[0])
       model_ct.automata.transition_label.append(t[1])
       model_ct.automata.transition_head.append(t[2])
+    return ct
 
   def AddInverse(self, variables, inverse_variables):
     """Adds Inverse(variables, inverse_variables).


### PR DESCRIPTION
Added "return ct" to three methods.  Ran python tests, but many of them don't use cp_model yet.

