### PR TITLE
Correct a Java SWIG type mapping that produces SEGV crashes

### DIFF
--- a/ortools/util/java/vector.i
+++ b/ortools/util/java/vector.i
@@ -153,17 +153,21 @@ VECTOR_AS_JAVA_ARRAY(double, double, Double);
 %typemap(jtype) std::vector<CType*> "JavaType[]"
 %typemap(jni) std::vector<CType*> "jobjectArray"
 %typemap(in) std::vector<CType*> (std::vector<CType*> result) {
-  jclass object_class = jenv->FindClass("JavaPackage/JavaType");
+  std::string java_class_path = #JavaPackage "/" #JavaType;
+  jclass object_class = jenv->FindClass(java_class_path.c_str());
   if (nullptr == object_class)
     return $null;
-  jmethodID method_id = jenv->GetStaticMethodID(
-    object_class, "getCPtr", "(LJavaPackage/JavaType;)J");
+  jmethodID method_id =
+      jenv->GetStaticMethodID(object_class,
+                              "getCPtr",
+                              std::string("(L" + java_class_path + ";)J").c_str());
   assert(method_id != nullptr);
   for (int i = 0; i < jenv->GetArrayLength($input); i++) {
     jobject elem = jenv->GetObjectArrayElement($input, i);
     jlong ptr_value = jenv->CallStaticLongMethod(object_class, method_id, elem);
-    $1.push_back(CastOp(CType, ptr_value));
+    result.push_back(CastOp(CType, ptr_value));
   }
+  $1 = result;
 }
 %enddef  // CONVERT_VECTOR_WITH_CAST
 


### PR DESCRIPTION
Whilst attempting to use dimension breaks via Java SWIG bindings I encountered SEGV crashes.

Below is a very simple code example that exhibits the SEGV crashes.

```java
package tmp;

import com.google.ortools.constraintsolver.IntervalVar;
import com.google.ortools.constraintsolver.RoutingDimension;
import com.google.ortools.constraintsolver.RoutingIndexManager;
import com.google.ortools.constraintsolver.RoutingModel;

public class Tmp {
    static {
        System.loadLibrary("jniortools");
    }

    public static void main(String[] args) {
        RoutingIndexManager manager = new RoutingIndexManager(2, 1, new int[]{0}, new int[]{1});
        RoutingModel model = new RoutingModel(manager);
        model.addConstantDimension(0, 0, false, "tmp");
        RoutingDimension dimension = model.getMutableDimension("tmp");
        // The line below causes the SEGV
        dimension.setBreakIntervalsOfVehicle(new IntervalVar[]{}, 0, -1, -1);
    }
}
```
This changeset aims to correct the java swig in type maps for std::vector<CType*> 