### PR TITLE
feat: Expose the GetStartIndex and GetEndIndex methods of RouteIndexManager for the Java wrapper

### DIFF
--- a/ortools/constraint_solver/java/routing_index_manager.i
+++ b/ortools/constraint_solver/java/routing_index_manager.i
@@ -23,6 +23,8 @@
 DEFINE_INDEX_TYPE_TYPEDEF(operations_research::RoutingNodeIndex,
                           operations_research::RoutingIndexManager::NodeIndex);
 
+%rename (getStartIndex) GetStartIndex;
+%rename (getEndIndex) GetEndIndex;
 %rename (indexToNode) IndexToNode;
 %rename (nodeToIndex) NodeToIndex;
 %rename (nodesToIndices) NodesToIndices;
@@ -34,6 +36,8 @@ DEFINE_INDEX_TYPE_TYPEDEF(operations_research::RoutingNodeIndex,
 namespace operations_research {
 
 %unignore RoutingIndexManager;
+%unignore RoutingIndexManager::GetStartIndex(int);
+%unignore RoutingIndexManager::GetEndIndex(int);
 %unignore RoutingIndexManager::IndexToNode(int64);
 %unignore RoutingIndexManager::NodeToIndex(NodeIndex);
 %unignore RoutingIndexManager::NodesToIndices(const std::vector<NodeIndex>&);


### PR DESCRIPTION
This changeset aims to expose the GetStartIndex and GetEndIndex methods of the RouteIndexManager for the Java language wrapper

<!--
Thank you for submitting a PR!

Please make sure you are targeting the master branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->