### PR TITLE
Add support for additional cost elements

### DIFF
--- a/ortools/constraint_solver/java/routing.i
+++ b/ortools/constraint_solver/java/routing.i
@@ -145,6 +145,7 @@ import java.util.function.LongUnaryOperator;
 %rename (compactAssignment) RoutingModel::CompactAssignment;
 %rename (computeLowerBound) RoutingModel::ComputeLowerBound;
 %rename (costVar) RoutingModel::CostVar;
+%rename (addExtraCost) RoutingModel::AddExtraCost;
 %rename (costsAreHomogeneousAcrossVehicles) RoutingModel::CostsAreHomogeneousAcrossVehicles;
 %rename (debugOutputAssignment) RoutingModel::DebugOutputAssignment;
 %rename (end) RoutingModel::End;

--- a/ortools/constraint_solver/routing.cc
+++ b/ortools/constraint_solver/routing.cc
@@ -2147,6 +2147,9 @@ void RoutingModel::CloseModelWithParameters(
   for (int i = 0; i < same_vehicle_costs_.size(); ++i) {
     cost_elements.push_back(CreateSameVehicleCost(i));
   }
+  // Add in any extra cost elements
+  cost_elements.insert(cost_elements.end(), extra_costs_.begin(), extra_costs_.end());
+
   cost_ = solver_->MakeSum(cost_elements)->Var();
   cost_->set_name("Cost");
 

--- a/ortools/constraint_solver/routing.h
+++ b/ortools/constraint_solver/routing.h
@@ -1072,6 +1072,15 @@ class RoutingModel {
     }
     extra_filters_.push_back(filter);
   }
+  // Adds a custom extra cost to the list of cost elements that make up the
+  // objective value
+  void AddExtraCost(IntVar* intVar) {
+    CHECK(intVar != nullptr);
+    if (closed_) {
+      LOG(WARNING) << "Model is closed, cost addition will be ignored.";
+    }
+    extra_costs_.push_back(intVar);
+  }
 
   /// Model inspection.
   /// Returns the variable index of the starting node of a vehicle route.
@@ -1679,6 +1688,7 @@ class RoutingModel {
   std::vector<LocalSearchFilter*> filters_;
   std::vector<LocalSearchFilter*> feasibility_filters_;
   std::vector<LocalSearchFilter*> extra_filters_;
+  std::vector<IntVar*> extra_costs_;
 #ifndef SWIG
   std::vector<std::pair<IntVar*, int64>> finalizer_variable_cost_pairs_;
   std::vector<std::pair<IntVar*, int64>> finalizer_variable_target_pairs_;


### PR DESCRIPTION
The objective of this pull request is to provide support for adding user-defined cost elements to the cost value.

The primary purpose of this is to support the addition of user-defined cost elements that are accompanied by LocalSearchFilter(s) to direct the local search to find a solution that has the lowest cost value.

<!--
Thank you for submitting a PR!

Please make sure you are targeting the master branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->