### PR TITLE
fix: update the java out type mapping of std::vector<CType*>&

### DIFF
--- a/ortools/util/java/vector.i
+++ b/ortools/util/java/vector.i
@@ -132,16 +132,19 @@ VECTOR_AS_JAVA_ARRAY(double, double, Double);
   $1 = &result;
 }
 %typemap(out) const std::vector<CType*>& {
-  jclass object_class = jenv->FindClass("JavaPackage/JavaType");
+  if (nullptr == $1)
+    return $null;
+  std::string java_class_path = #JavaPackage "/" #JavaType;
+  jclass object_class = jenv->FindClass(java_class_path.c_str());
+  if (nullptr == object_class)
+    return $null;
   $result = jenv->NewObjectArray($1->size(), object_class, 0);
-  if (nullptr != object_class) {
-    jmethodID ctor = jenv->GetMethodID(object_class,"<init>", "(JZ)V");
-    for (int i = 0; i < $1->size(); ++i) {
-      jlong obj_ptr = 0;
-      *((CType **)&obj_ptr) = (*$1)[i];
-      jobject elem = jenv->NewObject(object_class, ctor, obj_ptr, false);
-      jenv->SetObjectArrayElement($result, i, elem);
-    }
+  jmethodID ctor = jenv->GetMethodID(object_class,"<init>", "(JZ)V");
+  for (int i = 0; i < $1->size(); ++i) {
+    jlong obj_ptr = 0;
+    *((CType **)&obj_ptr) = (*$1)[i];
+    jobject elem = jenv->NewObject(object_class, ctor, obj_ptr, false);
+    jenv->SetObjectArrayElement($result, i, elem);
   }
 }
 %typemap(javaout) const std::vector<CType*> & {


### PR DESCRIPTION
This change attempts to resolve the cause of segfault(s) that occur when retrieving the break intervals of a vehicle for a RoutingDimension using the Java SWIG bindings. 

```java
package tmp;

import com.google.ortools.constraintsolver.RoutingDimension;
import com.google.ortools.constraintsolver.RoutingIndexManager;
import com.google.ortools.constraintsolver.RoutingModel;

public class Tmp {
    static {
        System.loadLibrary("jniortools");
    }

    public static void main(String[] args) {
        RoutingIndexManager manager = new RoutingIndexManager(2, 1, new int[]{0}, new int[]{1});
        RoutingModel model = new RoutingModel(manager);
        model.addConstantDimension(0, 0, false, "tmp");
        RoutingDimension dimension = model.getMutableDimension("tmp");
        // The line below causes a segfault 
        dimension.getBreakIntervalsOfVehicle(0);
    }
}
```

<!--
Thank you for submitting a PR!

Please make sure you are targeting the master branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->