### PR TITLE
Adding PWLSolver to the linear solvers

### DIFF
--- a/examples/cpp/mip_example_with_sos_constraint.cc
+++ b/examples/cpp/mip_example_with_sos_constraint.cc
@@ -1,0 +1,99 @@
+// Copyright 2010-2018 Google LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Integer programming example that shows how to use the API.
+
+#include "ortools/base/logging.h"
+#include "ortools/linear_solver/linear_solver.h"
+
+namespace operations_research {
+void RunMixedIntegerProgrammingExample(
+    MPSolver::OptimizationProblemType optimization_problem_type) {
+  MPSolver solver("MixedIntegerProgrammingExample", optimization_problem_type);
+  const double infinity = solver.infinity();
+  // x and y are integer non-negative variables.
+  MPVariable* const x = solver.MakeIntVar(0.0, infinity, "x");
+  MPVariable* const y = solver.MakeIntVar(0.0, infinity, "y");
+
+  // Maximize x + 10 * y.
+  MPObjective* const objective = solver.MutableObjective();
+  objective->SetCoefficient(x, 1);
+  objective->SetCoefficient(y, 10);
+  objective->SetMaximization();
+
+  // x + 7 * y <= 17.5.
+  MPConstraint* const c0 = solver.MakeRowConstraint(-infinity, 17.5);
+  c0->SetCoefficient(x, 1);
+  c0->SetCoefficient(y, 7);
+
+  // x <= 3.5
+  MPConstraint* const c1 = solver.MakeRowConstraint(-infinity, 3.5);
+  c1->SetCoefficient(x, 1);
+  c1->SetCoefficient(y, 0);
+
+  SOSConstraint* const c2 = solver.MakeSOSConstraint(MPSolver::SOS1);
+  c2->SetCoefficient(x, 1);
+  c2->SetCoefficient(y, 1);
+
+  LOG(INFO) << "Number of variables = " << solver.NumVariables();
+  LOG(INFO) << "Number of constraints = " << solver.NumConstraints();
+  LOG(INFO) << "Number of SOS constraints = " << solver.NumSOSConstraints();
+
+  const MPSolver::ResultStatus result_status = solver.Solve();
+  // Check that the problem has an optimal solution.
+  if (result_status != MPSolver::OPTIMAL) {
+    LOG(FATAL) << "The problem does not have an optimal solution!";
+  }
+  LOG(INFO) << "Solution:";
+  LOG(INFO) << "x = " << x->solution_value();
+  LOG(INFO) << "y = " << y->solution_value();
+  LOG(INFO) << "Optimal objective value = " << objective->Value();
+  LOG(INFO) << "";
+  LOG(INFO) << "Advanced usage:";
+  LOG(INFO) << "Problem solved in " << solver.wall_time() << " milliseconds";
+  LOG(INFO) << "Problem solved in " << solver.iterations() << " iterations";
+  LOG(INFO) << "Problem solved in " << solver.nodes()
+            << " branch-and-bound nodes";
+}
+
+void RunAllExamples() {
+#if defined(USE_CBC)
+  LOG(INFO) << "---- Mixed integer programming example with CBC ----";
+  RunMixedIntegerProgrammingExample(MPSolver::CBC_MIXED_INTEGER_PROGRAMMING);
+#endif
+#if defined(USE_GLPK)
+  LOG(INFO) << "---- Mixed integer programming example with GLPK ----";
+  RunMixedIntegerProgrammingExample(MPSolver::GLPK_MIXED_INTEGER_PROGRAMMING);
+#endif
+#if defined(USE_SCIP)
+  LOG(INFO) << "---- Mixed integer programming example with SCIP ----";
+  RunMixedIntegerProgrammingExample(MPSolver::SCIP_MIXED_INTEGER_PROGRAMMING);
+#endif
+#if defined(USE_GUROBI)
+  LOG(INFO) << "---- Mixed integer programming example with Gurobi ----";
+  RunMixedIntegerProgrammingExample(MPSolver::GUROBI_MIXED_INTEGER_PROGRAMMING);
+#endif  // USE_GUROBI
+#if defined(USE_CPLEX)
+  LOG(INFO) << "---- Mixed integer programming example with CPLEX ----";
+  RunMixedIntegerProgrammingExample(MPSolver::CPLEX_MIXED_INTEGER_PROGRAMMING);
+#endif  // USE_CPLEX
+}
+}  // namespace operations_research
+
+int main(int argc, char** argv) {
+  google::InitGoogleLogging(argv[0]);
+  FLAGS_logtostderr = 1;
+  //operations_research::RunAllExamples();
+  RunMixedIntegerProgrammingExample(operations_research::MPSolver::GUROBI_MIXED_INTEGER_PROGRAMMING);
+  return EXIT_SUCCESS;
+}

--- a/examples/cpp/pwl_mip_solver_example.cc
+++ b/examples/cpp/pwl_mip_solver_example.cc
@@ -1,0 +1,110 @@
+// Copyright 2010-2018 Google LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Integer programming example that shows how to use the API.
+
+#include "ortools/base/logging.h"
+#include "ortools/linear_solver/linear_solver.h"
+
+namespace operations_research {
+void RunPwlMipExample(
+    PWLSolver::OptimizationSuite optimization_suite) {
+  PWLSolver solver("PieceWiseLinearMixedIntegerProgrammingExample", optimization_suite);
+
+  PWLSolver::MatrixOfDoubles x = { { 1.0, 2.0, 4.0 } };
+  PWLSolver::VectorOfDoubles y = { 1.0, 1.5, 2.0 };
+  PWLSolver::MatrixOfDoubles A = { { 2.0 }, { 1.0 } };
+  PWLSolver::MatrixOfDoubles B = { { -1.0, 2.8 }, { 2.8, 1.0 } };
+  PWLSolver::VectorOfDoubles b = { 1.0, 2.0 };
+  PWLSolver::VectorOfDoubles c = {  0.5  };
+  PWLSolver::VectorOfDoubles d =  { 10.8, 13.8 };
+
+  solver.SetXValues(x);
+  solver.SetYValues(y);
+  solver.SetParameter(b, PWLSolver::VectorParameterType::bVector);
+  solver.SetParameter(c, PWLSolver::VectorParameterType::cVector);
+  solver.SetParameter(d, PWLSolver::VectorParameterType::dVector);
+  solver.SetParameter(A, PWLSolver::MatrixParameterType::AMatrix);
+  solver.SetParameter(B, PWLSolver::MatrixParameterType::BMatrix);
+
+
+  LOG(INFO) << "Number of points = " << solver.numb_of_x_points();
+  LOG(INFO) << "Dimension of a point = " << solver.dim_of_x_point();
+  LOG(INFO) << "Number of variables = " << solver.numb_of_vars();
+  LOG(INFO) << "Number of constraints = " << solver.numb_of_constr();
+  LOG(INFO) << "Number of continuous variables = " << solver.numb_of_real_vars();
+
+  const MPSolver::ResultStatus result_status = solver.Solve();
+  // Check that the problem has an optimal solution.
+  if (result_status != MPSolver::OPTIMAL) {
+    LOG(FATAL) << "The problem does not have an optimal solution!";
+  }
+  
+  auto & vars = solver.variables();
+  
+  auto lambda_1 = vars[0];
+  auto lambda_2 = vars[1];
+  auto lambda_3 = vars[2];
+  
+  auto z_1 = vars[3];
+  auto z_2 = vars[4];
+  
+
+  LOG(INFO) << "Solution:";
+
+  LOG(INFO) << "lambda_1 = " << lambda_1->solution_value();
+  LOG(INFO) << "lambda_2 = " << lambda_2->solution_value();
+  LOG(INFO) << "lambda_3 = " << lambda_3->solution_value();
+
+  LOG(INFO) << "z_1 = " << z_1->solution_value();
+  LOG(INFO) << "z_2 = " << z_2->solution_value();
+
+  LOG(INFO) << "Optimal objective value = " << solver.objective()->Value();
+  LOG(INFO) << "";
+  LOG(INFO) << "Advanced usage:";
+  LOG(INFO) << "Problem solved in " << solver.wall_time() << " milliseconds";
+  LOG(INFO) << "Problem solved in " << solver.nodes()
+            << " branch-and-bound nodes";
+}
+
+void RunAllExamples() {
+#if defined(USE_CBC)
+  LOG(INFO) << "---- Integer programming example with CBC ----";
+  RunPwlMipExample(PWLSolver::CBC);
+#endif
+#if defined(USE_GLPK)
+  LOG(INFO) << "---- Integer programming example with GLPK ----";
+  RunPwlMipExample(PWLSolver::GLPK);
+#endif
+#if defined(USE_SCIP)
+  LOG(INFO) << "---- Integer programming example with SCIP ----";
+  RunPwlMipExample(PWLSolver::SCIP);
+#endif
+#if defined(USE_GUROBI)
+  LOG(INFO) << "---- Integer programming example with Gurobi ----";
+  RunPwlMipExample(PWLSolver::GUROBI);
+#endif  // USE_GUROBI
+#if defined(USE_CPLEX)
+  LOG(INFO) << "---- Integer programming example with CPLEX ----";
+  RunPwlMipExample(PWLSolver::CPLEX);
+#endif  // USE_CPLEX
+}
+}  // namespace operations_research
+
+int main(int argc, char** argv) {
+  google::InitGoogleLogging(argv[0]);
+  FLAGS_logtostderr = 1;
+  //operations_research::RunAllExamples();
+  RunPwlMipExample(operations_research::PWLSolver::GUROBI);
+  return EXIT_SUCCESS;
+}

