### PR TITLE
Added .NET Framework 4.6.1 as second target framework for win-x64 runtime project

### DIFF
--- a/ortools/dotnet/Google.OrTools.runtime.win-x64/Google.OrTools.runtime.win-x64.csproj.in
+++ b/ortools/dotnet/Google.OrTools.runtime.win-x64/Google.OrTools.runtime.win-x64.csproj.in
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <AssemblyName>Google.OrTools</AssemblyName>
     <Version>@PROJECT_VERSION@</Version>


### PR DESCRIPTION
Idea is to solve .NET 4.6.1 compatibility problems and therefore #1221 