### PR TITLE
Xpress interface

### DIFF
--- a/ortools/linear_solver/xpress_interface.cc
+++ b/ortools/linear_solver/xpress_interface.cc
@@ -1294,9 +1294,7 @@ namespace operations_research {
 
 		// Set log level.
 		CHECK_STATUS(
-			XPRSsetintcontrol(mLp, XPRS_LPLOG, quiet() ? 0 : 1));
-		CHECK_STATUS(
-			XPRSsetintcontrol(mLp, XPRS_MIPLOG, quiet() ? 0 : 1));
+			XPRSsetintcontrol(mLp, XPRS_OUTPUTLOG, quiet() ? 0 : 1));
 
 		// Set parameters.
 		// NOTE: We must invoke SetSolverSpecificParametersAsString() _first_.
@@ -1336,7 +1334,7 @@ namespace operations_research {
 		}
 
 		// Disable screen output right after solve
-		XPRSsetintcontrol(mLp, XPRS_LPLOG, 0);
+		XPRSsetintcontrol(mLp, XPRS_OUTPUTLOG, 0);
 
 		if (status) {
 			VLOG(1) << absl::StrFormat("Failed to optimize MIP. Error %d", status);

--- a/ortools/linear_solver/xpress_interface.cc
+++ b/ortools/linear_solver/xpress_interface.cc
@@ -1214,7 +1214,10 @@ namespace operations_research {
 			CHECK_STATUS(XPRSsetintcontrol(mLp, XPRS_SCALING, 0));
 			break;
 		case MPSolverParameters::SCALING_ON:
-			CHECK_STATUS(XPRSsetintcontrol(mLp, XPRS_SCALING, 1));
+                  	CHECK_STATUS(XPRSsetdefaultcontrol(mLp, XPRS_SCALING));
+                        // In Xpress, scaling is not  a binary on/off control, but a bit vector control
+                        // setting it to 1 would only enable bit 1. Instead we reset it to its default (163 for the current version 8.6)
+                        // Alternatively, we could call CHECK_STATUS(XPRSsetintcontrol(mLp, XPRS_SCALING, 163));
 			break;
 		}
 	}

--- a/ortools/linear_solver/xpress_interface.cc
+++ b/ortools/linear_solver/xpress_interface.cc
@@ -1305,15 +1305,17 @@ namespace operations_research {
 		SetParameters(param);
 		if (solver_->time_limit()) {
 			VLOG(1) << "Setting time limit = " << solver_->time_limit() << " ms.";
+                        // In Xpress, a time limit should usually have a negative sign. With a positive sign,
+                        // the solver will only stop when a solution has been found
 			CHECK_STATUS(
-				XPRSsetdblcontrol(mLp, XPRS_MAXTIME, solver_->time_limit() * 1e-3));
+				XPRSsetdblcontrol(mLp, XPRS_MAXTIME, -1.0*solver_->time_limit_in_secs()));
 		}
 
 		// Solve.
 		// Do not CHECK_STATUS here since some errors (for example CPXERR_NO_MEMORY)
 		// still allow us to query useful information.
 		timer.Restart();
-		
+
 		int xpressstat = 0;
 		if (mMip) {
 			if (this->maximize_)


### PR DESCRIPTION
This includes a few fixes to the use of Xpress controls (which in some cases differ to the usage in other solvers).

Namely, time limits should usually be given as negative numbers (positive numbers will only cause a stop when a solution has already been found,
scaling is a bit field control, not an on/off switch, and
outputlog is the control to use for deactivating all output. Lplog and miplog are merely there to change frequency and style of output.