--- a/examples/python/pwl_func_mip_solver.py
+++ b/examples/python/pwl_func_mip_solver.py
@@ -1,0 +1,52 @@
+from __future__ import print_function
+from ortools.linear_solver import pywraplp
+solver = pywraplp.PwlSolver('Test', pywraplp.PwlSolver.GUROBI)
+
+x = [ [ 1.0, 2.0, 4.0 ] ]
+y = [ 1.0, 1.5, 2.0 ]
+A = [ [ 2.0 ], [ 1.0 ] ]
+B = [ [ -1.0, 2.8 ], [ 2.8, 1.0 ] ]
+b = [ 1.0, 2.0 ]
+c = [ 0.5 ]
+d = [ 10.8, 13.8 ]
+
+solver.SetXValues(x)
+solver.SetYValues(y)
+solver.SetParameter(b, pywraplp.PwlSolver.bVector)
+solver.SetParameter(c, pywraplp.PwlSolver.cVector)
+solver.SetParameter(d, pywraplp.PwlSolver.dVector)
+solver.SetParameter(A, pywraplp.PwlSolver.AMatrix)
+solver.SetParameter(B, pywraplp.PwlSolver.BMatrix)
+
+print("Number of discrete points = {0}".format(solver.NumOfXPoints()))
+
+print("Total number of variables (integer and continuous) = {0}".format(solver.NumVariables()))
+
+print("Total number of continuous variables = {0}".format(solver.NumRealVariables()))
+
+result_status = solver.Solve()
+
+assert result_status == pywraplp.Solver.OPTIMAL
+
+assert solver.VerifySolution(1e-7, True)
+
+objective = solver.Objective()
+
+print("The objective value is equal to {0}".format(objective.Value()))
+
+var1 = solver.GetVariable(0)
+print("The solution for lambda_1 = {0}".format(var1.solution_value()))
+
+var2 = solver.GetVariable(1)
+print("The solution for lambda_2 = {0}".format(var2.solution_value()))
+
+var3 = solver.GetVariable(2)
+print("The solution for lambda_3 = {0}".format(var3.solution_value()))
+
+var4 = solver.GetVariable(3)
+print("The solution for z_1 = {0}".format(var4.solution_value()))
+
+var5 = solver.GetVariable(4)
+print("The solution for z_2 = {0}".format(var5.solution_value()))
+
+

--- a/makefiles/Makefile.python.mk
+++ b/makefiles/Makefile.python.mk
@@ -34,6 +34,7 @@ PYTHON3 := true
 SWIG_PYTHON3_FLAG := -py3 -DPY3
 PYTHON3_CFLAGS := -DPY3
 endif
+PYTHON_DEBUG := -DNDEBUG
 endif
 
 .PHONY: python # Build Python OR-Tools.
@@ -268,7 +269,7 @@ $(GEN_DIR)/ortools/linear_solver/pywraplp.py: \
 		$(SRC_DIR)/ortools/linear_solver/linear_solver.h \
 		$(GEN_DIR)/ortools/linear_solver/linear_solver.pb.h \
 		$(GEN_DIR)/ortools/linear_solver/linear_solver_pb2.py
-	$(SWIG_BINARY) $(SWIG_INC) -I$(INC_DIR) -c++ -python $(SWIG_PYTHON3_FLAG) -o $(GEN_DIR)$Sortools$Slinear_solver$Slinear_solver_python_wrap.cc -module pywraplp $(SRC_DIR)/ortools/linear_solver$Spython$Slinear_solver.i
+	$(SWIG_BINARY) $(SWIG_INC) -I$(INC_DIR) $(PYTHON_DEBUG) -c++ -python $(SWIG_PYTHON3_FLAG) -o $(GEN_DIR)$Sortools$Slinear_solver$Slinear_solver_python_wrap.cc -module pywraplp $(SRC_DIR)/ortools/linear_solver$Spython$Slinear_solver.i
 
 $(GEN_DIR)/ortools/linear_solver/linear_solver_python_wrap.cc: $(GEN_DIR)/ortools/linear_solver/pywraplp.py
 
@@ -493,6 +494,7 @@ endif
 	@echo PYTHON_INC = $(PYTHON_INC)
 	@echo PYTHON_LNK = $(PYTHON_LNK)
 	@echo SWIG_PYTHON3_FLAG = $(SWIG_PYTHON3_FLAG)
