### PR TITLE
Fix zlib patch directory with add_directory

### DIFF
--- a/cmake/dependencies/CMakeLists.txt
+++ b/cmake/dependencies/CMakeLists.txt
@@ -40,7 +40,7 @@ if(BUILD_ZLIB)
     TAG
       "v1.2.11"
     APPLY_PATCH
-      "${CMAKE_SOURCE_DIR}/patches/ZLIB.patch"
+      "${CMAKE_CURRENT_SOURCE_DIR}/../../patches/ZLIB.patch"
  )
 endif()
 


### PR DESCRIPTION
When a project is added using `add_directory`, `CMAKE_SOURCE_DIR` is the source directory of the parent project instead of the ortools directory.

This should fix #1658. We made this change to our fork (which is used as a subproject) when we had similar issues, however I can't recall if this problem was the exact same one.