### PR TITLE
Support pairs with disjunctions in local search operators

### DIFF
--- a/ortools/constraint_solver/routing_neighborhoods.cc
+++ b/ortools/constraint_solver/routing_neighborhoods.cc
@@ -102,18 +102,22 @@ MakePairActiveOperator::MakePairActiveOperator(
       delivery_disjunction_index_(0),
       pairs_(pairs) {}
 
-int MakePairActiveOperator::FindNextPair(int start_pair_index) {
+int MakePairActiveOperator::FindNextPair(int pair_index) {
   bool all_inactive = false;
-  for (;!all_inactive && start_pair_index < pairs_.size(); ++start_pair_index) {
+  for (;pair_index < pairs_.size(); ++pair_index) {
     all_inactive = true;
-    for (auto index : pairs_[start_pair_index].first) {
+    for (auto index : pairs_[pair_index].first) {
       all_inactive = all_inactive && IsInactive(index);
     }
-    for (auto index : pairs_[start_pair_index].second) {
+    for (auto index : pairs_[pair_index].second) {
       all_inactive = all_inactive && IsInactive(index);
+    }
+    if (all_inactive) {
+      return pair_index;
     }
   }
-  return start_pair_index;
+
+  return pairs_.size();
 }
 
 bool MakePairActiveOperator::MakeOneNeighbor() {

--- a/ortools/constraint_solver/routing_neighborhoods.h
+++ b/ortools/constraint_solver/routing_neighborhoods.h
@@ -148,8 +148,8 @@ class MakePairInactiveOperator : public PathWithPreviousNodesOperator {
  private:
   void OnNodeInitialization() override;
 
-  absl::flat_hash_map<int64, int64> active_pair_nodes_;
-  RoutingIndexPairs pairs_;
+  std::vector<int> pairs_;
+  RoutingIndexPairs index_pairs_;
 };
 
 /// Operator which moves a pair of nodes to another position where the first

--- a/ortools/constraint_solver/routing_neighborhoods.h
+++ b/ortools/constraint_solver/routing_neighborhoods.h
@@ -146,7 +146,7 @@ class MakePairInactiveOperator : public PathWithPreviousNodesOperator {
   std::string DebugString() const override { return "MakePairInActive"; }
 
  private:
-  std::vector<int> pairs_;
+  absl::flat_hash_map<int64, const std::vector<int64>*> pairs_;
 };
 
 /// Operator which moves a pair of nodes to another position where the first

--- a/ortools/constraint_solver/routing_neighborhoods.h
+++ b/ortools/constraint_solver/routing_neighborhoods.h
@@ -105,11 +105,12 @@ class MakePairActiveOperator : public PathOperator {
                          std::function<int(int64)> start_empty_path_class,
                          const RoutingIndexPairs& pairs);
   ~MakePairActiveOperator() override {}
-  bool MakeNextNeighbor(Assignment* delta, Assignment* deltadelta) override;
   bool MakeNeighbor() override;
   std::string DebugString() const override { return "MakePairActive"; }
 
  protected:
+  bool MakeOneNeighbor() override;
+
   bool OnSamePathAsPreviousBase(int64 base_index) override {
     /// Both base nodes have to be on the same path since they represent the
     /// nodes after which unactive node pairs will be moved.
@@ -125,7 +126,11 @@ class MakePairActiveOperator : public PathOperator {
  private:
   void OnNodeInitialization() override;
 
+  int FindNextPair(int start_pair_index);
+
   int inactive_pair_;
+  int pickup_disjunction_index_;
+  int delivery_disjunction_index_;
   RoutingIndexPairs pairs_;
 };
 

--- a/ortools/constraint_solver/routing_neighborhoods.h
+++ b/ortools/constraint_solver/routing_neighborhoods.h
@@ -180,9 +180,10 @@ class PairRelocateOperator : public PathWithPreviousNodesOperator {
 
  private:
   bool RestartAtPathStartOnSynchronize() override { return true; }
+  void OnNodeInitialization() override;
 
   std::vector<int> pairs_;
-  std::vector<bool> is_first_;
+  RoutingIndexPairs index_pairs_;
   static const int kPairFirstNode = 0;
   static const int kPairFirstNodeDestination = 1;
   static const int kPairSecondNodeDestination = 2;
@@ -202,7 +203,10 @@ class LightPairRelocateOperator : public PathWithPreviousNodesOperator {
   }
 
  private:
+  void OnNodeInitialization() override;
+
   std::vector<int> pairs_;
+  RoutingIndexPairs index_pairs_;
 };
 
 /// Operator which exchanges the position of two pairs; for both pairs the first
@@ -226,9 +230,10 @@ class PairExchangeOperator : public PathWithPreviousNodesOperator {
   bool RestartAtPathStartOnSynchronize() override { return true; }
   bool GetPreviousAndSibling(int64 node, int64* previous, int64* sibling,
                              int64* sibling_previous) const;
+  void OnNodeInitialization() override;
 
   std::vector<int> pairs_;
-  std::vector<bool> is_first_;
+  RoutingIndexPairs index_pairs_;
 };
 
 /// Operator which exchanges the paths of two pairs (path have to be different).
@@ -269,9 +274,10 @@ class PairExchangeRelocateOperator : public PathWithPreviousNodesOperator {
                 int64 prev[2][2]);
   bool LoadAndCheckDest(int pair, int node, int64 base_node, int64 nodes[2][2],
                         int64 dest[2][2]) const;
+  void OnNodeInitialization() override;
 
   std::vector<int> pairs_;
-  std::vector<bool> is_first_;
+  RoutingIndexPairs index_pairs_;
   static const int kFirstPairFirstNode = 0;
   static const int kSecondPairFirstNode = 1;
   static const int kFirstPairFirstNodeDestination = 2;
@@ -347,6 +353,7 @@ class IndexPairSwapActiveOperator : public PathWithPreviousNodesOperator {
 
   int inactive_node_;
   std::vector<int> pairs_;
+  RoutingIndexPairs index_pairs_;
 };
 
 /// RelocateExpensiveChain

--- a/ortools/constraint_solver/routing_neighborhoods.h
+++ b/ortools/constraint_solver/routing_neighborhoods.h
@@ -146,7 +146,10 @@ class MakePairInactiveOperator : public PathWithPreviousNodesOperator {
   std::string DebugString() const override { return "MakePairInActive"; }
 
  private:
-  absl::flat_hash_map<int64, const std::vector<int64>*> pairs_;
+  void OnNodeInitialization() override;
+
+  absl::flat_hash_map<int64, int64> active_pair_nodes_;
+  RoutingIndexPairs pairs_;
 };
 
 /// Operator which moves a pair of nodes to another position where the first


### PR DESCRIPTION
This PR adds support for pairs with disjunctions in MakePairActiveOperator, MakePairInactiveOperator, PairRelocateOperator, LightPairRelocateOperator, PairExchangeOperator, PairExchangeRelocateOperator and IndexPairSwapActiveOperator. The existing implementation does not support disjunctions and only considers the first alternative of each disjunction, with the changes in the PR, all alternatives are considered.

This has been tested against a number of real-world test cases and achieves significant solution quality improvements.