### PR TITLE
Lock abseil-cpp to 20190808

### DIFF
--- a/cmake/dependencies/CMakeLists.txt
+++ b/cmake/dependencies/CMakeLists.txt
@@ -54,7 +54,7 @@ if(BUILD_absl)
     REPOSITORY
       "https://github.com/abseil/abseil-cpp.git"
     TAG
-      "master"
+      "aa844899c937bde5d2b24f276b59997e5b668bde"
  )
 endif()
 


### PR DESCRIPTION
This commit locks abseil-cpp to the latest tag, 20190808.

Recent commits to `master` in abseil-cpp result in build failures, for example on Travis CI:
https://travis-ci.org/google/or-tools/jobs/615294753

```
In file included from /home/travis/build/google/or-tools/ortools/sat/linear_programming_constraint.cc:26:0:
/home/travis/build/google/or-tools/ortools/base/int128.h:31:7: error: redefinition of ‘class absl::int128’
 class int128 {
       ^
```