### PR TITLE
[Python] store start, end, size in IntervalVar

### DIFF
--- a/ortools/sat/python/cp_model.py
+++ b/ortools/sat/python/cp_model.py
@@ -642,7 +642,7 @@ class IntervalVar(object):
   """
 
     def __init__(self, model, start_index, size_index, end_index,
-                 is_present_index, name):
+                 is_present_index, name, start=None, end=None, size=None):
         self.__model = model
         self.__index = len(model.constraints)
         self.__ct = self.__model.constraints.add()
@@ -653,6 +653,10 @@ class IntervalVar(object):
             self.__ct.enforcement_literal.append(is_present_index)
         if name:
             self.__ct.name = name
+
+        self.__start = start
+        self.__end = end
+        self.__size = size
 
     def Index(self):
         """Returns the index of the interval constraint in the model."""
@@ -682,6 +686,14 @@ class IntervalVar(object):
     def Name(self):
         return self.__ct.name
 
+    def Start(self):
+        return self.__start
+
+    def End(self):
+        return self.__end
+
+    def Size(self):
+        return self.__size
 
 class CpModel(object):
     """Methods for building a CP model.
@@ -1277,7 +1289,7 @@ class CpModel(object):
         size_index = self.GetOrMakeIndex(size)
         end_index = self.GetOrMakeIndex(end)
         return IntervalVar(self.__model, start_index, size_index, end_index,
-                           None, name)
+                           None, name, start, end, size)
 
     def NewOptionalIntervalVar(self, start, size, end, is_present, name):
         """Creates an optional interval var from start, size, end, and is_present.
@@ -1307,7 +1319,7 @@ class CpModel(object):
         size_index = self.GetOrMakeIndex(size)
         end_index = self.GetOrMakeIndex(end)
         return IntervalVar(self.__model, start_index, size_index, end_index,
-                           is_present_index, name)
+                           is_present_index, name, start, end, size)
 
     def AddNoOverlap(self, interval_vars):
         """Adds NoOverlap(interval_vars).


### PR DESCRIPTION
A common pattern I see when using IntervalVars is that you usually want to keep track of its `start`, `end` and `size` (I guess also the `is_present` literal).

See:
https://github.com/google/or-tools/blob/858fa626959f7e386153af82756384b79f983b5a/examples/python/jobshop_ft06_distance_sat.py#L58-L70

Can you consider adding them as attributes of the IntervalVar class?