### PR TITLE
changed deprecated method ramdon_integers for randint

### DIFF
--- a/examples/python/cvrptw_plot.py
+++ b/examples/python/cvrptw_plot.py
@@ -127,7 +127,7 @@ class Customers():
 
         # The customers demand min_tw to max_tw hour time window for each
         # delivery
-        time_windows = np.random.random_integers(min_tw * 3600, max_tw * 3600,
+        time_windows = np.random.randint(min_tw * 3600, max_tw * 3600,
                                                  num_stops)
         # The last time a delivery window can start
         latest_time = self.time_horizon - time_windows
@@ -135,7 +135,7 @@ class Customers():
         stop_times = [None for o in time_windows]
         # Make random timedeltas, nominaly from the start of the day.
         for idx in range(self.number):
-            stime = int(np.random.random_integers(0, latest_time[idx]))
+            stime = int(np.random.randint(0, latest_time[idx]))
             start_times[idx] = timedelta(seconds=stime)
             stop_times[idx] = (
                 start_times[idx] + timedelta(seconds=int(time_windows[idx])))
@@ -752,3 +752,4 @@ def main():
 
 if __name__ == '__main__':
     main()
+    


### PR DESCRIPTION
According to numpy documentation, the method [random_integers](https://docs.scipy.org/doc/numpy/reference/random/generated/numpy.random.mtrand.RandomState.random_integers.html) is deprecated and randint should be used instead

> This function has been deprecated. Use randint instead.