### PR TITLE
Typo fixes on cvrptw python example

### DIFF
--- a/examples/python/cvrptw_plot.py
+++ b/examples/python/cvrptw_plot.py
@@ -337,15 +337,15 @@ class Customers():
             speed_kmph: the average speed in km/h
 
         Returns:
-            function [tranit_time_return(a, b)]: A function that takes the
+            function [transit_time_return(a, b)]: A function that takes the
                 from/a node index and the to/b node index and returns the
-                tranit time from a to b.
+                transit time from a to b.
         """
 
-        def tranit_time_return(a, b):
+        def transit_time_return(a, b):
             return (self.distmat[a][b] / (speed_kmph * 1.0 / 60**2))
 
-        return tranit_time_return
+        return transit_time_return
 
 
 class Vehicles():
@@ -361,13 +361,13 @@ class Vehicles():
 
     Note:
         If numpy arrays are given for capacity and cost, then they must be of
-        the same length, and the number of vehicles are infered from them.
-        If scalars are given, the fleet is homogenious, and the number of
-        vehicles is determied by number.
+        the same length, and the number of vehicles are inferred from them.
+        If scalars are given, the fleet is homogeneous, and the number of
+        vehicles is determined by number.
 
     Args: capacity (scalar or numpy array): The integer capacity of demand
     units.  cost (scalar or numpy array): The fixed cost of the vehicle.  number
-    (Optional [int]): The number of vehicles in a homogenious fleet.
+    (Optional [int]): The number of vehicles in a homogeneous fleet.
   """
 
     def __init__(self, capacity=100, cost=100, number=None):
@@ -588,7 +588,7 @@ def main():
     # Create a list of inhomgenious vehicle capacities as integer units.
     capacity = [50, 75, 100, 125, 150, 175, 200, 250]
 
-    # Create a list of inhomogenious fixed vehicle costs.
+    # Create a list of inhomogeneous fixed vehicle costs.
     cost = [int(100 + 2 * np.sqrt(c)) for c in capacity]
 
     # Create a set of vehicles, the number set by the length of capacity.
@@ -657,11 +657,11 @@ def main():
 
     tot_time_fn_index = routing.RegisterTransitCallback(tot_time_fn)
 
-    # Set the cost function (distance callback) for each arc, homogenious for
+    # Set the cost function (distance callback) for each arc, homogeneous for
     # all vehicles.
     routing.SetArcCostEvaluatorOfAllVehicles(dist_fn_index)
 
-    # Set vehicle costs for each vehicle, not homogenious.
+    # Set vehicle costs for each vehicle, not homogeneous.
     for veh in vehicles.vehicles:
         routing.SetFixedCostOfVehicle(veh.cost, int(veh.index))
 


### PR DESCRIPTION
File `examples/python/cvrptw_plot.py` contains a few typos. With this PR I fix them.