### PR TITLE
Expose swap index pair as its own local search operator

### DIFF
--- a/ortools/constraint_solver/routing.cc
+++ b/ortools/constraint_solver/routing.cc
@@ -4086,6 +4086,10 @@ void RoutingModel::CreateNeighborhoodOperators(
       CostsAreHomogeneousAcrossVehicles() ? empty : vehicle_vars_,
       vehicle_start_class_callback_,
       [this](int64 from, int64 to) { return GetHomogeneousCost(from, to); });
+  local_search_operators_[SWAP_INDEX_PAIR] = SwapIndexPair(
+      solver_.get(), nexts_,
+      CostsAreHomogeneousAcrossVehicles() ? empty : vehicle_vars_,
+      pickup_delivery_pairs_);
   local_search_operators_[NODE_PAIR_SWAP] = solver_->ConcatenateOperators(
       {IndexPairSwapActive(
            solver_.get(), nexts_,
@@ -4163,6 +4167,7 @@ LocalSearchOperator* RoutingModel::GetNeighborhoodOperators(
     }
     CP_ROUTING_PUSH_OPERATOR(EXCHANGE_PAIR, exchange_pair, operators);
     CP_ROUTING_PUSH_OPERATOR(NODE_PAIR_SWAP, node_pair_swap_active, operators);
+    CP_ROUTING_PUSH_OPERATOR(SWAP_INDEX_PAIR, swap_index_pair, operators);
     CP_ROUTING_PUSH_OPERATOR(RELOCATE_SUBTRIP, relocate_subtrip, operators);
     CP_ROUTING_PUSH_OPERATOR(EXCHANGE_SUBTRIP, exchange_subtrip, operators);
   }

--- a/ortools/constraint_solver/routing.h
+++ b/ortools/constraint_solver/routing.h
@@ -1282,6 +1282,7 @@ class RoutingModel {
     SWAP_ACTIVE,
     EXTENDED_SWAP_ACTIVE,
     NODE_PAIR_SWAP,
+    SWAP_INDEX_PAIR,
     PATH_LNS,
     FULL_PATH_LNS,
     TSP_LNS,

--- a/ortools/constraint_solver/routing_parameters.cc
+++ b/ortools/constraint_solver/routing_parameters.cc
@@ -76,6 +76,7 @@ RoutingSearchParameters DefaultRoutingSearchParameters() {
       "  use_swap_active: BOOL_TRUE"
       "  use_extended_swap_active: BOOL_FALSE"
       "  use_node_pair_swap_active: BOOL_TRUE"
+      "  use_swap_index_pair: BOOL_FALSE"
       "  use_path_lns: BOOL_FALSE"
       "  use_full_path_lns: BOOL_FALSE"
       "  use_tsp_lns: BOOL_FALSE"

--- a/ortools/constraint_solver/routing_parameters.proto
+++ b/ortools/constraint_solver/routing_parameters.proto
@@ -284,6 +284,17 @@ message RoutingSearchParameters {
     // of nodes) are:
     //   1 -> [4] -> [5] -> 3 with 2 inactive
     OptionalBoolean use_node_pair_swap_active = 20;
+    // Operator which iterates through each alternative of a set of pairs. If a
+    // pair has n and m alternatives, n.m alternatives will be explored.
+    // Possible neighbors for the path 1 -> A -> a -> 2 (where (1, 2) are first and
+    // last nodes of a path and A has B, C as alternatives and a has b as
+    // alternative):
+    // 1 -> A -> [b] -> 2
+    // 1 -> [B] -> a -> 2
+    // 1 -> [B] -> [b] -> 2
+    // 1 -> [C] -> a -> 2
+    // 1 -> [C] -> [b] -> 2
+    OptionalBoolean use_swap_index_pair = 27;
     // --- Large neighborhood search operators ---
     // Operator which relaxes two sub-chains of three consecutive arcs each.
     // Each sub-chain is defined by a start node and the next three arcs. Those


### PR DESCRIPTION
This PR exposes "swap index pair" as its own independent local search operator. It currently exists as part of "node pair swap".

I have experienced significant speedups by using "swap index pair" by itself and not "node pair swap". "node pair swap" seems to be quite computationally expensive operator and "swap index pair" much cheaper while still being powerful as a search operator.

The use case this has been tested under is pickup-delivery with time windows and capacity where each pickup and delivery have multiple options (disjunctions).