### PR TITLE
Change the order of variable declaration to save memory

### DIFF
--- a/ortools/linear_solver/linear_solver.h
+++ b/ortools/linear_solver/linear_solver.h
@@ -1088,25 +1088,25 @@ class MPVariable {
       : index_(index),
         lb_(lb),
         ub_(ub),
-        integer_(integer),
         name_(name.empty() ? absl::StrFormat("auto_v_%09d", index) : name),
         solution_value_(0.0),
         reduced_cost_(0.0),
-        interface_(interface_in) {}
+        interface_(interface_in),
+	integer_(integer){}
 
   void set_solution_value(double value) { solution_value_ = value; }
   void set_reduced_cost(double reduced_cost) { reduced_cost_ = reduced_cost; }
 
  private:
   const int index_;
+  int branching_priority_ = 0;
   double lb_;
   double ub_;
-  bool integer_;
   const std::string name_;
   double solution_value_;
   double reduced_cost_;
-  int branching_priority_ = 0;
   MPSolverInterface* const interface_;
+  bool integer_;
   DISALLOW_COPY_AND_ASSIGN(MPVariable);
 };
 
@@ -1230,8 +1230,8 @@ class MPConstraint {
         lb_(lb),
         ub_(ub),
         name_(name.empty() ? absl::StrFormat("auto_c_%09d", index) : name),
-        is_lazy_(false),
         indicator_variable_(nullptr),
+        is_lazy_(false),
         dual_value_(0.0),
         interface_(interface_in) {}
 
@@ -1256,15 +1256,15 @@ class MPConstraint {
   // Name.
   const std::string name_;
 
-  // True if the constraint is "lazy", i.e. the constraint is added to the
-  // underlying Linear Programming solver only if it is violated.
-  // By default this parameter is 'false'.
-  bool is_lazy_;
-
   // If given, this constraint is only active if `indicator_variable_`'s value
   // is equal to `indicator_value_`.
   const MPVariable* indicator_variable_;
   bool indicator_value_;
+
+  // True if the constraint is "lazy", i.e. the constraint is added to the
+  // underlying Linear Programming solver only if it is violated.
+  // By default this parameter is 'false'.
+  bool is_lazy_;
 
   double dual_value_;
   MPSolverInterface* const interface_;


### PR DESCRIPTION
Changing the order of variable declaration we can waste less memory on memory alignment generated by the compiler.
In one test problem with 9,320,328 variables and 1,107 constraints it saves 10% of memory usage.