+	@echo PYTHON_DEBUG = $(PYTHON_DEBUG)
 ifeq ($(SYSTEM),win)
 	@echo off & echo(
 else

--- a/ortools/base/macros.h
+++ b/ortools/base/macros.h
@@ -36,6 +36,10 @@ const bool DEBUG_MODE = true;
   TypeName(const TypeName&);               \
   void operator=(const TypeName&)
 
+#define DISALLOW_NO_ARGS_CTOR(TypeName) \
+  private: \
+    TypeName();
+
 // The FALLTHROUGH_INTENDED macro can be used to annotate implicit fall-through
 // between switch labels.
 #ifndef FALLTHROUGH_INTENDED

--- a/ortools/base/optimization_suites.h
+++ b/ortools/base/optimization_suites.h
@@ -1,0 +1,8 @@
+#ifndef OR_TOOLS_BASE_OPTIMIZATION_SUITES_H_
+#define OR_TOOLS_BASE_OPTIMIZATION_SUITES_H_
+
+#if defined(USE_GUROBI) || defined(USE_SCIP) || defined(USE_GLPK) || defined(USE_CBC) || defined(USE_CPLEX)
+#define MIP_SOLVER_WITH_SOS_CONSTRAINTS   
+#endif
+
+#endif

--- a/ortools/linear_solver/cbc_interface.cc
+++ b/ortools/linear_solver/cbc_interface.cc
@@ -74,6 +74,10 @@ class CBCInterface : public MPSolverInterface {
 
   // Add constraint incrementally.
   void AddRowConstraint(MPConstraint* const ct) override;
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS
+  // Add SOS Constraint incrementally
+  void AddSOSConstraint(SOSConstraint* const ct) override;
+#endif
   // Add variable incrementally.
   void AddVariable(MPVariable* const var) override;
   // Change a coefficient in a constraint.
@@ -230,6 +234,13 @@ void CBCInterface::SetConstraintBounds(int index, double lb, double ub) {
 void CBCInterface::AddRowConstraint(MPConstraint* const ct) {
   sync_status_ = MUST_RELOAD;
 }
+
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS
+//TO DO (dimitarpg13): SOS constraints need to be implemented
+void CBCInterface::AddSOSConstraint(SOSConstraint* const ct) {
+   sync_status_ = MUST_RELOAD;
+}
+#endif
 
 void CBCInterface::AddVariable(MPVariable* const var) {
   sync_status_ = MUST_RELOAD;

--- a/ortools/linear_solver/cplex_interface.cc
+++ b/ortools/linear_solver/cplex_interface.cc
@@ -79,6 +79,9 @@ namespace operations_research {
       virtual void SetConstraintBounds(int row_index, double lb, double ub);
 
       virtual void AddRowConstraint(MPConstraint* const ct);
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS
+  virtual void AddSOSConstraint(SOSConstraint* const ct);
+#endif
       virtual void AddVariable(MPVariable* const var);
       virtual void SetCoefficient(MPConstraint* const constraint,
                                   MPVariable const* const variable,
@@ -477,6 +480,13 @@ namespace operations_research {
       // ExtractNewConstraints() right before the solve.
       InvalidateModelSynchronization();
    }
+
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS
+   // TO DO (dimitarpg13): SOS constraints need to be implemented
+   void CplexInterface::AddSOSConstraint(SOSConstraint* ct) {
+       InvalidateModelSynchronization();
+   }
+#endif
 
    void CplexInterface::AddVariable(MPVariable* const ct)
    {

--- a/ortools/linear_solver/glpk_interface.cc
+++ b/ortools/linear_solver/glpk_interface.cc
@@ -116,6 +116,10 @@ class GLPKInterface : public MPSolverInterface {
 
   // Add Constraint incrementally.
   void AddRowConstraint(MPConstraint* const ct) override;
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS
+  // Add SOS Constraint incrementally
+  void AddSOSConstraint(SOSConstraint* const ct) override;
+#endif
   // Add variable incrementally.
   void AddVariable(MPVariable* const var) override;
   // Change a coefficient in a constraint.
@@ -373,6 +377,13 @@ void GLPKInterface::ClearObjective() {
 void GLPKInterface::AddRowConstraint(MPConstraint* const ct) {
   sync_status_ = MUST_RELOAD;
 }
+
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS
+//TO DO (dimitarpg13): implement SOS constraint here
+void GLPKInterface::AddSOSConstraint(SOSConstraint* const ct) {
+  sync_status_ = MUST_RELOAD;
+}
+#endif
 
 void GLPKInterface::AddVariable(MPVariable* const var) {
   sync_status_ = MUST_RELOAD;

--- a/ortools/linear_solver/linear_solver.cc
+++ b/ortools/linear_solver/linear_solver.cc
@@ -44,6 +44,7 @@
 #include "ortools/linear_solver/model_validator.h"
 #include "ortools/util/fp_utils.h"
 #include "ortools/base/canonical_errors.h"
+#include "gurobi_c.h"
 
 DEFINE_bool(verify_solution, false,
             "Systematically verify the solution when calling Solve()"
@@ -147,6 +148,67 @@ bool MPConstraint::ContainsNewVariables() {
   }
   return false;
 }
+
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS
+// ----- SOSConstraint ----
+
+void SOSConstraint::Clear() {
+  // TO DO (dimitarpg13): implement it
+  interface_->ClearSOSConstraint(this);
+  coefficients_.clear();
+}
+
+void SOSConstraint::SetCoefficient(const MPVariable* const var, double coeff) {
+  // TO DO (dimitarpg13): implement it
+  DLOG_IF(DFATAL, !interface_->solver_->OwnsVariable(var)) << var;
+  if (var == nullptr) return;
+  if (coeff == 0.0) {
+    auto it = coefficients_.find(var);
+    // If setting a coefficient to 0 when this coefficient did not
+    // exist or was already 0, do nothing: skip
+    // interface_->SetCoefficient() and do not store a coefficient in
+    // the map.  Note that if the coefficient being set to 0 did exist
+    // and was not 0, we do have to keep a 0 in the coefficients_ map,
+    // because the extraction of the constraint might rely on it,
+    // depending on the underlying solver.
+    if (it != coefficients_.end() && it->second != 0.0) {
+      const double old_value = it->second;
+      it->second = 0.0;
+      interface_->SetCoefficient(this, var, 0.0, old_value);
+    }
+    return;
+  }
+  auto insertion_result = coefficients_.insert(std::make_pair(var, coeff));
+  if (insertion_result.second) {
+     ind_.push_back(var->index()); 
+     weight_.push_back(coeff);
+  }
+  else {
+     auto it = std::find(std::begin(ind_), std::end(ind_), var->index());
+     if (it != ind_.end()) {
+        auto idx = std::distance(std::begin(ind_), it);
+        weight_[idx] = coeff;
+     } else {
+        std::string err_msg = "SOS constraint internal inconsistency";
+        LOG(DFATAL) << "Error: could not create environment: " << err_msg;
+        throw std::runtime_error(err_msg);        
+     }
+  }
+  const double old_value =
+      insertion_result.second ? 0.0 : insertion_result.first->second;
+  insertion_result.first->second = coeff;
+  interface_->SetCoefficient(this, var, coeff, old_value);
+}
+
+double SOSConstraint::GetCoefficient(const MPVariable* const var) const {
+  // TO DO (dimitarpg13): implement it
+  DLOG_IF(DFATAL, !interface_->solver_->OwnsVariable(var)) << var;
+  if (var == nullptr) return 0.0;
+  return gtl::FindWithDefault(coefficients_, var, 0.0);
+}
+
+#endif // MIP_SOLVER_WITH_SOS_CONSTRAINTS
+
 
 // ----- MPObjective -----
 
@@ -521,6 +583,21 @@ void MPSolver::SetIndexConstraints(bool enabled) {
 #endif  // _MSC_VER
                                 nullptr;
   constraint_name_to_index_.reset(new_map);
+
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS
+  auto* const new_sos_map = enabled ?
+#ifdef _MSC_VER
+
+                                new std::unordered_map<std::string, int>()
+                                :
+#else   // _MSC_VER
+                                new std::unordered_map<std::string, int>(1)
+                                :
+#endif  // _MSC_VER
+                                nullptr;
+  sos_constraint_name_to_index_.reset(new_sos_map);
+#endif
+
 }
 
 MPConstraint* MPSolver::LookupConstraintOrNull(const std::string& constraint_name)
@@ -533,6 +610,19 @@ MPConstraint* MPSolver::LookupConstraintOrNull(const std::string& constraint_nam
   return constraints_[it->second];
 }
 
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS
+
+SOSConstraint* MPSolver::LookupSOSConstraintOrNull(
+    const std::string& sos_constraint_name) const {
+  if (!sos_constraint_name_to_index_) {
+     return nullptr;
+  }
+  const auto it = sos_constraint_name_to_index_->find(sos_constraint_name);
+  if (it == sos_constraint_name_to_index_->end()) return nullptr;
+  return sos_constraints_[it->second];
+}
+
+#endif
 // ----- Methods using protocol buffers -----
 
 MPSolverResponseStatus MPSolver::LoadModelFromProto(
@@ -600,6 +690,11 @@ MPSolverResponseStatus MPSolver::LoadModelFromProtoInternal(
                          ct_proto.coefficient(j));
     }
   }
+  
+  //TO DO (dimitarpg13): load sos constraints from model here
+  //
+  //
+
   objective->SetOptimizationDirection(input_model.maximize());
   if (input_model.has_objective_offset()) {
     objective->SetOffset(input_model.objective_offset());
@@ -752,6 +847,11 @@ void MPSolver::ExportModelToProto(MPModelProto* output_model) const {
       constraint_proto->add_coefficient(var_and_coeff.second);
     }
   }
+
+  //TO DO (dimitarpg13): handle SOS constraints here
+  //
+  //
+
   output_model->set_maximize(Objective().maximization());
   output_model->set_objective_offset(Objective().offset());
 }
@@ -830,6 +930,13 @@ void MPSolver::Clear() {
     constraint_name_to_index_->clear();
   }
   constraint_is_extracted_.clear();
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS
+  sos_constraints_.clear();
+  if (sos_constraint_name_to_index_) {
+    sos_constraint_name_to_index_->clear();
+  }
+  sos_constraint_is_extracted_.clear();
+#endif
   interface_->Reset();
   solution_hint_.clear();
 }
@@ -944,6 +1051,30 @@ MPConstraint* MPSolver::MakeRowConstraint(const LinearRange& range,
   }
   return constraint;
 }
+
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS
+SOSConstraint* MPSolver::MakeSOSConstraint(const std::string& name, 
+                                           const SOSType sos_type) {
+   //TO DO (dimitarpg13): finish this method after an appropriate method
+   //is added to the MPSolverInterface
+   const int sos_constraint_index = NumSOSConstraints();
+   SOSConstraint* const sos_constraint =
+      new SOSConstraint(sos_constraint_index, sos_type, name, interface_.get());
+   if (constraint_name_to_index_) {
+       gtl::InsertOrDie(&*sos_constraint_name_to_index_, sos_constraint->name(),
+                     sos_constraint_index);
+   }
+   sos_constraints_.push_back(sos_constraint);
+   sos_constraint_is_extracted_.push_back(false);
+   interface_->AddSOSConstraint(sos_constraint);
+   return sos_constraint;   
+}
+
+SOSConstraint* MPSolver::MakeSOSConstraint(const SOSType sos_type) {
+   return MakeSOSConstraint("", sos_type);
+}
+ 
+#endif
 
 int MPSolver::ComputeMaxConstraintSize(int min_constraint_index,
                                        int max_constraint_index) const {
@@ -1279,6 +1410,7 @@ MPSolverInterface::MPSolverInterface(MPSolver* const solver)
       maximize_(false),
       last_constraint_index_(0),
       last_variable_index_(0),
+      last_sos_constraint_index_(0),
       objective_value_(0.0),
       quiet_(true) {}
 
@@ -1288,15 +1420,28 @@ void MPSolverInterface::Write(const std::string& filename) {
   LOG(WARNING) << "Writing model not implemented in this solver interface.";
 }
 
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS
+void MPSolverInterface::ExtractNewSOSConstraints() {
+   // do nothing since if this method execute the SOS constraints are not applicable 
+   // to this solver instance
+}
+#endif
+
 void MPSolverInterface::ExtractModel() {
   switch (sync_status_) {
     case MUST_RELOAD: {
       ExtractNewVariables();
       ExtractNewConstraints();
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS
+      ExtractNewSOSConstraints();
+#endif
       ExtractObjective();
 
       last_constraint_index_ = solver_->constraints_.size();
       last_variable_index_ = solver_->variables_.size();
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS
+      last_sos_constraint_index_ = solver_->sos_constraints_.size();
+#endif
       sync_status_ = MODEL_SYNCHRONIZED;
       break;
     }
@@ -1304,12 +1449,18 @@ void MPSolverInterface::ExtractModel() {
       // Everything has already been extracted.
       DCHECK_EQ(last_constraint_index_, solver_->constraints_.size());
       DCHECK_EQ(last_variable_index_, solver_->variables_.size());
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS
+      DCHECK_EQ(last_sos_constraint_index_, solver_->sos_constraints_.size());
+#endif
       break;
     }
     case SOLUTION_SYNCHRONIZED: {
       // Nothing has changed since last solve.
       DCHECK_EQ(last_constraint_index_, solver_->constraints_.size());
       DCHECK_EQ(last_variable_index_, solver_->variables_.size());
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS
+      DCHECK_EQ(last_sos_constraint_index_, solver_->sos_constraints_.size());
+#endif
       break;
     }
   }
@@ -1319,9 +1470,11 @@ void MPSolverInterface::ExtractModel() {
 void MPSolverInterface::ResetExtractionInformation() {
   sync_status_ = MUST_RELOAD;
   last_constraint_index_ = 0;
+  last_sos_constraint_index_ = 0;
   last_variable_index_ = 0;
   solver_->variable_is_extracted_.assign(solver_->variables_.size(), false);
   solver_->constraint_is_extracted_.assign(solver_->constraints_.size(), false);
+  solver_->sos_constraint_is_extracted_.assign(solver_->sos_constraints_.size(), false);
 }
 
 bool MPSolverInterface::CheckSolutionIsSynchronized() const {
@@ -1495,6 +1648,34 @@ bool MPSolverInterface::ReadParameterFile(const std::string& filename) {
 std::string MPSolverInterface::ValidFileExtensionForParameterFile() const {
   return ".tmp";
 }
+
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS
+void MPSolverInterface::AddSOSConstraint(SOSConstraint* const ct) {
+   // this base method should never get called
+   std::string err_msg = "SOS constraintis are not implemented yet for this solver!";
+   LOG(DFATAL) << "Error: could not create environment: " << err_msg;
+   throw std::runtime_error(err_msg);
+}
+
+// Changes a coefficient in a SOS constraint.
+void MPSolverInterface::SetCoefficient(SOSConstraint* const sos_constraint,
+                              const MPVariable* const variable,
+                              double new_value, double old_value) {
+   // this base method should never get called
+   std::string err_msg = "SOS constraints are not implemented yet for this solver!";
+   LOG(DFATAL) << "Error: could not create environment: " << err_msg;
+   throw std::runtime_error(err_msg);
+}
+
+// Clears a constraint from all its terms.
+void MPSolverInterface::ClearSOSConstraint(SOSConstraint* const sos_constraint)
+{
+   // this base method should never get called
+   std::string err_msg = "SOS constraints are not implemented yet for this solver!";
+   LOG(DFATAL) << "Error: could not create environment: " << err_msg;
+   throw std::runtime_error(err_msg);
+}
+#endif
 
 // ---------- MPSolverParameters ----------
 
@@ -1673,5 +1854,673 @@ int MPSolverParameters::GetIntegerParam(MPSolverParameters::IntegerParam param)
   }
 }
 
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS
+PWLSolver::PWLSolver(const std::string& name, enum OptimizationSuite opt_suite) : 
+	name_(name), opt_suite_(opt_suite), 
+    sos_constraint_(nullptr), objective_(nullptr),
+    xvalues_inited_(false), yvalues_inited_(false), Avalues_inited_(false),
+    Bvalues_inited_(false), bvalues_inited_(false), cvalues_inited_(false), 
+    dvalues_inited_(false), validated_(false), valid_state_(false)
+{
+    timer_.Restart();
+    MPSolver::OptimizationProblemType prob_type;
+    bool res = GetProblemType(opt_suite, &prob_type);
+    if (res) {
+       mp_solver_ = std::unique_ptr<MPSolver>(new MPSolver(name_, prob_type));
+    }
+    // TO DO (dimitarpg13): initialize data members
+    //
+}
+
+void PWLSolver::Clear() {
+    //TO DO (dimitarpg13): clear initialized data members
+    //
+    variables_.clear();
+    constraints_.clear();
+    sos_constraint_ = nullptr;
+
+    x_.clear();
+    y_.clear();
+    A_.clear();
+    B_.clear();
+    b_.clear();
+    c_.clear();
+    d_.clear();
+    C_.clear();
+
+    xvalues_inited_ = false;
+    yvalues_inited_ = false;
+    Avalues_inited_ = false;
+    Bvalues_inited_ = false;
+    bvalues_inited_ = false;
+    cvalues_inited_ = false;
+    dvalues_inited_ = false;
+
+    validated_ = false;
+    valid_state_ = false;
+
+    mp_solver_->Clear();
+}
+
+PWLSolver::~PWLSolver() {
+    //TO DO (dimitarpg13): destroy any additional objects here
+    //
+    
+}
+
+MPVariable* PWLSolver::GetVariableOrNull(const int var_idx) const {
+   if (variables_.size() > var_idx)
+       return variables_[var_idx];
+   else
+       return nullptr;
+}
+
+// Solves the problem using default parameter values.
+MPSolver::ResultStatus PWLSolver::Solve() {
+    //TO DO (dimitarpg13): do any extra preparation for PWL solving here
+    //
+    if (!ExtractState()) {
+        LOG(ERROR) << "Invalid parameter(s) data. Check x_i, y_i, A, B, b, c, and d!"; 
+#ifndef NDEBUG
+        LOG(INFO) << "x coordinates:";
+        PrintXValues();
+        LOG(INFO) << "y coordinates:";
+        PrintYValues();
+        LOG(INFO) << "matrix A:";
+        PrintAValues();
+        LOG(INFO) << "matrix B:";
+        PrintBValues();
+        LOG(INFO) << "vector b:";
+        PrintbValues();
+        LOG(INFO) << "vector c:";
+        PrintcValues();
+        LOG(INFO) << "vector d:";
+        PrintdValues();
+#endif
+        return MPSolver::ABNORMAL;
+    }
+
+    return mp_solver_->Solve();
+}
+
+// Solves the problem using the specified parameter values.
+MPSolver::ResultStatus PWLSolver::Solve(const MPSolverParameters& param) {
+    //TO DO (dimitarpg13): do any additional preparation for PWL solving here
+    //
+    if (!ExtractState()) {
+        LOG(ERROR) << "Invalid parameter(s) data. Check x_i, y_i, A, B, b, c, and d!"; 
+#ifndef NDEBUG
+        LOG(INFO) << "x coordinates:";
+        PrintXValues();
+        LOG(INFO) << "y coordinates:";
+        PrintYValues();
+        LOG(INFO) << "matrix A:";
+        PrintAValues();
+        LOG(INFO) << "matrix B:";
+        PrintBValues();
+        LOG(INFO) << "vector b:";
+        PrintbValues();
+        LOG(INFO) << "vector c:";
+        PrintcValues();
+        LOG(INFO) << "vector d:";
+        PrintdValues();
+#endif
+        return MPSolver::ABNORMAL;
+    }
+
+    return mp_solver_->Solve(param);
+}
+
+bool PWLSolver::VerifySolution(double tolerance, bool log_errors) const {
+
+    return mp_solver_->VerifySolution(tolerance, log_errors);
+}
+
+int64 PWLSolver::nodes() const {
+    if (mp_solver_) {
+       return mp_solver_->nodes();
+    }
+    else
+       return 0;
+}
+
+void PWLSolver::SetXValues(MatrixOfDoubles const & x) {
+  if (xvalues_inited_)
+      x_.clear();
+  x_.assign(x.begin(),x.end());
+  xvalues_inited_ = true;
+  validated_ = false;
+}
+
+
+void PWLSolver::SetYValues(VectorOfDoubles const & y) {
+  if (yvalues_inited_)
+      y_.clear();
+  y_.assign(y.begin(),y.end());
+  yvalues_inited_ = true;
+  validated_ = false;
+}
+
+void PWLSolver::SetParameter(VectorOfDoubles const & v, VectorParameterType type) {
+  if (type == VectorParameterType::bVector) {
+    if (bvalues_inited_)
+        b_.clear();
+    b_.assign(v.begin(),v.end()); 
+    bvalues_inited_ = true;
+    validated_ = false;
+  }
+  else if (type == VectorParameterType::cVector) {
+    if (cvalues_inited_)
+        c_.clear();
+    c_.assign(v.begin(),v.end());
+    cvalues_inited_ = true;
+    validated_ = false;
+  }
+  else if (type == VectorParameterType::dVector) {
+    if (dvalues_inited_)
+        d_.clear();
+    d_.assign(v.begin(),v.end());
+    dvalues_inited_ = true;
+    validated_ = false;
+  }
+  else {
+     LOG(ERROR) << "Trying to set an unknown vector parameter type: " << type << ".";
+  }
+}
+
+void PWLSolver::SetParameter(MatrixOfDoubles const & m, MatrixParameterType type) {
+ //TO DO (dimitarpg13): finish this method
+  if (type == MatrixParameterType::AMatrix) {
+     if (Avalues_inited_)
+        A_.clear();
+     A_.assign(m.begin(), m.end());
+     Avalues_inited_ = true;
+     validated_ = false;
+  } else if (type == MatrixParameterType::BMatrix) {
+     if (Bvalues_inited_)
+        B_.clear();
+     B_.assign(m.begin(), m.end());
+     Bvalues_inited_ = true;
+     validated_ = false;
+  } else {
+     LOG(ERROR) << "Trying to set an unknown vector parameter type: " << type << ".";
+  }
+
+}
+
+int PWLSolver::dim_of_x_point() { // denoted by m
+   if (inited())
+      return x_.size();
+   else 
+      return 0;
+}
+
+int PWLSolver::numb_of_x_points() { // denoted by k
+    if (inited() && dim_of_x_point() > 0)
+        return x_[0].size();
+    else
+        return 0;
+}
+
+int PWLSolver::numb_of_constr() { // denoted by p
+    if (inited())
+        return A_.size();
+    else
+        return 0;
+}
+
+int PWLSolver::numb_of_real_vars() { // denoted by l
+    if (inited())
+        return b_.size();
+    else
+        return 0;
+}
+
+int PWLSolver::numb_of_vars() { //denoted by l + k
+   return numb_of_x_points() + numb_of_real_vars();
+}
+
+// public methods useful for debugging and troubleshooting
+//
+
+#ifndef NDEBUG
+void PWLSolver::PrintXValues() {
+  print_matrix(x_);
+}
+
+void PWLSolver::PrintYValues() {
+  print_vector(y_);
+}
+
+void PWLSolver::PrintAValues() {
+  print_matrix(A_);
+}
+
+void PWLSolver::PrintBValues() {
+  print_matrix(B_);
+}
+
+void PWLSolver::PrintbValues() {
+  print_vector(b_);
+}
+
+void PWLSolver::PrintcValues() {
+  print_vector(c_);
+}
+
+void PWLSolver::PrintdValues() {
+  print_vector(d_);
+}
+
+void PWLSolver::print_matrix(MatrixOfDoubles const & m) {
+  printf("[");
+  int i=1;
+  for (auto & row : m ) {
+    int j=1;
+    if (i>1)
+      printf(" ");
+    printf("[");
+    for (auto & val : row) {
+      printf("%3.3f", val);
+      if (j < row.size())
+          printf(",");
+      ++j;
+    }
+    printf("]");
+    if (i < m.size())
+       printf(",\n");
+    ++i;
+  }
+  printf("]\n");
+
+}
+
+
+void PWLSolver::print_vector(VectorOfDoubles const & v) {
+    int j=1;
+    printf("[");
+    for (auto & val : v) {
+      printf("%3.3f", val);
+      if (j < v.size())
+          printf(",");
+      ++j;
+    }
+    printf("]\n");
+}
+
+#endif //ifndef NDEBUG
+
+// protected PWLSolver methods for handling state
+//
+//
+
+bool PWLSolver::inited() {
+
+   return xvalues_inited_ &&
+          yvalues_inited_ &&
+          Avalues_inited_ &&
+          Bvalues_inited_ &&
+          bvalues_inited_ &&
+          cvalues_inited_ &&
+          dvalues_inited_;
+
+}
+
+bool PWLSolver::ExtractState() {
+   if (!inited()               ||
+       !ValidateState()        ||
+       !ExtractVariables()     ||
+       !ExtractObjective()     ||
+       !ExtractConstraints()   || 
+       !ExtractSOSConstraint())         
+   {
+       Clear();
+       return false;
+   }
+
+   return true;
+}
+
+bool PWLSolver::ExtractVariables() {
+
+   int k = numb_of_x_points();
+   int m = dim_of_x_point();
+   int p = numb_of_constr();
+   int l = numb_of_real_vars();
+
+   // there are k integer variables lambda_i, i=1..k
+   // and l continuous variables (a.k.a free variables) 
+   // z_j, j=1..l
+   //
+   MPVariable * curVar = nullptr;
+   char buffer[32];
+   for (int i = 0; i < k; ++i) {
+     snprintf( buffer, 31, "lambda_%d", i+1 );
+     curVar = mp_solver_->MakeIntVar(0.0, infinity(), std::string(buffer)); 
+     variables_.push_back(curVar);
+   }
+   for (int j = 0; j < l; ++j) {
+     snprintf( buffer, 31, "z_%d", j+1 );
+     curVar = mp_solver_->MakeNumVar(0.0, infinity(), std::string(buffer));
+     variables_.push_back(curVar);
+   }
+   return true;
+}
+
+bool PWLSolver::ExtractObjective() {
+   int k = numb_of_x_points();
+   int m = dim_of_x_point();
+   int l = numb_of_real_vars();
+
+   //
+   // The objective function is given by
+   //
+   // f = y * lambda + ( c * x ) * lambda + b * z  
+   //
+   // lambda -> integer variables
+   // z -> continuous variables
+   // f -> objective function
+   //
+   // c -> double[1,m]
+   // x -> double[m,k]
+   // lambda -> double[1,k] 
+   // y -> double[1,k]
+   // b -> double[1,l]
+   // z -> double[l,1]
+   //
+   // let us use the helper vector a given by :
+   // a = y + c * x
+   // a -> double[1,k]
+   //
+   // then the objective function can be rewritten as:
+   // f = a * lambda + b * z
+   //
+   MultiplyAndSum(c_, x_, y_, k, m, a_);
+
+   objective_ = mp_solver_->MutableObjective();
+   
+   for (int i = 0; i < k; ++i) {
+     objective_->SetCoefficient(variables_[i], a_[i]); 
+   }
+
+   for (int i = 0; i < l; ++i) {
+     objective_->SetCoefficient(variables_[i+k], b_[i]);
+   }
+   objective_->SetMaximization();
+
+   return  true;
+}
+
+bool PWLSolver::ExtractConstraints() {
+   int k = numb_of_x_points();
+   int m = dim_of_x_point();
+   int p = numb_of_constr();
+   int l = numb_of_real_vars();
+
+   // calculate the helper matrix C_ used for extracting the constraints
+   //
+   // A -> double[p,m]
+   // x -> double[m,k]
+   // C -> double[p,k]
+   //
+   // C = A * x
+   //
+   Multiply(A_, x_, p, m, k, C_);
+
+   // create the constraints of the model using the notation:
+   //
+   // lambda -> integer variables
+   // z -> continuous variables
+   //
+   // C -> double[p,k]
+   // B -> double[p,l]
+   // lambda -> double[k,1]
+   // z -> double[l,1]
+   // d -> double[p,1]
+   //
+   // C * lambda + B * z <= d
+   //
+   MPConstraint* curConstr = nullptr;
+   MPVariable* curVar = nullptr;
+   for (int i=0; i < p; ++i) {
+      // we are at the i-th inequality
+      //
+      curConstr = mp_solver_->MakeRowConstraint(-infinity(),d_[i]); 
+      for (int j=0; j < k; ++j) {
+          // we are setting the coefficient for lambda_j for the i-th inequality
+          //
+          curVar = variables_[j];
+          curConstr->SetCoefficient(curVar, C_[i][j]);
+      }
+
+      for (int j=0; j < l; ++j) {
+          // we are setting the coefficient for z_j for the i-th inequality
+          //
+          curVar = variables_[k+j];
+          curConstr->SetCoefficient(curVar, B_[i][j]);
+      }
+   }
+
+
+   // add one last constraint to make sure that at least one of the integer 
+   // (in fact boolean) variables lambda_i is turned on.
+   curConstr = mp_solver_->MakeRowConstraint(1, infinity());
+   for (int j=0; j < k; ++j) {
+       curVar = variables_[j];
+       curConstr->SetCoefficient(curVar, 1.0);
+   }
+
+   return true;
+}
+
+bool PWLSolver::ExtractSOSConstraint() {
+    sos_constraint_ = mp_solver_->MakeSOSConstraint("lambda", MPSolver::SOS1);
+    int k = numb_of_x_points();
+    for (int i = 0; i < k; ++i) {
+      sos_constraint_->SetCoefficient(variables_[i], 1.0);  
+    }
+    return true;
+}
+
+bool PWLSolver::ValidateState() {
+   if (validated_)
+       return valid_state_;
+
+   validated_ = true;
+   int m = x_.size();
+   int k = 0;
+   if (m > 0) {
+       k = x_[0].size();
+       if (k == 0) {
+         valid_state_ = false;
+         return valid_state_;
+       }
+   }
+   else {
+     valid_state_ = false;
+     return valid_state_;
+   }
+   for (int i = 1; i < m; ++i) {
+     if (x_[i].size() < k) {
+         valid_state_ = false;
+         return valid_state_;
+     }
+   }      
+   if (y_.size() < k)
+   {
+     valid_state_ = false;
+     return valid_state_;
+   }
+   int p = A_.size();
+   if (p > 0)
+   {
+      for (int j = 0; j < p; ++j) {
+        if (A_[j].size() < m) {
+           valid_state_ = false;
+           return valid_state_;
+        }
+      }
+   }
+   else
+   {
+     valid_state_ = false;
+     return valid_state_;
+   }
+
+   int l = b_.size();
+   if (l > 0) { 
+      if (B_.size() < p) {
+        valid_state_ = false;
+        return valid_state_;
+      }
+      else {
+        for (int j = 0; j < p; ++j) {
+          if (B_[j].size() < l) {
+            valid_state_ = false;
+            return valid_state_;
+          }
+        }
+      }
+   }
+   else
+   {
+      if (B_.size() < p) {
+        valid_state_ = false;
+        return valid_state_;
+      }
+   }
+
+   if (c_.size() < m) {
+     valid_state_ = false;
+     return valid_state_;
+   }
+
+   if (d_.size() < p) {
+     valid_state_ = false;
+     return valid_state_;
+   }
+
+   valid_state_ = true;
+   return valid_state_;
+}
+
+void PWLSolver::Multiply(MatrixOfDoubles const & A, VectorOfDoubles const & v, 
+        const int n, const int m, VectorOfDoubles& r) {
+   // r[n] = A[n][m] * v[m]
+   //
+   r.resize(m,0.0);
+   for (int i = 0; i < n; ++i) {
+      r[i] = 0.0;
+      for (int j = 0; j < m; ++j) {
+          r[i] += A[i][j]*v[j];
+      }
+   }
+}
+
+void PWLSolver::Multiply(MatrixOfDoubles const & A, MatrixOfDoubles const & B,
+           const int n, const int m, const int p, MatrixOfDoubles& C) {
+   // C[n][p] = sum_{m} A[n][m] * B[m][p]
+   //
+   C.resize(n);
+   for (int i = 0; i < n; ++i) {
+      C[i].resize(p,0.0);
+      for (int k = 0; k < p; ++k) {
+          for (int j = 0; j < m; ++j) {
+              C[i][k] += A[i][j] * B[j][k];
+          }
+      }
+   }
+}
+
+// helper method for multiplying a vector with matrix and summing the result with another vector
+// a[k] = y[k] + sum_{m} c[m]*x[m][k]
+//
+void PWLSolver::MultiplyAndSum(VectorOfDoubles const & c, MatrixOfDoubles const & x, 
+           VectorOfDoubles const & y, const int k, const int m, VectorOfDoubles& a) {
+   a.resize(k);
+   for (int i = 0; i < k; ++i) {
+      a[i] = y[i];
+      for (int j = 0; j < m; ++j) {
+         a[i] += c[j] * x[j][i];
+      }
+   }
+}
+
+
+// static PWLSolver methods
+//
+
+bool PWLSolver::GetProblemType(PWLSolver::OptimizationSuite opt_suite, MPSolver::OptimizationProblemType* pType) {
+#ifdef USE_GUROBI
+    if (opt_suite == PWLSolver::GUROBI) { 
+        *pType = MPSolver::GUROBI_MIXED_INTEGER_PROGRAMMING;
+        return true;
+    }
+#endif
+#ifdef USE_SCIP
+    else if (opt_suite == PWLSolver::SCIP) {
+        *pType =  MPSolver::SCIP_MIXED_INTEGER_PROGRAMMING;
+        return true;
+    }
+#endif
+#ifdef USE_CBC
+    else if (opt_suite == PWLSolver::CBC) {
+        *pType = MPSolver::CBC_MIXED_INTEGER_PROGRAMMING;
+        return true;
+    }
+#endif
+#ifdef USE_GLPK
+    else if (opt_suite == PWLSolver::GLPK) { 
+        *pType = MPSolver::GLPK_MIXED_INTEGER_PROGRAMMING;
+        return true;
+    }
+#endif
+    else return false;
+}
+
+
+
+bool PWLSolver::SupportsOptimizationSuite(PWLSolver::OptimizationSuite opt_suite) {
+#ifdef USE_GUROBI
+    if (opt_suite == GUROBI) return true;
+#endif
+#ifdef USE_SCIP
+    if (opt_suite == SCIP) return true;
+#endif
+#ifdef USE_CBC
+    if (opt_suite == CBC) return true;
+#endif
+#ifdef USE_GLPK
+    if (opt_suite == GLPK) return true;
+#endif
+    return false;
+}
+
+
+bool PWLSolver::ParseOptimizationSuite(absl::string_view suite,
+                                       PWLSolver::OptimizationSuite* pSuite) {
+#if defined(USE_GUROBI)
+   if (suite == "gurobi") {
+     *pSuite = PWLSolver::GUROBI;
+#endif
+#if defined(USE_SCIP)
+   } else if (suite == "scip") {
+    *pSuite = PWLSolver::SCIP;
+#endif
+#if defined(USE_CBC)
+  } else if (suite == "cbc") {
+    *pSuite = PWLSolver::CBC;
+#endif
+#if defined(USE_GLPK)
+  } else if (suite == "glpk") {
+    *type = PWLSolver::GLPK;
+#endif
+  } else {
+    return false;
+  }
+  return true;
+}
+
+#endif // MIP_SOLVER_WITH_SOS_CONSTRAINTS
 
 }  // namespace operations_research

--- a/ortools/linear_solver/linear_solver.h
+++ b/ortools/linear_solver/linear_solver.h
@@ -146,7 +146,9 @@
 #include <utility>
 #include <vector>
 
+#include "ortools/base/optimization_suites.h"
 #include "ortools/base/integral_types.h"
+#include "ortools/base/stringprintf.h"
 #include "ortools/base/logging.h"
 #include "ortools/base/timer.h"
 #include "ortools/glop/parameters.pb.h"
@@ -163,6 +165,8 @@ class MPObjective;
 class MPSolverInterface;
 class MPSolverParameters;
 class MPVariable;
+class SOSConstraint;
+
 
 // This mathematical programming (MP) solver class is the main class
 // though which users build and solve problems.
@@ -302,13 +306,36 @@ class MPSolver {
   MPConstraint* MakeRowConstraint(double lb, double ub, const std::string& name);
   // Creates a named constraint with -infinity and +infinity bounds.
   MPConstraint* MakeRowConstraint(const std::string& name);
-
+  // Creates a constraint owned by MPSolver enforcing:
+  // range.lower_bound() <= range.linear_expr() <= range.upper_bound()
+  MPConstraint* MakeRowConstraint(const LinearRange& range, const std::string& name);
   // Creates a constraint owned by MPSolver enforcing:
   // range.lower_bound() <= range.linear_expr() <= range.upper_bound()
   MPConstraint* MakeRowConstraint(const LinearRange& range);
   // As above, but also names the constraint.
-  MPConstraint* MakeRowConstraint(const LinearRange& range, const std::string& name);
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS
+  // ----- SOS Constraints -----
+  // Returns the number of SOS constraints (both types SOS1 and SOS2).
+  int NumSOSConstraints() const { return sos_constraints_.size(); }
+  // Returns the array of constraints handled by the MPSolver.
+  // (They are listed in the order in which they were created.)
+  const std::vector<SOSConstraint*>& sos_constraints() const { return sos_constraints_; }
 
+  // Looks up a SOS constraint by name, and returns nullptr if it does not exist.
+  // The first call has a O(n) complexity, as the constraint name index is
+  // lazily created upon first use. Will crash if constraint names are not
+  // unique.
+  SOSConstraint* LookupSOSConstraintOrNull(
+      const std::string& sos_constraint_name) const;
+
+  enum SOSType {
+    SOS1 = 1,
+    SOS2 = 2
+  };
+
+  SOSConstraint* MakeSOSConstraint(const std::string& name, const SOSType sos_type);
+  SOSConstraint* MakeSOSConstraint(const SOSType sos_type);
+#endif
   // ----- Objective -----
   // Note that the objective is owned by the solver, and is initialized to
   // its default value (see the MPObjective class below) at construction.
@@ -580,7 +607,9 @@ class MPSolver {
   friend class BopInterface;
   friend class SatInterface;
   friend class KnapsackInterface;
-
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS
+  friend class SOSConstraintAggregator;
+#endif
   // Debugging: verify that the given MPVariable* belongs to this solver.
   bool OwnsVariable(const MPVariable* var) const;
 
@@ -615,10 +644,21 @@ class MPSolver {
 
   // The vector of constraints in the problem.
   std::vector<MPConstraint*> constraints_;
+
   // A map from a constraint's name to its index in constraints_.
   std::unique_ptr<std::unordered_map<std::string, int> > constraint_name_to_index_;
   // Whether constraints have been extracted to the underlying interface.
   std::vector<bool> constraint_is_extracted_;
+
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS
+  // the vector of SOS contraints in the problem in case it is MIP
+  std::vector<SOSConstraint*> sos_constraints_;
+  
+  // A map from a SOS constraint's name to its index in constraints_.
+  std::unique_ptr<std::unordered_map<std::string, int> > sos_constraint_name_to_index_;
+  // Whether constraints have been extracted to the underlying interface.
+  std::vector<bool> sos_constraint_is_extracted_;
+#endif
 
   // The linear objective function.
   std::unique_ptr<MPObjective> objective_;
@@ -761,6 +801,284 @@ class MPObjective {
 
   DISALLOW_COPY_AND_ASSIGN(MPObjective);
 };
+
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS
+// this class provides a solver for a generalized piece-wise linear approximation of a discrete
+// linear function with mixed constrains (SOS-1 and general inequality constraints)
+class PWLSolver {
+ public:
+  // TO DO (dimitarpg13):  if we are going to support invocation through protobuf (PWLSolver::SolveWithProto)
+  // we need to create PWLModelRequest template for this class 
+  enum OptimizationSuite {
+#ifdef USE_GUROBI
+    GUROBI = 1, // Recommended default value
+#endif
+#ifdef USE_SCIP
+    SCIP = 2,  
+#endif
+#ifdef USE_GLPK
+    GLPK = 4,
+#endif
+#ifdef USE_CBC
+    CBC = 8,
+#endif
+#ifdef USE_CPLEX
+    CPLEX = 16,
+#endif
+  };
+
+  enum CoordType {
+    XCoord = 1,
+    YCoord = 2
+  };
+
+  enum VectorParameterType {
+    bVector = 1,
+    cVector = 2,
+    dVector = 4
+  };
+
+  enum MatrixParameterType {
+    AMatrix = 1,
+    BMatrix = 2
+  };
+
+  typedef std::vector<std::vector<double>> MatrixOfDoubles;
+  typedef std::vector<double> VectorOfDoubles;
+
+  PWLSolver(const std::string& name, OptimizationSuite opt_suite);
+  ~PWLSolver();
+
+  static double infinity() { return std::numeric_limits<double>::infinity(); }
+  // Whether the given problem type is supported (this will depend on the
+  // targets that you linked).
+  static bool SupportsOptimizationSuite(PWLSolver::OptimizationSuite opt_suite);
+
+  // Parses the name of the solver. Returns true if the solver type is
+  // successfully parsed as one of the OptimizationProblemType.
+  static bool ParseOptimizationSuite(absl::string_view suite,
+                                     PWLSolver::OptimizationSuite* pSuite);
+
+  static bool GetProblemType(OptimizationSuite opt_suite, MPSolver::OptimizationProblemType* pType);
+
+  const std::string& Name() const {
+      return name_;  // Set at construction.
+  }
+
+  const OptimizationSuite OptSuite() const {
+      return opt_suite_;
+  }
+
+  // Clears the objective (including the optimization direction), all
+  // variables and constraints. All the other properties of the MPSolver
+  // (like the time limit) are kept untouched.
+  void Clear();
+
+
+  // ----- Variables ------
+  // Returns the number of variables.
+  // int NumVariables() const { return variables_.size(); }
+  // Returns the array of variables handled by the MPSolver.
+  // (They are listed in the order in which they were created.)
+  const std::vector<MPVariable*>& variables() const { return variables_; }
+  // Looks up a variable by index, and returns nullptr if it does not exist.
+  MPVariable* GetVariableOrNull(const int var_idx) const;
+
+  // ----- Constraints -----
+  // Returns the number of constraints.
+  // int NumConstraints() const { return constraints_.size(); }
+  // Returns the array of constraints handled by the MPSolver.
+  // (They are listed in the order in which they were created.)
+  const std::vector<MPConstraint*>& constraints() const { return constraints_; }
+
+  const SOSConstraint* sos_constraint() const { return sos_constraint_; }
+
+  const MPObjective* objective() const { return objective_; }
+
+  void SetXValues(MatrixOfDoubles const & );
+
+  void SetYValues(VectorOfDoubles const & );
+  
+  void SetParameter(VectorOfDoubles const &, VectorParameterType );
+
+  void SetParameter(MatrixOfDoubles const &, MatrixParameterType );
+
+#ifndef NDEBUG
+  void PrintXValues();
+  void PrintYValues();
+  void PrintAValues();
+  void PrintBValues();
+  void PrintbValues();
+  void PrintcValues();
+  void PrintdValues();
+#endif
+
+  // Solves the problem using default parameter values.
+  MPSolver::ResultStatus Solve();
+  // Solves the problem using the specified parameter values.
+  MPSolver::ResultStatus Solve(const MPSolverParameters& param);
+
+  // Advanced usage:
+  // Verifies the *correctness* of the solution: all variables must be within
+  // their domains, all constraints must be satisfied, and the reported
+  // objective value must be accurate.
+  // Usage:
+  // - This can only be called after Solve() was called.
+  // - "tolerance" is interpreted as an absolute error threshold.
+  // - For the objective value only, if the absolute error is too large,
+  //   the tolerance is interpreted as a relative error threshold instead.
+  // - If "log_errors" is true, every single violation will be logged.
+  // - If "tolerance" is negative, it will be set to infinity().
+  //
+  // Most users should just set the --verify_solution flag and not bother
+  // using this method directly.
+  bool VerifySolution(double tolerance, bool log_errors) const;
+
+
+  // Controls (or queries) the amount of output produced by the underlying
+  // solver. The output can surface to LOGs, or to stdout or stderr, depending
+  // on the implementation. The amount of output will greatly vary with each
+  // implementation and each problem.
+  //
+  // Output is suppressed by default.
+  bool OutputIsEnabled() const;
+  void EnableOutput();
+  void SuppressOutput();
+
+  void set_time_limit(int64 time_limit_milliseconds) {
+    DCHECK_GE(time_limit_milliseconds, 0);
+    time_limit_ = time_limit_milliseconds;
+  }
+
+  // In milliseconds.
+  int64 time_limit() const { return time_limit_; }
+
+  // In seconds. Note that this returns a double.
+  double time_limit_in_secs() const {
+    // static_cast<double> avoids a warning with -Wreal-conversion. This
+    // helps catching bugs with unwanted conversions from double to ints.
+    return static_cast<double>(time_limit_) / 1000.0;
+  }
+
+  // Returns wall_time() in milliseconds since the creation of the solver.
+  int64 wall_time() const { return timer_.GetInMs(); }
+
+  // Returns the number of branch-and-bound nodes. 
+  int64 nodes() const;
+
+  int numb_of_x_points(); // denoted by k
+  int dim_of_x_point(); // denoted by m
+  int numb_of_constr(); // denoted by p
+  int numb_of_real_vars(); // denoted by l
+  int numb_of_vars(); // denoted by l+k
+
+ protected:
+
+   // protected fields
+   //
+   //
+   // the name of the problem
+   std::string name_;
+
+   // the chosen optimization suite to be used to solve this problem
+   enum OptimizationSuite opt_suite_;
+
+   // The vector of variables in the problem.
+   std::vector<MPVariable*> variables_;
+   // The vector of constraints in the problem.
+   std::vector<MPConstraint*> constraints_;
+
+   SOSConstraint * sos_constraint_;
+   
+   MPObjective * objective_;
+   // a row vector of all column vectors composed by the x_i values
+   // where i = 1..numb_of_x_points(). each x_i is a column vector of size dim_of_x_point() in x_.
+   // Hence x_ is matrix of size numb_of_x_points() times dim_of_x_point().
+   MatrixOfDoubles x_;
+
+   // column vector of the y-coordinate values y_i = y(x_i)
+   // the vector y_ is of size numb_of_x_points(). 
+   VectorOfDoubles y_;
+
+   // column vector containing numb_of_constr() row vectors each with size dim_of_x_point(). 
+   MatrixOfDoubles A_;
+
+   // column vector containing numb_of_constr() row vectors each with size dim_of_x_point()
+   MatrixOfDoubles B_;
+
+   // column vector containing dim_of_x_point() parameters for the continuous variables z
+   VectorOfDoubles b_;
+
+   // column vector containing dim_of_x_point() parameters for the x coordinates x_i, i=1..numb_of_x_points(). 
+   VectorOfDoubles c_;
+
+   // column vector containing dim_of_x_point() values which are the rhs of the system of constraint inequalities
+   VectorOfDoubles d_;
+
+   // C_ -> helper matrix given by:
+   // C_ = A_ * x_
+   // each row is the set of coefficients corresponding to lambda_i, i=1..numb_of_x_points() where the current row
+   // corresponds to the current constraint
+   MatrixOfDoubles C_;
+
+   // a_ -> helper vector of size numb_of_x_points() given by:
+   // a_ = y_ + c_ * x_
+   //
+   VectorOfDoubles a_;
+
+   std::unique_ptr<MPSolver> mp_solver_; 
+
+   // Time limit in milliseconds (0 = no limit).
+   int64 time_limit_;
+
+   WallTimer timer_;
+
+   // protected methods and fields for handling state
+   //
+   //
+   bool valid_state_;
+   bool validated_;
+   bool ValidateState();
+
+   bool ExtractState();
+   bool ExtractVariables();
+   bool ExtractObjective();
+   bool ExtractConstraints();
+   bool ExtractSOSConstraint();
+
+   // helper method for multiplying a matrix with a vector
+   // r[n] = sum_{m} A[n][m] * v[m]
+   //
+   void Multiply(MatrixOfDoubles const & A, VectorOfDoubles const & v,
+           const int n, const int m, VectorOfDoubles& r);
+
+   // helper method for multiplying two matrices
+   // C[n][p] = sum_{m} A[n][m] * B[m][p]
+   //
+   void Multiply(MatrixOfDoubles const & A, MatrixOfDoubles const & B,
+           const int n, const int m, const int p, MatrixOfDoubles& C);
+
+   // helper method for multiplying a vector with matrix and summing the result with another vector
+   // a[k] = y[k] + sum_{m} c[m]*x[m][k]
+   //
+   void MultiplyAndSum(VectorOfDoubles const & c, MatrixOfDoubles const & x, 
+           VectorOfDoubles const & y, const int k, const int m, VectorOfDoubles& a);  
+
+   bool inited();
+   bool xvalues_inited_;
+   bool yvalues_inited_;
+   bool Avalues_inited_;
+   bool Bvalues_inited_;
+   bool bvalues_inited_;
+   bool cvalues_inited_;
+   bool dvalues_inited_;
+
+#ifndef NDEBUG
+   void print_matrix(MatrixOfDoubles const &);
+   void print_vector(VectorOfDoubles const &);
+#endif
+};
+#endif // MIP_SOLVER_WITH_SOS_CONSTRAINTS
 
 // The class for variables of a Mathematical Programming (MP) model.
 class MPVariable {
@@ -964,6 +1282,100 @@ class MPConstraint {
   MPSolverInterface* const interface_;
   DISALLOW_COPY_AND_ASSIGN(MPConstraint);
 };
+
+
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS
+
+class SOSConstraintAggregator;
+// The class for constraints of a Mathematical Programming (MP) model.
+// A constraint is represented as a linear equation or inequality.
+class SOSConstraint {
+ public:
+  // Returns the name of the constraint.
+  const std::string& name() const { return name_; }
+
+  // Clears all variables and coefficients. Does not clear the bounds.
+  void Clear();
+
+  // Sets the coefficient of the variable on the constraint. If the variable
+  // does not belong to the solver, the function just returns, or crashes in
+  // non-opt mode.
+  void SetCoefficient(const MPVariable* const var, double coeff);
+  // Gets the coefficient of a given variable on the constraint (which
+  // is 0 if the variable does not appear in the constraint).
+  double GetCoefficient(const MPVariable* const var) const;
+
+  MPSolver::SOSType GetSOSType() const { return sos_type_; }
+  // Returns a map from variables to their coefficients in the constraint. If a
+  // variable is not present in the map, then its coefficient is zero.
+  const std::unordered_map<const MPVariable*, double>& terms() const {
+    return coefficients_;
+  }
+
+
+  // Returns the index of the constraint in the MPSolver::sos_constraints_.
+  int index() const { return index_; }
+
+
+ protected:
+  friend class MPSolver;
+  friend class MPSolverInterface;
+  friend class CBCInterface;
+  friend class GLPKInterface;
+  friend class SCIPInterface;
+  friend class GurobiInterface;
+  friend class CplexInterface;
+  friend class SOSConstraintAggregator;
+
+  // Constructor. A constraint points to a single MPSolverInterface
+  // that is specified in the constructor. A constraint cannot belong
+  // to several models.
+  SOSConstraint(int index, MPSolver::SOSType sos_type,  const std::string& name,
+               MPSolverInterface* const interface)
+      : coefficients_(1),
+        sos_type_(sos_type),
+        index_(index),
+        name_(name.empty() ? absl::StrFormat("auto_sc_%09d", index) : name),
+        interface_(interface) {}
+
+  // Advanced use only. Order index of the first variable in the constraint 
+  int begin_index() { return beg_; }
+
+  // Advanced use only. Order indices of the variables associated with this constraint
+  std::vector<int>& variable_indices() { return ind_; }
+
+  // Advanced use only. weights of the variables indexed by their order indices
+  std::vector<double>& weights() { return weight_; }
+
+ private:
+  // Returns true if the constraint contains variables that have not
+  // been extracted yet.
+  bool ContainsNewVariables();
+
+  // Mapping var -> coefficient.
+  std::unordered_map<const MPVariable*, double> coefficients_;
+
+  const MPSolver::SOSType sos_type_;
+  const int index_;  // See index().
+
+
+  // Name.
+  const std::string name_;
+
+  // Order index of the first variable in the constraint  
+  int beg_; 
+
+  // Order indices of the variables associated with this constraint
+  std::vector<int> ind_;
+
+  // Weights associated with variables indexed by their order indices
+  std::vector<double> weight_;
+
+  MPSolverInterface* const interface_;
+  DISALLOW_COPY_AND_ASSIGN(SOSConstraint);
+};
+
+#endif // MIP_SOLVER_WITH_SOS_CONSTRAINTS
 
 // This class stores parameter settings for LP and MIP solvers.
 // Some parameters are marked as advanced: do not change their values
@@ -1180,6 +1592,10 @@ class MPSolverInterface {
   // Adds a linear constraint.
   virtual void AddRowConstraint(MPConstraint* const ct) = 0;
 
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS
+  // Adds a SOS constraint.
+  virtual void AddSOSConstraint(SOSConstraint* const ct);
+#endif
   // Add a variable.
   virtual void AddVariable(MPVariable* const var) = 0;
 
@@ -1190,6 +1606,18 @@ class MPSolverInterface {
 
   // Clears a constraint from all its terms.
   virtual void ClearConstraint(MPConstraint* const constraint) = 0;
+
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS
+
+  // Changes a coefficient in a SOS constraint.
+  virtual void SetCoefficient(SOSConstraint* const sos_constraint,
+                              const MPVariable* const variable,
+                              double new_value, double old_value);
+
+  // Clears a constraint from all its terms.
+  virtual void ClearSOSConstraint(SOSConstraint* const sos_constraint);
+
+#endif
 
   // Changes a coefficient in the linear objective.
   virtual void SetObjectiveCoefficient(const MPVariable* const variable,
@@ -1265,7 +1693,14 @@ class MPSolverInterface {
   void set_constraint_as_extracted(int ct_index, bool extracted) {
     solver_->constraint_is_extracted_[ct_index] = extracted;
   }
-
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS
+  bool sos_constraint_is_extracted(int ct_index) const {
+    return solver_->sos_constraint_is_extracted_[ct_index];
+  }
+  void set_sos_constraint_as_extracted(int ct_index, bool extracted) {
+    solver_->sos_constraint_is_extracted_[ct_index] = extracted;
+  }
+#endif
   // Returns the boolean indicating the verbosity of the solver output.
   bool quiet() const { return quiet_; }
   // Sets the boolean indicating the verbosity of the solver output.
@@ -1304,6 +1739,10 @@ class MPSolverInterface {
 
   // To access the maximize_ bool and the MPSolver.
   friend class MPConstraint;
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS
+  friend class SOSConstraint;
+  friend class SOSConstraintAggregator;
+#endif
   friend class MPObjective;
 
  protected:
@@ -1316,9 +1755,15 @@ class MPSolverInterface {
   // Optimization direction.
   bool maximize_;
 
-  // Index in MPSolver::variables_ of last constraint extracted.
+  // Index in MPSolver::constraints_ of last constraint extracted.
   int last_constraint_index_;
-  // Index in MPSolver::constraints_ of last variable extracted.
+
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS
+  // Index in MPSolver::sos_constraints_
+  int last_sos_constraint_index_;
+#endif
+
+  // Index in MPSolver::variables_ of last variable extracted.
   int last_variable_index_;
 
   // The value of the objective function.
@@ -1337,6 +1782,10 @@ class MPSolverInterface {
   virtual void ExtractNewVariables() = 0;
   // Extracts the constraints that have not been extracted yet.
   virtual void ExtractNewConstraints() = 0;
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS
+  // Extracts the SOS constraints that have not been extracted yet.
+  virtual void ExtractNewSOSConstraints();
+#endif
   // Extracts the objective.
   virtual void ExtractObjective() = 0;
   // Resets the extraction information.

--- a/ortools/linear_solver/linear_solver.proto
+++ b/ortools/linear_solver/linear_solver.proto
@@ -99,6 +99,11 @@ message MPConstraintProto {
   optional bool is_lazy = 5 [default = false];
 }
 
+// TO DO (dimitarpg13): implement SOSConstraintProto here
+// 
+//
+//
+
 // This message encodes a partial (or full) assignment of the variables of a
 // MPModelProto problem. The indices in var_index should be unique and valid
 // variable indices of the associated problem.
@@ -120,6 +125,9 @@ message MPModelProto {
 
   // All the constraints appearing in the model.
   repeated MPConstraintProto constraint = 4;
+
+
+  // TO DO (dimitarpg13): add sos_constraint member here
 
   // Name of the model.
   optional string name = 5 [default = ""];

--- a/ortools/linear_solver/model_exporter.cc
+++ b/ortools/linear_solver/model_exporter.cc
@@ -336,6 +336,13 @@ bool MPModelProtoExporter::ExportModelAsLpFormat(bool obfuscated,
     }
   }
 
+
+  // SOS Constraints 
+  // TO DO (dimitarpg13): handle SOS constraints here
+  //
+  //
+
+
   // Bounds
   absl::StrAppend(output, "Bounds\n");
   if (proto_.objective_offset() != 0.0) {
@@ -522,6 +529,11 @@ bool MPModelProtoExporter::ExportModelAsMpsFormat(bool fixed_format,
     absl::StrAppend(output, "ROWS\n", rows_section);
   }
 
+  // SOS Constraints 
+  // TO DO (dimitarpg13): handle SOS constraints here
+  //
+  //
+
   // As the information regarding a column needs to be contiguous, we create
   // a vector associating a variable index to a vector containing the indices
   // of the constraints where this variable appears.
@@ -543,6 +555,11 @@ bool MPModelProtoExporter::ExportModelAsMpsFormat(bool fixed_format,
       }
     }
   }
+
+  // SOS Constraints 
+  // TO DO (dimitarpg13): handle SOS constraints here
+  //
+  //
 
   // COLUMNS section.
   std::string columns_section;
@@ -593,6 +610,11 @@ bool MPModelProtoExporter::ExportModelAsMpsFormat(bool fixed_format,
   if (!ranges_section.empty()) {
     absl::StrAppend(output, "RANGES\n", ranges_section);
   }
+
+  // SOS Constraints 
+  // TO DO (dimitarpg13): handle SOS constraints here
+  //
+  //
 
   // BOUNDS section.
   current_mps_column_ = 0;

--- a/ortools/linear_solver/model_validator.cc
+++ b/ortools/linear_solver/model_validator.cc
@@ -108,8 +108,14 @@ std::string FindErrorInMPConstraint(const MPConstraintProto& constraint,
   return std::string();
 }
 
+//TO DO (dimitarpg13): create 
+//std::string FindErrorInSOSConstraint(const SOSConstraintProto& constraint,
+//                                    std::vector<bool>* var_mask)
+
+
 std::string FindErrorInSolutionHint(const PartialVariableAssignment& solution_hint,
                                int num_vars) {
+
   if (solution_hint.var_index_size() != solution_hint.var_value_size()) {
     return absl::StrCat("var_index_size() != var_value_size() [",
                         solution_hint.var_index_size(), " VS ",
@@ -190,6 +196,10 @@ std::string FindErrorInMPModelProto(const MPModelProto& model) {
     }
   }
 
+  //TO DO (dimitarpg13): validate SOS constraints here
+  //
+  //
+
   // Validate the solution hint.
   error = FindErrorInSolutionHint(model.solution_hint(), num_vars);
   if (!error.empty()) {
@@ -260,6 +270,10 @@ std::string FindFeasibilityErrorInSolutionHint(const MPModelProto& model,
           absl::LegacyPrecision(tolerance), ".");
     }
   }
+
+  // TO DO (dimitarpg13): write a code which checks if all SOS constraints are satisfiable
+  //
+  //
 
   return "";
 }

--- a/ortools/linear_solver/python/linear_solver.i
+++ b/ortools/linear_solver/python/linear_solver.i
@@ -29,7 +29,8 @@
 // TODO(user): test all the APIs that are currently marked as 'untested'.
 
 %include "ortools/base/base.i"
-
+%include "ortools/base/optimization_suites.h"
+%include "std_vector.i"
 
 // We need to forward-declare the proto here, so that the PROTO_* macros
 // involving them work correctly. The order matters very much: this declaration
@@ -39,6 +40,11 @@ class MPModelProto;
 class MPModelRequest;
 class MPSolutionResponse;
 }  // namespace operations_research
+
+namespace std {
+%template(Vector) vector < double >;
+%template(Matrix)  vector < vector < double > >;
+}
 
 %{
 #include "ortools/linear_solver/linear_solver.h"
@@ -196,7 +202,6 @@ from ortools.linear_solver.linear_solver_natural_api import VariableExpr
 %unignore operations_research::MPSolver::CPLEX_LINEAR_PROGRAMMING;
 %unignore operations_research::MPSolver::CPLEX_MIXED_INTEGER_PROGRAMMING;
 
-
 // Expose the MPSolver::ResultStatus enum.
 %unignore operations_research::MPSolver::ResultStatus;
 %unignore operations_research::MPSolver::OPTIMAL;
@@ -218,6 +223,7 @@ from ortools.linear_solver.linear_solver_natural_api import VariableExpr
 %rename (Constraint) operations_research::MPSolver::MakeRowConstraint();
 %rename (Constraint) operations_research::MPSolver::MakeRowConstraint(double, double, const std::string&);
 %rename (Constraint) operations_research::MPSolver::MakeRowConstraint(const std::string&);
+
 %unignore operations_research::MPSolver::~MPSolver;
 %unignore operations_research::MPSolver::Solve;
 %unignore operations_research::MPSolver::VerifySolution;
@@ -250,6 +256,78 @@ from ortools.linear_solver.linear_solver_natural_api import VariableExpr
 %unignore operations_research::MPSolver::AT_UPPER_BOUND;
 %unignore operations_research::MPSolver::FIXED_VALUE;  // No unit test
 %unignore operations_research::MPSolver::BASIC;
+
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS 
+%rename (PwlSolver) operations_research::PWLSolver;
+%rename (PwlSolver) operations_research::PWLSolver::PWLSolver;
+%rename (SosConstraint) operations_research::SOSConstraint;
+%rename (NumSosConstraints) operations_research::MPSolver::NumSOSConstraints; 
+%rename (SosConstraint) operations_research::MPSolver::MakeSOSConstraint(const SOSType);
+%rename (SosConstraint) operations_research::MPSolver::MakeSOSConstraint(const std::string&,
+                                                                         const SOSType);
+%rename (NumOfXPoints) operations_research::PWLSolver::numb_of_x_points();
+%rename (DimOfXPoint) operations_research::PWLSolver::dim_of_x_point();
+%rename (NumConstraints) operations_research::PWLSolver::numb_of_constr();
+%rename (NumRealVariables) operations_research::PWLSolver::numb_of_real_vars();
+%rename (NumVariables) operations_research::PWLSolver::numb_of_vars();
+%rename (Objective) operations_research::PWLSolver::objective;
+%rename (GetVariable) operations_research::PWLSolver::GetVariableOrNull;
+%rename (LookupSosConstraint)
+         operations_research::MPSolver::LookupSOSConstraintOrNull;
+
+%unignore operations_research::PWLSolver::OptimizationSuite;
+%unignore operations_research::PWLSolver::SCIP;
+%unignore operations_research::PWLSolver::CBC;
+%unignore operations_research::PWLSolver::GLPK;
+%unignore operations_research::PWLSolver::GUROBI;
+%unignore operations_research::PWLSolver::CPLEX;
+
+%unignore operations_research::PWLSolver::VectorParameterType;
+%unignore operations_research::PWLSolver::bVector;
+%unignore operations_research::PWLSolver::cVector;
+%unignore operations_research::PWLSolver::dVector;
+
+%unignore operations_research::PWLSolver::MatrixParameterType;
+%unignore operations_research::PWLSolver::AMatrix;
+%unignore operations_research::PWLSolver::BMatrix;
+
+// Expose the PWLSolver's basic API.
+%unignore operations_research::PWLSolver::~PWLSolver;
+%unignore operations_research::PWLSolver::Solve;
+%unignore operations_research::PWLSolver::VerifySolution;
+%unignore operations_research::PWLSolver::infinity;
+%unignore operations_research::PWLSolver::set_time_limit;  // No unit test
+%unignore operations_research::PWLSolver::SetXValues;
+%unignore operations_research::PWLSolver::SetYValues;
+%unignore operations_research::PWLSolver::SetParameter;
+
+#ifndef NDEBUG
+%unignore operations_research::PWLSolver::PrintXValues;
+%unignore operations_research::PWLSolver::PrintYValues;
+%unignore operations_research::PWLSolver::PrintAValues;
+%unignore operations_research::PWLSolver::PrintBValues;
+%unignore operations_research::PWLSolver::PrintbValues;
+%unignore operations_research::PWLSolver::PrintcValues;
+%unignore operations_research::PWLSolver::PrintdValues;
+#endif
+
+// Expose some of the more advanced PWLSolver API.
+%unignore operations_research::PWLSolver::Clear;  // No unit test
+%unignore operations_research::PWLSolver::NextSolution;
+
+%unignore operations_research::MPSolver::SOSType;
+%unignore operations_research::MPSolver::SOS1;
+%unignore operations_research::MPSolver::SOS2;
+
+// SOSConstraint: writer API.
+%unignore operations_research::SOSConstraint::SetCoefficient;
+
+// SOSConstraint: reader API.
+%unignore operations_research::SOSConstraint::GetCoefficient;
+%unignore operations_research::SOSConstraint::GetSOSType;
+%unignore operations_research::SOSConstraint::name;
+%unignore operations_research::SOSConstraint::index;
+#endif
 
 // MPVariable: reader API.
 %unignore operations_research::MPVariable::solution_value;

--- a/ortools/linear_solver/scip_interface.cc
+++ b/ortools/linear_solver/scip_interface.cc
@@ -60,6 +60,9 @@ class SCIPInterface : public MPSolverInterface {
   void SetConstraintBounds(int row_index, double lb, double ub) override;
 
   void AddRowConstraint(MPConstraint* ct) override;
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS
+  void AddSOSConstraint(SOSConstraint* const ct) override;
+#endif
   void AddVariable(MPVariable* var) override;
   void SetCoefficient(MPConstraint* constraint, const MPVariable* variable,
                       double new_value, double old_value) override;
@@ -308,6 +311,13 @@ void SCIPInterface::ClearObjective() {
 void SCIPInterface::AddRowConstraint(MPConstraint* ct) {
   sync_status_ = MUST_RELOAD;
 }
+
+#ifdef MIP_SOLVER_WITH_SOS_CONSTRAINTS
+//TO DO (dimitarpg13): SOS constraints need to be implemented
+void SCIPInterface::AddSOSConstraint(SOSConstraint* ct) {
+  sync_status_ = MUST_RELOAD;
+}
+#endif
 
 void SCIPInterface::AddVariable(MPVariable* var) { sync_status_ = MUST_RELOAD; }
 

--- a/ortools/lp_data/proto_utils.cc
+++ b/ortools/lp_data/proto_utils.cc
@@ -45,6 +45,8 @@ void LinearProgramToMPModelProto(const LinearProgram& input,
       constraint->add_coefficient(e.coefficient());
     }
   }
+  //TO DO (dimitarpg13): handle SOSConstraintProto here
+  //
 }
 
 // Converts a MPModelProto to a LinearProgram.
@@ -78,6 +80,9 @@ void MPModelProtoToLinearProgram(const MPModelProto& input,
                              cst.coefficient(k));
     }
   }
+  //TO DO (dimitarpg13): read the SOS constraints from the input and save their
+  //coefficients to the output
+  //
 }
 
 }  // namespace glop

--- a/ortools/sat/lp_utils.cc
+++ b/ortools/sat/lp_utils.cc
@@ -40,6 +40,7 @@ using glop::RowIndex;
 using glop::kInfinity;
 
 using operations_research::MPConstraintProto;
+//TO DO (dimitarpg13): add ref to SOSConstraintProto here
 using operations_research::MPModelProto;
 using operations_research::MPVariableProto;
 
@@ -183,6 +184,10 @@ bool ConvertMPModelProtoToCpModelProto(const MPModelProto& mp_model,
     // solver!
     if (arg->vars_size() == 0) constraint->Clear();
   }
+
+  //TO DO (dimitarpg13): add the SOS constraints here
+  //
+  //
 
   // Display the error/scaling without taking into account the objective first.
   VLOG(1) << "Maximum constraint coefficient relative error: "
@@ -374,6 +379,10 @@ bool ConvertBinaryMPModelProtoToBooleanProblem(const MPModelProto& mp_model,
       }
     }
   }
+
+  //TO DO (dimitarpg13): add all SOS constraints here
+  //
+  //
 
   // Display the error/scaling without taking into account the objective first.
   LOG(INFO) << "Maximum constraint relative error: " << max_relative_error;

--- a/ortools/sat/optimization.cc
+++ b/ortools/sat/optimization.cc
@@ -1914,6 +1914,10 @@ SatSolver::Status MinimizeWithHittingSetAndLazyEncoding(
     }
   }
 
+  // TO DO (dimitarpg13): add the corresponding SOS constraint to hs_model here.
+  //
+  //
+
   // Returns MODEL_SAT if we found the optimal.
   return num_solutions > 0 && result == SatSolver::MODEL_UNSAT
              ? SatSolver::MODEL_SAT


### PR DESCRIPTION
Adds a PWL Solver which optimizes a form including a piecewise linear (discrete) function. The PWL Solver is a wrapper around MIP solver which uses a SOS constraint. For now implemented only with Gurobi interface.

Things which need to be done
1. Implement the PWL Solver and SOS constraints with CBC , GLPK, SCIP and CPLEX.
2. finish the persisting to the Data model of the newly added to or-tools SOSConstraint. This will involve modifying the proto specification files of the model.

