### PR TITLE
fix: update cmake protobuf version

### DIFF
--- a/cmake/dependencies/CMakeLists.txt
+++ b/cmake/dependencies/CMakeLists.txt
@@ -102,7 +102,7 @@ if(BUILD_Protobuf)
     REPOSITORY
       "https://github.com/protocolbuffers/protobuf.git"
     TAG
-      "v3.7.1"
+      "v3.8.0"
     CMAKE_ARGS
       "SOURCE_SUBDIR cmake"
   )


### PR DESCRIPTION
This aligns the version of protobuf used by cmake to the same as what is defined in Dependencies.txt. Currently using BUILD_DEPS=ON with cmake builds the wrong version of protobuf (3.7.1) and so when the resulting ortools binary is used, protobuf throws an error due to a mismatch between the version of protoc used to generate the protobuf source files and the runtime version.