### PR TITLE
Remove Python 2 compatibility code

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -65,7 +65,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=raising-string,xrange-builtin,execfile-builtin,parameter-unpacking,import-star-module-level,no-absolute-import,long-suffix,useless-suppression,oct-method,nonzero-method,raw_input-builtin,round-builtin,delslice-method,getslice-method,dict-iter-method,range-builtin-not-iterating,buffer-builtin,intern-builtin,map-builtin-not-iterating,reload-builtin,hex-method,old-division,backtick,setslice-method,dict-view-method,apply-builtin,unichr-builtin,coerce-method,using-cmp-argument,long-builtin,old-octal-literal,filter-builtin-not-iterating,old-ne-operator,cmp-method,suppressed-message,coerce-builtin,input-builtin,next-method-called,file-builtin,print-statement,unpacking-in-except,unicode-builtin,reduce-builtin,standarderror-builtin,basestring-builtin,cmp-builtin,indexing-exception,zip-builtin-not-iterating,old-raise-syntax,metaclass-assignment
+disable=raising-string,execfile-builtin,parameter-unpacking,import-star-module-level,no-absolute-import,long-suffix,useless-suppression,oct-method,nonzero-method,raw_input-builtin,round-builtin,delslice-method,getslice-method,dict-iter-method,range-builtin-not-iterating,buffer-builtin,intern-builtin,map-builtin-not-iterating,reload-builtin,hex-method,old-division,backtick,setslice-method,dict-view-method,apply-builtin,unichr-builtin,coerce-method,using-cmp-argument,long-builtin,old-octal-literal,filter-builtin-not-iterating,old-ne-operator,cmp-method,suppressed-message,coerce-builtin,input-builtin,next-method-called,file-builtin,print-statement,unpacking-in-except,unicode-builtin,reduce-builtin,standarderror-builtin,basestring-builtin,cmp-builtin,indexing-exception,zip-builtin-not-iterating,old-raise-syntax,metaclass-assignment
 
 
 [REPORTS]
@@ -247,7 +247,7 @@ callbacks=cb_,_cb
 
 # List of qualified module names which can have objects that can redefine
 # builtins.
-redefining-builtins-modules=six.moves,future.builtins
+redefining-builtins-modules=future.builtins
 
 
 [LOGGING]

--- a/examples/contrib/3_jugs_mip.py
+++ b/examples/contrib/3_jugs_mip.py
@@ -27,7 +27,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.linear_solver import pywraplp
 

--- a/examples/contrib/3_jugs_regular.py
+++ b/examples/contrib/3_jugs_regular.py
@@ -47,7 +47,6 @@
 
 """
 
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 from collections import defaultdict
 
@@ -236,7 +235,7 @@ def main(n):
     x_val = [1] + [x[i].Value() for i in range(n)]
     print('x:', x_val)
     for i in range(1, n + 1):
-      print('%s -> %s' % (nodes[x_val[i - 1] - 1], nodes[x_val[i] - 1]))
+      print('{} -> {}'.format(nodes[x_val[i - 1] - 1], nodes[x_val[i] - 1]))
 
   solver.EndSearch()
 

--- a/examples/contrib/a_round_of_golf.py
+++ b/examples/contrib/a_round_of_golf.py
@@ -64,7 +64,6 @@
 
 """
 
-from __future__ import print_function
 
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/contrib/all_interval.py
+++ b/examples/contrib/all_interval.py
@@ -50,7 +50,6 @@
 
 """
 
-from __future__ import print_function
 
 import sys
 

--- a/examples/contrib/alldifferent_except_0.py
+++ b/examples/contrib/alldifferent_except_0.py
@@ -48,7 +48,6 @@
 
 """
 
-from __future__ import print_function
 
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/contrib/alphametic.py
+++ b/examples/contrib/alphametic.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
+r"""
 
   Generic alphametic solver in Google CP Solver.
 
@@ -43,7 +43,6 @@
   http://www.hakank.org/google_or_tools/
 
 """
-from __future__ import print_function
 import sys
 import re
 
@@ -59,7 +58,7 @@ def main(problem_str="SEND+MORE=MONEY", base=10):
   print("\nproblem:", problem_str)
 
   # convert to array.
-  problem = re.split("[\s+=]", problem_str)
+  problem = re.split(r"[\s+=]", problem_str)
 
   p_len = len(problem)
   print("base:", base)

--- a/examples/contrib/assignment.py
+++ b/examples/contrib/assignment.py
@@ -30,7 +30,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/assignment6_mip.py
+++ b/examples/contrib/assignment6_mip.py
@@ -39,7 +39,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.linear_solver import pywraplp
 

--- a/examples/contrib/blending.py
+++ b/examples/contrib/blending.py
@@ -21,7 +21,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.linear_solver import pywraplp
 

--- a/examples/contrib/broken_weights.py
+++ b/examples/contrib/broken_weights.py
@@ -46,7 +46,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 
 from ortools.constraint_solver import pywrapcp

--- a/examples/contrib/bus_schedule.py
+++ b/examples/contrib/bus_schedule.py
@@ -33,7 +33,6 @@
   http://www.hakank.org/google_or_tools/
 
 """
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/contrib/car.py
+++ b/examples/contrib/car.py
@@ -28,7 +28,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 
 from ortools.constraint_solver import pywrapcp

--- a/examples/contrib/circuit.py
+++ b/examples/contrib/circuit.py
@@ -41,7 +41,6 @@
 
 """
 
-from __future__ import print_function
 
 import sys
 from ortools.constraint_solver import pywrapcp

--- a/examples/contrib/coins3.py
+++ b/examples/contrib/coins3.py
@@ -37,7 +37,6 @@
   http://www.hakank.org/google_or_tools/
 """
 
-from __future__ import print_function
 
 import sys
 from ortools.constraint_solver import pywrapcp

--- a/examples/contrib/coins_grid.py
+++ b/examples/contrib/coins_grid.py
@@ -51,7 +51,6 @@
   http://www.hakank.org/google_or_tools/
 """
 
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/contrib/coins_grid_mip.py
+++ b/examples/contrib/coins_grid_mip.py
@@ -40,7 +40,6 @@
   http://www.hakank.org/google_or_tools/
 """
 
-from __future__ import print_function
 from ortools.linear_solver import pywraplp
 
 

--- a/examples/contrib/coloring_ip.py
+++ b/examples/contrib/coloring_ip.py
@@ -36,7 +36,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.linear_solver import pywraplp
 

--- a/examples/contrib/combinatorial_auction2.py
+++ b/examples/contrib/combinatorial_auction2.py
@@ -28,7 +28,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from collections import *
 from ortools.constraint_solver import pywrapcp

--- a/examples/contrib/contiguity_regular.py
+++ b/examples/contrib/contiguity_regular.py
@@ -39,7 +39,6 @@
   http://www.hakank.org/google_or_tools/
 
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 #

--- a/examples/contrib/costas_array.py
+++ b/examples/contrib/costas_array.py
@@ -59,7 +59,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 
 from ortools.constraint_solver import pywrapcp

--- a/examples/contrib/covering_opl.py
+++ b/examples/contrib/covering_opl.py
@@ -55,7 +55,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 
 from ortools.constraint_solver import pywrapcp

--- a/examples/contrib/crew.py
+++ b/examples/contrib/crew.py
@@ -37,7 +37,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/contrib/crossword2.py
+++ b/examples/contrib/crossword2.py
@@ -56,7 +56,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/crypta.py
+++ b/examples/contrib/crypta.py
@@ -43,7 +43,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/crypto.py
+++ b/examples/contrib/crypto.py
@@ -42,7 +42,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/curious_set_of_integers.py
+++ b/examples/contrib/curious_set_of_integers.py
@@ -58,7 +58,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/debruijn_binary.py
+++ b/examples/contrib/debruijn_binary.py
@@ -41,7 +41,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/contrib/diet1.py
+++ b/examples/contrib/diet1.py
@@ -43,7 +43,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 from ortools.sat.python import cp_model
 
 

--- a/examples/contrib/diet1_b.py
+++ b/examples/contrib/diet1_b.py
@@ -45,7 +45,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/diet1_mip.py
+++ b/examples/contrib/diet1_mip.py
@@ -34,7 +34,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.linear_solver import pywraplp
 

--- a/examples/contrib/discrete_tomography.py
+++ b/examples/contrib/discrete_tomography.py
@@ -53,7 +53,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 
@@ -146,7 +145,7 @@ def print_solution(x, rows, cols, row_sums, col_sums):
 # Read a problem instance from a file
 #
 def read_problem(file):
-  f = open(file, "r")
+  f = open(file)
   row_sums = f.readline()
   col_sums = f.readline()
   row_sums = [int(r) for r in (row_sums.rstrip()).split(",")]

--- a/examples/contrib/divisible_by_9_through_1.py
+++ b/examples/contrib/divisible_by_9_through_1.py
@@ -51,7 +51,6 @@
   http://www.hakank.org/google_or_tools/
 
 """
-from __future__ import print_function
 import sys
 
 from ortools.constraint_solver import pywrapcp

--- a/examples/contrib/dudeney.py
+++ b/examples/contrib/dudeney.py
@@ -10,7 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/einav_puzzle.py
+++ b/examples/contrib/einav_puzzle.py
@@ -62,7 +62,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/einav_puzzle2.py
+++ b/examples/contrib/einav_puzzle2.py
@@ -63,7 +63,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/eq10.py
+++ b/examples/contrib/eq10.py
@@ -26,7 +26,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/eq20.py
+++ b/examples/contrib/eq20.py
@@ -26,7 +26,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/fill_a_pix.py
+++ b/examples/contrib/fill_a_pix.py
@@ -50,7 +50,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 
@@ -151,7 +150,7 @@ def main(puzzle='', n=''):
 # Read a problem instance from a file
 #
 def read_problem(file):
-  f = open(file, 'r')
+  f = open(file)
   n = int(f.readline())
   puzzle = []
   for i in range(n):

--- a/examples/contrib/furniture_moving.py
+++ b/examples/contrib/furniture_moving.py
@@ -35,7 +35,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/contrib/futoshiki.py
+++ b/examples/contrib/futoshiki.py
@@ -44,7 +44,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/game_theory_taha.py
+++ b/examples/contrib/game_theory_taha.py
@@ -23,7 +23,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.linear_solver import pywraplp
 

--- a/examples/contrib/grocery.py
+++ b/examples/contrib/grocery.py
@@ -35,7 +35,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 
 from ortools.constraint_solver import pywrapcp

--- a/examples/contrib/hidato.py
+++ b/examples/contrib/hidato.py
@@ -39,7 +39,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/contrib/just_forgotten.py
+++ b/examples/contrib/just_forgotten.py
@@ -44,7 +44,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/kakuro.py
+++ b/examples/contrib/kakuro.py
@@ -54,7 +54,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 
 from ortools.constraint_solver import pywrapcp

--- a/examples/contrib/kenken2.py
+++ b/examples/contrib/kenken2.py
@@ -55,7 +55,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 
 from ortools.constraint_solver import pywrapcp

--- a/examples/contrib/killer_sudoku.py
+++ b/examples/contrib/killer_sudoku.py
@@ -67,7 +67,6 @@
   http://www.hakank.org/google_or_tools/
 """
 
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/contrib/knapsack_cp.py
+++ b/examples/contrib/knapsack_cp.py
@@ -21,7 +21,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/knapsack_mip.py
+++ b/examples/contrib/knapsack_mip.py
@@ -21,7 +21,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.linear_solver import pywraplp
 

--- a/examples/contrib/labeled_dice.py
+++ b/examples/contrib/labeled_dice.py
@@ -46,7 +46,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/langford.py
+++ b/examples/contrib/langford.py
@@ -43,7 +43,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 
 from ortools.constraint_solver import pywrapcp

--- a/examples/contrib/least_diff.py
+++ b/examples/contrib/least_diff.py
@@ -36,7 +36,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_cp_solver/
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/least_square.py
+++ b/examples/contrib/least_square.py
@@ -24,7 +24,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.linear_solver import pywraplp
 

--- a/examples/contrib/lectures.py
+++ b/examples/contrib/lectures.py
@@ -43,7 +43,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/contrib/magic_sequence_sat.py
+++ b/examples/contrib/magic_sequence_sat.py
@@ -12,9 +12,6 @@
 # limitations under the License.
 """Solve the magic sequence problem with the CP-SAT solver."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from ortools.sat.python import cp_model
 

--- a/examples/contrib/magic_square.py
+++ b/examples/contrib/magic_square.py
@@ -21,7 +21,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/contrib/magic_square_and_cards.py
+++ b/examples/contrib/magic_square_and_cards.py
@@ -27,7 +27,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/contrib/magic_square_mip.py
+++ b/examples/contrib/magic_square_mip.py
@@ -41,7 +41,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.linear_solver import pywraplp
 

--- a/examples/contrib/map.py
+++ b/examples/contrib/map.py
@@ -32,7 +32,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/marathon2.py
+++ b/examples/contrib/marathon2.py
@@ -46,7 +46,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/contrib/max_flow_taha.py
+++ b/examples/contrib/max_flow_taha.py
@@ -27,7 +27,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/max_flow_winston1.py
+++ b/examples/contrib/max_flow_winston1.py
@@ -27,7 +27,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/contrib/minesweeper.py
+++ b/examples/contrib/minesweeper.py
@@ -62,7 +62,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 
@@ -186,7 +185,7 @@ def main(game="", r="", c=""):
 # Read a problem instance from a file
 #
 def read_problem(file):
-  f = open(file, "r")
+  f = open(file)
   rows = int(f.readline())
   cols = int(f.readline())
   game = []

--- a/examples/contrib/mr_smith.py
+++ b/examples/contrib/mr_smith.py
@@ -46,7 +46,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/contrib/nonogram_default_search.py
+++ b/examples/contrib/nonogram_default_search.py
@@ -39,7 +39,6 @@
   http://geodisi.u-strasbg.fr/~daurat/papiers/tomoqconv.pdf
 
 """
-from __future__ import print_function
 import sys
 
 from ortools.constraint_solver import pywrapcp

--- a/examples/contrib/nonogram_regular.py
+++ b/examples/contrib/nonogram_regular.py
@@ -65,7 +65,6 @@
   http://www.hakank.org/google_or_tools/
 
 """
-from __future__ import print_function
 import sys
 
 from ortools.constraint_solver import pywrapcp

--- a/examples/contrib/nonogram_table.py
+++ b/examples/contrib/nonogram_table.py
@@ -65,7 +65,6 @@
   http://www.hakank.org/google_or_tools/
 
 """
-from __future__ import print_function
 import sys
 
 from ortools.constraint_solver import pywrapcp

--- a/examples/contrib/nonogram_table2.py
+++ b/examples/contrib/nonogram_table2.py
@@ -65,7 +65,6 @@
   http://www.hakank.org/google_or_tools/
 
 """
-from __future__ import print_function
 import sys
 
 from ortools.constraint_solver import pywrapcp

--- a/examples/contrib/nontransitive_dice.py
+++ b/examples/contrib/nontransitive_dice.py
@@ -66,7 +66,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/contrib/nqueens.py
+++ b/examples/contrib/nqueens.py
@@ -21,7 +21,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/nqueens2.py
+++ b/examples/contrib/nqueens2.py
@@ -24,7 +24,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/contrib/nqueens3.py
+++ b/examples/contrib/nqueens3.py
@@ -26,7 +26,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/contrib/nurse_rostering.py
+++ b/examples/contrib/nurse_rostering.py
@@ -28,7 +28,6 @@
   http://www.hakank.org/google_or_tools/
 
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 from collections import defaultdict
 

--- a/examples/contrib/nurses_cp.py
+++ b/examples/contrib/nurses_cp.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/contrib/olympic.py
+++ b/examples/contrib/olympic.py
@@ -55,7 +55,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/contrib/organize_day.py
+++ b/examples/contrib/organize_day.py
@@ -31,7 +31,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/contrib/p_median.py
+++ b/examples/contrib/p_median.py
@@ -33,7 +33,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/contrib/pandigital_numbers.py
+++ b/examples/contrib/pandigital_numbers.py
@@ -60,7 +60,6 @@
   http://www.hakank.org/google_or_tools/
 
 """
-from __future__ import print_function
 import sys
 
 from ortools.constraint_solver import pywrapcp

--- a/examples/contrib/photo_problem.py
+++ b/examples/contrib/photo_problem.py
@@ -45,7 +45,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 
 from ortools.constraint_solver import pywrapcp

--- a/examples/contrib/place_number_puzzle.py
+++ b/examples/contrib/place_number_puzzle.py
@@ -23,7 +23,7 @@
        2 - 5
      / | X | \
    1 - 3 - 6 - 8
-     \ | X | /
+     \\ | X | /
        4 - 7
   ""
 
@@ -39,7 +39,6 @@
   http://www.hakank.org/google_or_tools/
 
 """
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/contrib/post_office_problem2.py
+++ b/examples/contrib/post_office_problem2.py
@@ -53,7 +53,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/production.py
+++ b/examples/contrib/production.py
@@ -21,7 +21,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.linear_solver import pywraplp
 

--- a/examples/contrib/project_scheduling_sat.py
+++ b/examples/contrib/project_scheduling_sat.py
@@ -1,6 +1,3 @@
-from __future__ import division
-from __future__ import print_function
-
 from ortools.sat.python import cp_model
 
 #project name, duration, starts earliest, ends latest, demand role A, demand role S, demand role J

--- a/examples/contrib/pyls_api.py
+++ b/examples/contrib/pyls_api.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/quasigroup_completion.py
+++ b/examples/contrib/quasigroup_completion.py
@@ -52,7 +52,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 
@@ -166,7 +165,7 @@ def main(puzzle="", n=0):
 # Read a problem instance from a file
 #
 def read_problem(file):
-  f = open(file, "r")
+  f = open(file)
   n = int(f.readline())
   game = []
   for i in range(n):

--- a/examples/contrib/regular.py
+++ b/examples/contrib/regular.py
@@ -37,7 +37,6 @@
   http://www.hakank.org/google_or_tools/
 
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/regular_table.py
+++ b/examples/contrib/regular_table.py
@@ -37,7 +37,6 @@
   http://www.hakank.org/google_or_tools/
 
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/regular_table2.py
+++ b/examples/contrib/regular_table2.py
@@ -37,7 +37,6 @@
   http://www.hakank.org/google_or_tools/
 
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/rogo2.py
+++ b/examples/contrib/rogo2.py
@@ -44,7 +44,6 @@
   http://www.hakank.org/google_or_tools/
 
 """
-from __future__ import print_function
 import sys
 import re
 

--- a/examples/contrib/safe_cracking.py
+++ b/examples/contrib/safe_cracking.py
@@ -44,7 +44,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/scheduling_speakers.py
+++ b/examples/contrib/scheduling_speakers.py
@@ -28,7 +28,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/scheduling_with_transitions_sat.py
+++ b/examples/contrib/scheduling_with_transitions_sat.py
@@ -1,12 +1,8 @@
-# -*- coding: utf-8 -*-
 """Scheduling problem with transition time between tasks and transitions costs.
 
 @author: CSLiu2
 """
 
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
 
 import argparse
 import collections

--- a/examples/contrib/school_scheduling_sat.py
+++ b/examples/contrib/school_scheduling_sat.py
@@ -1,7 +1,7 @@
 from ortools.sat.python import cp_model
 
 
-class SchoolSchedulingProblem(object):
+class SchoolSchedulingProblem:
 
   def __init__(self, subjects, teachers, curriculum, specialties, working_days,
                periods, levels, sections, teacher_work_hours):
@@ -16,7 +16,7 @@ class SchoolSchedulingProblem(object):
     self.teacher_work_hours = teacher_work_hours
 
 
-class SchoolSchedulingSatSolver(object):
+class SchoolSchedulingSatSolver:
 
   def __init__(self, problem):
     # Problem
@@ -24,7 +24,7 @@ class SchoolSchedulingSatSolver(object):
 
     # Utilities
     self.timeslots = [
-        '{0:10} {1:6}'.format(x, y)
+        '{:10} {:6}'.format(x, y)
         for x in problem.working_days
         for y in problem.periods
     ]

--- a/examples/contrib/secret_santa.py
+++ b/examples/contrib/secret_santa.py
@@ -59,7 +59,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/contrib/secret_santa2.py
+++ b/examples/contrib/secret_santa2.py
@@ -60,7 +60,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/contrib/send_more_money_any_base.py
+++ b/examples/contrib/send_more_money_any_base.py
@@ -41,7 +41,6 @@
   http://www.hakank.org/google_or_tools/
 
 """
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/contrib/send_most_money.py
+++ b/examples/contrib/send_most_money.py
@@ -37,7 +37,6 @@
   http://www.hakank.org/google_or_tools/
 
 """
-from __future__ import print_function
 
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/contrib/seseman.py
+++ b/examples/contrib/seseman.py
@@ -53,7 +53,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/seseman_b.py
+++ b/examples/contrib/seseman_b.py
@@ -55,7 +55,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/set_covering.py
+++ b/examples/contrib/set_covering.py
@@ -30,7 +30,6 @@
   http://www.hakank.org/google_or_tools/
 
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/set_covering2.py
+++ b/examples/contrib/set_covering2.py
@@ -32,7 +32,6 @@
   http://www.hakank.org/google_or_tools/
 
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/set_covering3.py
+++ b/examples/contrib/set_covering3.py
@@ -45,7 +45,6 @@
   http://www.hakank.org/google_or_tools/
 
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/set_covering4.py
+++ b/examples/contrib/set_covering4.py
@@ -65,7 +65,6 @@
   http://www.hakank.org/google_or_tools/
 
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/set_covering_deployment.py
+++ b/examples/contrib/set_covering_deployment.py
@@ -38,7 +38,6 @@
   http://www.hakank.org/google_or_tools/
 
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/set_covering_skiena.py
+++ b/examples/contrib/set_covering_skiena.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
+r"""
 
   Set covering in Google CP Solver.
 
@@ -38,7 +38,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/set_partition.py
+++ b/examples/contrib/set_partition.py
@@ -44,7 +44,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 
 from ortools.constraint_solver import pywrapcp

--- a/examples/contrib/sicherman_dice.py
+++ b/examples/contrib/sicherman_dice.py
@@ -58,7 +58,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/contrib/ski_assignment.py
+++ b/examples/contrib/ski_assignment.py
@@ -47,7 +47,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 
 from ortools.constraint_solver import pywrapcp

--- a/examples/contrib/stable_marriage.py
+++ b/examples/contrib/stable_marriage.py
@@ -37,7 +37,6 @@
   http://www.hakank.org/google_or_tools/
 
 """
-from __future__ import print_function
 import sys
 
 from ortools.constraint_solver import pywrapcp

--- a/examples/contrib/steel.py
+++ b/examples/contrib/steel.py
@@ -12,7 +12,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from __future__ import print_function
 import argparse
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/contrib/steel_lns.py
+++ b/examples/contrib/steel_lns.py
@@ -11,7 +11,6 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-from __future__ import print_function
 import argparse
 from ortools.constraint_solver import pywrapcp
 import random

--- a/examples/contrib/stigler.py
+++ b/examples/contrib/stigler.py
@@ -117,7 +117,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.linear_solver import pywraplp
 

--- a/examples/contrib/strimko2.py
+++ b/examples/contrib/strimko2.py
@@ -42,7 +42,6 @@
   This model was created by Hakan Kjellerstrand (hakank@gmail.com)
   See my other Google CP Solver models: http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 
 from ortools.constraint_solver import pywrapcp

--- a/examples/contrib/subset_sum.py
+++ b/examples/contrib/subset_sum.py
@@ -38,7 +38,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/contrib/survo_puzzle.py
+++ b/examples/contrib/survo_puzzle.py
@@ -59,7 +59,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 
@@ -147,7 +146,7 @@ def main(r=0, c=0, rowsums=[], colsums=[], game=[]):
 # Read a problem instance from a file
 #
 def read_problem(file):
-  f = open(file, "r")
+  f = open(file)
   r = int(f.readline())
   c = int(f.readline())
   rowsums = f.readline()

--- a/examples/contrib/toNum.py
+++ b/examples/contrib/toNum.py
@@ -22,7 +22,6 @@
   http://www.hakank.org/google_or_tools/
 
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 #

--- a/examples/contrib/traffic_lights.py
+++ b/examples/contrib/traffic_lights.py
@@ -69,7 +69,6 @@
   http://www.hakank.org/google_or_tools/
 
 """
-from __future__ import print_function
 import sys
 
 from ortools.constraint_solver import pywrapcp
@@ -114,7 +113,7 @@ def main(base=10, start=1, len1=1, len2=4):
   num_solutions = 0
   while solver.NextSolution():
     for i in range(n):
-      print("%+2s %+2s" % (lights[V[i].Value()], lights[P[i].Value()]), end=" ")
+      print("{:+2} {:+2}".format(lights[V[i].Value()], lights[P[i].Value()]), end=" ")
     print()
     num_solutions += 1
 

--- a/examples/contrib/vendor_scheduling.py
+++ b/examples/contrib/vendor_scheduling.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/volsay.py
+++ b/examples/contrib/volsay.py
@@ -21,7 +21,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 from ortools.linear_solver import pywraplp
 
 

--- a/examples/contrib/volsay2.py
+++ b/examples/contrib/volsay2.py
@@ -22,7 +22,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 from ortools.linear_solver import pywraplp
 
 

--- a/examples/contrib/volsay3.py
+++ b/examples/contrib/volsay3.py
@@ -22,7 +22,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 from ortools.linear_solver import pywraplp
 
 

--- a/examples/contrib/wedding_optimal_chart.py
+++ b/examples/contrib/wedding_optimal_chart.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 from ortools.constraint_solver import solver_parameters_pb2
 """Finding an optimal wedding seating chart.

--- a/examples/contrib/who_killed_agatha.py
+++ b/examples/contrib/who_killed_agatha.py
@@ -59,7 +59,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 from collections import defaultdict
 
 from ortools.constraint_solver import pywrapcp

--- a/examples/contrib/xkcd.py
+++ b/examples/contrib/xkcd.py
@@ -36,7 +36,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_cp_solver/
 """
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 
 

--- a/examples/contrib/young_tableaux.py
+++ b/examples/contrib/young_tableaux.py
@@ -60,7 +60,6 @@
   Also see my other Google CP Solver models:
   http://www.hakank.org/google_or_tools/
 """
-from __future__ import print_function
 import sys
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/python/appointments.py
+++ b/examples/python/appointments.py
@@ -12,8 +12,6 @@
 # limitations under the License.
 """Generates possible daily schedules for workers."""
 
-from __future__ import print_function
-from __future__ import division
 
 import argparse
 from ortools.sat.python import cp_model

--- a/examples/python/arc_flow_cutting_stock_sat.py
+++ b/examples/python/arc_flow_cutting_stock_sat.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 """Cutting stock problem with the objective to minimize wasted space."""
 
-from __future__ import print_function
 
 import argparse
 import collections

--- a/examples/python/assignment_sat.py
+++ b/examples/python/assignment_sat.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 from ortools.sat.python import cp_model
 
 

--- a/examples/python/assignment_with_constraints_sat.py
+++ b/examples/python/assignment_with_constraints_sat.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 """Solve an assignment problem with combination constraints on workers."""
 
-from __future__ import print_function
 
 from ortools.sat.python import cp_model
 

--- a/examples/python/balance_group_sat.py
+++ b/examples/python/balance_group_sat.py
@@ -18,8 +18,6 @@ Furthermore, if one color is an a group, at least k items with this color must
 be in that group.
 """
 
-from __future__ import print_function
-from __future__ import division
 
 from ortools.sat.python import cp_model
 

--- a/examples/python/bus_driver_scheduling_flow_sat.py
+++ b/examples/python/bus_driver_scheduling_flow_sat.py
@@ -21,7 +21,6 @@ Constraints:
 - 15 min cleaning time after the last shift
 - 2 min waiting time after each shift for passenger boarding and alighting
 """
-from __future__ import print_function
 
 import argparse
 import collections

--- a/examples/python/bus_driver_scheduling_sat.py
+++ b/examples/python/bus_driver_scheduling_sat.py
@@ -21,7 +21,6 @@ Constraints:
 - 15 min cleaning time after the last shift
 - 2 min waiting time after each shift for passenger boarding and alighting
 """
-from __future__ import print_function
 
 import collections
 import math

--- a/examples/python/chemical_balance_lp.py
+++ b/examples/python/chemical_balance_lp.py
@@ -17,8 +17,6 @@
 # Furthermore, if one color is an a group, at least k items with this color must
 # be in that group.
 
-from __future__ import print_function
-from __future__ import division
 
 from ortools.linear_solver import pywraplp
 
@@ -64,8 +62,8 @@ for p in all_products:
 
 solver.Minimize(epsilon)
 
-print(("Number of variables = %d" % solver.NumVariables()))
-print(("Number of constraints = %d" % solver.NumConstraints()))
+print("Number of variables = %d" % solver.NumVariables())
+print("Number of constraints = %d" % solver.NumConstraints())
 
 result_status = solver.Solve()
 
@@ -74,14 +72,14 @@ assert result_status == pywraplp.Solver.OPTIMAL
 
 assert solver.VerifySolution(1e-7, True)
 
-print(("Problem solved in %f milliseconds" % solver.wall_time()))
+print("Problem solved in %f milliseconds" % solver.wall_time())
 
 # The objective value of the solution.
-print(("Optimal objective value = %f" % solver.Objective().Value()))
+print("Optimal objective value = %f" % solver.Objective().Value())
 
 for s in all_sets:
     print(
-        "  %s = %f" % (chemical_set[s][0], set_vars[s].solution_value()),
+        "  {} = {:f}".format(chemical_set[s][0], set_vars[s].solution_value()),
         end=" ")
     print()
 for p in all_products:
@@ -89,4 +87,4 @@ for p in all_products:
     max_quantity = max_quantities[p][1]
     quantity = sum(
         set_vars[s].solution_value() * chemical_set[s][p + 1] for s in all_sets)
-    print("%s: %f out of %f" % (name, quantity, max_quantity))
+    print("{}: {:f} out of {:f}".format(name, quantity, max_quantity))

--- a/examples/python/chemical_balance_sat.py
+++ b/examples/python/chemical_balance_sat.py
@@ -17,8 +17,6 @@
 # Furthermore, if one color is an a group, at least k items with this color must
 # be in that group.
 
-from __future__ import print_function
-from __future__ import division
 
 from ortools.sat.python import cp_model
 import math
@@ -75,7 +73,7 @@ print("Optimal objective value = %f" % (solver.ObjectiveValue() / 10000.0))
 
 for s in all_sets:
     print(
-        "  %s = %f" % (chemical_set[s][0], solver.Value(set_vars[s]) / 1000.0),
+        "  {} = {:f}".format(chemical_set[s][0], solver.Value(set_vars[s]) / 1000.0),
         end=" ")
     print()
 for p in all_products:
@@ -84,4 +82,4 @@ for p in all_products:
     quantity = sum(
         solver.Value(set_vars[s]) / 1000.0 * chemical_set[s][p + 1]
         for s in all_sets)
-    print("%s: %f out of %f" % (name, quantity, max_quantity))
+    print("{}: {:f} out of {:f}".format(name, quantity, max_quantity))

--- a/examples/python/clustering_sat.py
+++ b/examples/python/clustering_sat.py
@@ -12,8 +12,6 @@
 # limitations under the License.
 """Cluster 40 cities in 4 equal groups to minimize sum of crossed distances."""
 
-from __future__ import print_function
-from __future__ import division
 
 from ortools.sat.python import cp_model
 

--- a/examples/python/cover_rectangle_sat.py
+++ b/examples/python/cover_rectangle_sat.py
@@ -12,8 +12,6 @@
 # limitations under the License.
 """Fill a 72x37 rectangle by a minimum number of non-overlapping squares."""
 
-from __future__ import print_function
-from __future__ import division
 
 from ortools.sat.python import cp_model
 
@@ -82,7 +80,7 @@ def cover_rectangle(num_squares):
     # Creates a solver and solves.
     solver = cp_model.CpSolver()
     status = solver.Solve(model)
-    print('%s found in %0.2fs' % (solver.StatusName(status), solver.WallTime()))
+    print('{} found in {:0.2f}s'.format(solver.StatusName(status), solver.WallTime()))
 
     # Prints solution.
     if status == cp_model.FEASIBLE:

--- a/examples/python/cvrptw_plot.py
+++ b/examples/python/cvrptw_plot.py
@@ -1,4 +1,3 @@
-# This Python file uses the following encoding: utf-8
 # Copyright 2015 Tin Arm Engineering AB
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -466,7 +465,7 @@ def vehicle_output_string(manager, routing, plan):
 
     for route_number in range(routing.vehicles()):
         order = routing.Start(route_number)
-        plan_output += 'Route {0}:'.format(route_number)
+        plan_output += 'Route {}:'.format(route_number)
         if routing.IsEnd(plan.Value(routing.NextVar(order))):
             plan_output += ' Empty \n'
         else:
@@ -482,7 +481,7 @@ def vehicle_output_string(manager, routing, plan):
                         tmax=str(timedelta(seconds=plan.Max(time_var))))
 
                 if routing.IsEnd(order):
-                    plan_output += ' EndRoute {0}. \n'.format(route_number)
+                    plan_output += ' EndRoute {}. \n'.format(route_number)
                     break
                 order = plan.Value(routing.NextVar(order))
         plan_output += '\n'
@@ -504,7 +503,7 @@ def build_vehicle_route(manager, routing, plan, customers, veh_number):
         (List) route: indexes of the customers for vehicle veh_number
     """
     veh_used = routing.IsVehicleUsed(plan, veh_number)
-    print('Vehicle {0} is used {1}'.format(veh_number, veh_used))
+    print('Vehicle {} is used {}'.format(veh_number, veh_used))
     if veh_used:
         route = []
         node = routing.Start(veh_number)  # Get the starting node index
@@ -722,7 +721,7 @@ def main():
         #    print('succesfully wrote assignment to file ' + save_file_base +
         #          '_assignment.ass')
 
-        print('The Objective Value is {0}'.format(assignment.ObjectiveValue()))
+        print('The Objective Value is {}'.format(assignment.ObjectiveValue()))
 
         plan_output, dropped = vehicle_output_string(manager, routing, assignment)
         print(plan_output)

--- a/examples/python/flexible_job_shop_sat.py
+++ b/examples/python/flexible_job_shop_sat.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 """Solves a flexible jobshop problems with the CP-SAT solver."""
 
-from __future__ import print_function
 
 import collections
 from ortools.sat.python import cp_model

--- a/examples/python/golomb8.py
+++ b/examples/python/golomb8.py
@@ -67,8 +67,8 @@ def main():
     time = solver.WallTime()
     branches = solver.Branches()
     failures = solver.Failures()
-    print(('Total run : failures = %i, branches = %i, time = %i ms' %
-           (failures, branches, time)))
+    print('Total run : failures = %i, branches = %i, time = %i ms' %
+           (failures, branches, time))
 
 
 if __name__ == '__main__':

--- a/examples/python/hidato_sat.py
+++ b/examples/python/hidato_sat.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 """Solves the Hidato problem with the CP-SAT solver."""
 
-from __future__ import print_function
 
 from ortools.sat.python import visualization
 from ortools.sat.python import cp_model
@@ -124,7 +123,7 @@ def solve_hidato(puzzle, index):
         print('')
         print('----- Solving problem %i -----' % index)
         print('')
-        print(('Initial game (%i x %i)' % (r, c)))
+        print('Initial game (%i x %i)' % (r, c))
         print_matrix(puzzle)
 
     #

--- a/examples/python/integer_programming.py
+++ b/examples/python/integer_programming.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 """Integer programming examples that show how to use the APIs."""
 
-from __future__ import print_function
 
 from ortools.linear_solver import pywraplp
 
@@ -76,7 +75,7 @@ def SolveAndPrint(solver, variable_list):
 
     # The value of each variable in the solution.
     for variable in variable_list:
-        print('%s = %f' % (variable.name(), variable.solution_value()))
+        print('{} = {:f}'.format(variable.name(), variable.solution_value()))
 
     print('Advanced usage:')
     print('Problem solved in %d branch-and-bound nodes' % solver.nodes())

--- a/examples/python/jobshop_ft06_distance_sat.py
+++ b/examples/python/jobshop_ft06_distance_sat.py
@@ -24,7 +24,6 @@ This variation introduces a minimum distance between all the jobs on each
 machine.
 """
 
-from __future__ import print_function
 
 import collections
 

--- a/examples/python/jobshop_ft06_sat.py
+++ b/examples/python/jobshop_ft06_sat.py
@@ -20,7 +20,6 @@ machine is task_type dependent.
 The objective is to minimize the maximum completion time of all
 jobs. This is called the makespan.
 """
-from __future__ import print_function
 
 import collections
 

--- a/examples/python/jobshop_with_maintenance_sat.py
+++ b/examples/python/jobshop_with_maintenance_sat.py
@@ -12,8 +12,6 @@
 # limitations under the License.
 """Jobshop with maintenance tasks using the CP-SAT solver."""
 
-from __future__ import absolute_import
-from __future__ import print_function
 
 import collections
 

--- a/examples/python/linear_assignment_api.py
+++ b/examples/python/linear_assignment_api.py
@@ -16,7 +16,6 @@
    http://www.ee.oulu.fi/~mpa/matreng/eem1_2-1.htm with kCost[0][1]
    modified so the optimum solution is unique.
 """
-from __future__ import print_function
 
 from ortools.graph import pywrapgraph
 

--- a/examples/python/linear_programming.py
+++ b/examples/python/linear_programming.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# This Python file uses the following encoding: utf-8
 # Copyright 2018 Google LLC
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +13,6 @@
 # limitations under the License.
 """Linear optimization example"""
 
-from __future__ import print_function
 from ortools.linear_solver import pywraplp
 
 

--- a/examples/python/magic_sequence_distribute.py
+++ b/examples/python/magic_sequence_distribute.py
@@ -17,7 +17,6 @@ occurrences of i in this sequence is equal to the value of the ith number.
 It uses an aggregated formulation of the count expression called
 distribute().
 """
-from __future__ import print_function
 
 from ortools.constraint_solver import pywrapcp
 

--- a/examples/python/nqueens_sat.py
+++ b/examples/python/nqueens_sat.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """OR-tools solution to the N-queens problem."""
-from __future__ import print_function
 import time
 import sys
 from ortools.sat.python import cp_model

--- a/examples/python/pyflow_example.py
+++ b/examples/python/pyflow_example.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 """MaxFlow and MinCostFlow examples."""
 
-from __future__ import print_function
 from ortools.graph import pywrapgraph
 
 
@@ -29,9 +28,9 @@ def MaxFlow():
     if max_flow.Solve(0, 5) == max_flow.OPTIMAL:
         print('Total flow', max_flow.OptimalFlow(), '/', expected_total_flow)
         for i in range(max_flow.NumArcs()):
-            print(('From source %d to target %d: %d / %d' %
+            print('From source %d to target %d: %d / %d' %
                    (max_flow.Tail(i), max_flow.Head(i), max_flow.Flow(i),
-                    max_flow.Capacity(i))))
+                    max_flow.Capacity(i)))
         print('Source side min-cut:', max_flow.GetSourceSideMinCut())
         print('Sink side min-cut:', max_flow.GetSinkSideMinCut())
     else:

--- a/examples/python/qubo_sat.py
+++ b/examples/python/qubo_sat.py
@@ -1,6 +1,5 @@
 """Solves a Qubo program using the CP-SAT solver."""
 
-from __future__ import print_function
 
 import time
 

--- a/examples/python/random_tsp.py
+++ b/examples/python/random_tsp.py
@@ -60,7 +60,7 @@ def Distance(manager, i, j):
     return node_i + node_j
 
 
-class RandomMatrix(object):
+class RandomMatrix:
     """Random matrix."""
 
     def __init__(self, size, seed):

--- a/examples/python/rcpsp_sat.py
+++ b/examples/python/rcpsp_sat.py
@@ -12,9 +12,6 @@
 # limitations under the License.
 """Sat based solver for the RCPSP problems (see rcpsp.proto)."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import argparse
 import collections

--- a/examples/python/reallocate_sat.py
+++ b/examples/python/reallocate_sat.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 """Reallocate production to smooth it over years."""
 
-from __future__ import print_function
 
 import collections
 

--- a/examples/python/shift_scheduling_sat.py
+++ b/examples/python/shift_scheduling_sat.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 """Creates a shift scheduling problem and solves it."""
 
-from __future__ import print_function
 
 import argparse
 

--- a/examples/python/single_machine_scheduling_with_setup_release_due_dates_sat.py
+++ b/examples/python/single_machine_scheduling_with_setup_release_due_dates_sat.py
@@ -11,9 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Single machine jobshop with setup times, release dates and due dates."""
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
 
 import argparse
 

--- a/examples/python/steel_mill_slab_sat.py
+++ b/examples/python/steel_mill_slab_sat.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 """Solves the Stell Mill Slab problem with 4 different techniques."""
 
-from __future__ import print_function
 
 import argparse
 import collections

--- a/examples/python/stigler_diet.py
+++ b/examples/python/stigler_diet.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Stigler diet example"""
 
-from six.moves import xrange
 from ortools.linear_solver import pywraplp
 
 

--- a/examples/python/stigler_diet.py
+++ b/examples/python/stigler_diet.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# This Python file uses the following encoding: utf-8
 # Copyright 2018 Google LLC
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +13,6 @@
 # limitations under the License.
 """Stigler diet example"""
 
-from __future__ import print_function
 from six.moves import xrange
 from ortools.linear_solver import pywraplp
 

--- a/examples/python/sudoku_sat.py
+++ b/examples/python/sudoku_sat.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 """This model implements a sudoku solver."""
 
-from __future__ import print_function
 
 from ortools.sat.python import cp_model
 

--- a/examples/python/task_allocation_sat.py
+++ b/examples/python/task_allocation_sat.py
@@ -15,7 +15,6 @@ see
 http://yetanothermathprogrammingconsultant.blogspot.com/2018/09/minizinc-cpsat-vs-mip.html
 """
 
-from __future__ import print_function
 
 from ortools.sat.python import cp_model
 

--- a/examples/python/tasks_and_workers_assignment_sat.py
+++ b/examples/python/tasks_and_workers_assignment_sat.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 """Tasks and workers to group assignment to average sum(cost) / #workers"""
 
-from __future__ import print_function
 
 from ortools.sat.python import cp_model
 

--- a/examples/python/transit_time.py
+++ b/examples/python/transit_time.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# This Python file uses the following encoding: utf-8
 # Copyright 2015 Tin Arm Engineering AB
 # Copyright 2018 Google LLC
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,7 +20,6 @@
    here we use: 114m x 80m city block
 """
 
-from __future__ import print_function
 from six.moves import xrange
 from ortools.constraint_solver import pywrapcp
 from ortools.constraint_solver import routing_enums_pb2
@@ -151,7 +149,7 @@ def manhattan_distance(position_1, position_2):
         abs(position_1[0] - position_2[0]) + abs(position_1[1] - position_2[1]))
 
 
-class CreateTimeEvaluator(object):
+class CreateTimeEvaluator:
     """Creates callback to get total times between locations."""
 
     @staticmethod
@@ -193,8 +191,8 @@ def print_transit_time(route, time_evaluator):
     total_time = 0
     for i, j in route:
         total_time += time_evaluator(i, j)
-        print('{0} -> {1}: {2}min'.format(i, j, time_evaluator(i, j)))
-    print('Total time: {0}min\n'.format(total_time))
+        print('{} -> {}: {}min'.format(i, j, time_evaluator(i, j)))
+    print('Total time: {}min\n'.format(total_time))
 
 
 ########

--- a/examples/python/transit_time.py
+++ b/examples/python/transit_time.py
@@ -20,7 +20,6 @@
    here we use: 114m x 80m city block
 """
 
-from six.moves import xrange
 from ortools.constraint_solver import pywrapcp
 from ortools.constraint_solver import routing_enums_pb2
 
@@ -171,9 +170,9 @@ class CreateTimeEvaluator:
         """Initializes the total time matrix."""
         self._total_time = {}
         # precompute total time to have time callback in O(1)
-        for from_node in xrange(data.num_locations):
+        for from_node in range(data.num_locations):
             self._total_time[from_node] = {}
-            for to_node in xrange(data.num_locations):
+            for to_node in range(data.num_locations):
                 if from_node == to_node:
                     self._total_time[from_node][to_node] = 0
                 else:

--- a/examples/python/tsp_sat.py
+++ b/examples/python/tsp_sat.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 """Simple travelling salesman problem between cities."""
 
-from __future__ import print_function
 
 from ortools.sat.python import cp_model
 

--- a/examples/python/vendor_scheduling_sat.py
+++ b/examples/python/vendor_scheduling_sat.py
@@ -12,9 +12,6 @@
 # limitations under the License.
 """Solves a simple shift scheduling problem."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from ortools.sat.python import cp_model
 

--- a/examples/python/wedding_optimal_chart_sat.py
+++ b/examples/python/wedding_optimal_chart_sat.py
@@ -36,7 +36,6 @@ Adapted from
 https://github.com/google/or-tools/blob/master/examples/csharp/wedding_optimal_chart.cs
 """
 
-from __future__ import print_function
 import time
 from ortools.sat.python import cp_model
 

--- a/examples/python/worker_schedule_sat.py
+++ b/examples/python/worker_schedule_sat.py
@@ -10,7 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import print_function
 
 from ortools.sat.python import cp_model
 

--- a/examples/python/zebra_sat.py
+++ b/examples/python/zebra_sat.py
@@ -31,7 +31,6 @@ The Norwegian lives next to the blue house.
 
 Who owns a zebra and who drinks water?
 """
-from __future__ import print_function
 
 from ortools.sat.python import cp_model
 

--- a/examples/tests/cp_model_test.py
+++ b/examples/tests/cp_model_test.py
@@ -1,8 +1,5 @@
 """Tests for ortools.sat.python.cp_model."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 
 import unittest

--- a/examples/tests/cp_viz_test.py
+++ b/examples/tests/cp_viz_test.py
@@ -1,4 +1,3 @@
-
 from ortools.constraint_solver import pywrapcp
 
 def MyTest():

--- a/examples/tests/issue1231.py
+++ b/examples/tests/issue1231.py
@@ -20,7 +20,6 @@ where each letter represents a unique digit.
 This problem has 72 different solutions in base 10.
 """
 
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 from os import abort
 

--- a/examples/tests/lp_test.py
+++ b/examples/tests/lp_test.py
@@ -11,9 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for ortools.linear_solver.pywraplp."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import unittest
 from ortools.linear_solver import linear_solver_pb2
@@ -39,8 +36,8 @@ class PyWrapLpTest(unittest.TestCase):
 
         self.SolveAndPrint(solver, [x1, x2, x3], [c0, c1, c2])
         # Print a linear expression's solution value.
-        print(('Sum of vars: %s = %s' % (sum_of_vars,
-                                         sum_of_vars.solution_value())))
+        print('Sum of vars: {} = {}'.format(sum_of_vars,
+                                         sum_of_vars.solution_value()))
 
     def RunLinearExampleCppStyleAPI(self, optimization_problem_type):
         """Example of simple linear program with the C++ style API."""
@@ -130,8 +127,8 @@ class PyWrapLpTest(unittest.TestCase):
 
     def SolveAndPrint(self, solver, variable_list, constraint_list):
         """Solve the problem and print the solution."""
-        print(('Number of variables = %d' % solver.NumVariables()))
-        print(('Number of constraints = %d' % solver.NumConstraints()))
+        print('Number of variables = %d' % solver.NumVariables())
+        print('Number of constraints = %d' % solver.NumConstraints())
 
         result_status = solver.Solve()
 
@@ -142,26 +139,26 @@ class PyWrapLpTest(unittest.TestCase):
         # GLOP_LINEAR_PROGRAMMING, verifying the solution is highly recommended!).
         assert solver.VerifySolution(1e-7, True)
 
-        print(('Problem solved in %f milliseconds' % solver.wall_time()))
+        print('Problem solved in %f milliseconds' % solver.wall_time())
 
         # The objective value of the solution.
-        print(('Optimal objective value = %f' % solver.Objective().Value()))
+        print('Optimal objective value = %f' % solver.Objective().Value())
 
         # The value of each variable in the solution.
         for variable in variable_list:
-            print(('%s = %f' % (variable.name(), variable.solution_value())))
+            print('{} = {:f}'.format(variable.name(), variable.solution_value()))
 
         print('Advanced usage:')
-        print(('Problem solved in %d iterations' % solver.iterations()))
+        print('Problem solved in %d iterations' % solver.iterations())
         for variable in variable_list:
-            print(('%s: reduced cost = %f' % (variable.name(),
-                                              variable.reduced_cost())))
+            print('{}: reduced cost = {:f}'.format(variable.name(),
+                                              variable.reduced_cost()))
         activities = solver.ComputeConstraintActivities()
         for i, constraint in enumerate(constraint_list):
             print(
-                ('constraint %d: dual value = %f\n'
+                'constraint %d: dual value = %f\n'
                  '               activity = %f' %
-                 (i, constraint.dual_value(), activities[constraint.index()])))
+                 (i, constraint.dual_value(), activities[constraint.index()]))
 
     def testApi(self):
         all_names_and_problem_types = (list(
@@ -173,21 +170,21 @@ class PyWrapLpTest(unittest.TestCase):
                 if name.startswith('GUROBI'):
                     continue
                 if name.endswith('LINEAR_PROGRAMMING'):
-                    print(('\n------ Linear programming example with %s ------' %
-                           name))
+                    print('\n------ Linear programming example with %s ------' %
+                           name)
                     print('\n*** Natural language API ***')
                     self.RunLinearExampleNaturalLanguageAPI(problem_type)
                     print('\n*** C++ style API ***')
                     self.RunLinearExampleCppStyleAPI(problem_type)
                 elif name.endswith('MIXED_INTEGER_PROGRAMMING'):
-                    print((
+                    print(
                         '\n------ Mixed Integer programming example with %s ------'
-                        % name))
+                        % name)
                     print('\n*** C++ style API ***')
                     self.RunMixedIntegerExampleCppStyleAPI(problem_type)
                 elif name.endswith('INTEGER_PROGRAMMING'):
-                    print(('\n------ Boolean programming example with %s ------' %
-                           name))
+                    print('\n------ Boolean programming example with %s ------' %
+                           name)
                     print('\n*** C++ style API ***')
                     self.RunBooleanExampleCppStyleAPI(problem_type)
                 else:

--- a/examples/tests/pywrapcp_test.py
+++ b/examples/tests/pywrapcp_test.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 """Unit tests for python/constraint_solver.swig. Not exhaustive."""
 
-from __future__ import print_function
 
 import sys
 import unittest

--- a/examples/tests/pywraplp_test.py
+++ b/examples/tests/pywraplp_test.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 """Simple unit tests for python/linear_solver.swig. Not exhaustive."""
 
-from __future__ import print_function
 
 from google.protobuf import text_format
 from ortools.linear_solver import linear_solver_pb2

--- a/examples/tests/pywraprouting_test.py
+++ b/examples/tests/pywraprouting_test.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 """pywrapcp unittest file."""
 
-from __future__ import print_function
 
 from functools import partial
 
@@ -44,7 +43,7 @@ def Three(unused_i, unused_j):
     return 1
 
 
-class Callback(object):
+class Callback:
 
     def __init__(self, model):
         self.model = model

--- a/examples/tests/sorted_interval_list_test.py
+++ b/examples/tests/sorted_interval_list_test.py
@@ -12,9 +12,6 @@
 # limitations under the License.
 """Tests for ortools.util.sorted_interval_list."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import unittest
 from ortools.util import sorted_interval_list

--- a/examples/tests/test_cp_api.py
+++ b/examples/tests/test_cp_api.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ Various calls to CP api from python to verify they work."""
-from __future__ import print_function
 
 import unittest
 

--- a/examples/tests/test_routing_api.py
+++ b/examples/tests/test_routing_api.py
@@ -1,6 +1,5 @@
 # Various calls to CP api from python to verify they work.
 '''Test routing API'''
-from __future__ import print_function
 import types
 import unittest
 

--- a/ortools/algorithms/samples/knapsack.py
+++ b/ortools/algorithms/samples/knapsack.py
@@ -13,7 +13,6 @@
 """A simple knapsack problem."""
 # [START program]
 # [START import]
-from __future__ import print_function
 from ortools.algorithms import pywrapknapsack_solver
 # [END import]
 

--- a/ortools/algorithms/samples/simple_knapsack_program.py
+++ b/ortools/algorithms/samples/simple_knapsack_program.py
@@ -13,7 +13,6 @@
 # [START program]
 """A simple knapsack problem."""
 # [START import]
-from __future__ import print_function
 from ortools.algorithms import pywrapknapsack_solver
 # [END import]
 

--- a/ortools/constraint_solver/doc/routing_svg.py
+++ b/ortools/constraint_solver/doc/routing_svg.py
@@ -13,7 +13,6 @@
 """Generate SVG for a Routing problem."""
 
 # [START import]
-from __future__ import print_function
 import argparse
 from ortools.constraint_solver import pywrapcp
 from ortools.constraint_solver import routing_enums_pb2
@@ -22,7 +21,7 @@ from ortools.constraint_solver import routing_enums_pb2
 
 
 # [START data_model]
-class DataModel(object):  # pylint: disable=too-many-instance-attributes
+class DataModel:  # pylint: disable=too-many-instance-attributes
     """Stores the data for the problem."""
 
     def __init__(self, args):
@@ -253,7 +252,7 @@ class DataModel(object):  # pylint: disable=too-many-instance-attributes
 ###########
 # Printer #
 ###########
-class GoogleColorPalette(object):
+class GoogleColorPalette:
     """Google color codes palette."""
 
     def __init__(self):
@@ -288,7 +287,7 @@ class GoogleColorPalette(object):
         return dict(self._colors)[name]
 
 
-class SVG(object):
+class SVG:
     """SVG draw primitives."""
 
     @staticmethod
@@ -375,7 +374,7 @@ class SVG(object):
             txt=text))
 
 
-class SVGPrinter(object):  # pylint: disable=too-many-instance-attributes
+class SVGPrinter:  # pylint: disable=too-many-instance-attributes
     """Generate Problem as svg file to stdout."""
 
     # pylint: disable=too-many-arguments

--- a/ortools/constraint_solver/samples/cvrp.py
+++ b/ortools/constraint_solver/samples/cvrp.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# This Python file uses the following encoding: utf-8
 # Copyright 2015 Tin Arm Engineering AB
 # Copyright 2018 Google LLC
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +22,6 @@
    Distances are in meters.
 """
 
-from __future__ import print_function
 
 from functools import partial
 from six.moves import xrange
@@ -145,7 +143,7 @@ def print_solution(data, routing, manager, assignment):  # pylint:disable=too-ma
             distance += routing.GetArcCostForVehicle(previous_index, index,
                                                      vehicle_id)
         load_var = capacity_dimension.CumulVar(index)
-        plan_output += ' {0} Load({1})\n'.format(
+        plan_output += ' {} Load({})\n'.format(
             manager.IndexToNode(index), assignment.Value(load_var))
         plan_output += 'Distance of the route: {}m\n'.format(distance)
         plan_output += 'Load of the route: {}\n'.format(

--- a/ortools/constraint_solver/samples/cvrp.py
+++ b/ortools/constraint_solver/samples/cvrp.py
@@ -24,7 +24,6 @@
 
 
 from functools import partial
-from six.moves import xrange
 
 from ortools.constraint_solver import pywrapcp
 from ortools.constraint_solver import routing_enums_pb2
@@ -82,9 +81,9 @@ def create_distance_evaluator(data):
     """Creates callback to return distance between points."""
     _distances = {}
     # precompute distance between location to have distance callback in O(1)
-    for from_node in xrange(data['num_locations']):
+    for from_node in range(data['num_locations']):
         _distances[from_node] = {}
-        for to_node in xrange(data['num_locations']):
+        for to_node in range(data['num_locations']):
             if from_node == to_node:
                 _distances[from_node][to_node] = 0
             else:
@@ -130,7 +129,7 @@ def print_solution(data, routing, manager, assignment):  # pylint:disable=too-ma
     total_distance = 0
     total_load = 0
     capacity_dimension = routing.GetDimensionOrDie('Capacity')
-    for vehicle_id in xrange(data['num_vehicles']):
+    for vehicle_id in range(data['num_vehicles']):
         index = routing.Start(vehicle_id)
         plan_output = 'Route for vehicle {}:\n'.format(vehicle_id)
         distance = 0

--- a/ortools/constraint_solver/samples/cvrp_reload.py
+++ b/ortools/constraint_solver/samples/cvrp_reload.py
@@ -24,7 +24,6 @@
 
 
 from functools import partial
-from six.moves import xrange
 
 from ortools.constraint_solver import pywrapcp
 from ortools.constraint_solver import routing_enums_pb2
@@ -120,9 +119,9 @@ def create_distance_evaluator(data):
     """Creates callback to return distance between points."""
     _distances = {}
     # precompute distance between location to have distance callback in O(1)
-    for from_node in xrange(data['num_locations']):
+    for from_node in range(data['num_locations']):
         _distances[from_node] = {}
-        for to_node in xrange(data['num_locations']):
+        for to_node in range(data['num_locations']):
             if from_node == to_node:
                 _distances[from_node][to_node] = 0
             else:
@@ -202,9 +201,9 @@ def create_time_evaluator(data):
 
     _total_time = {}
     # precompute total time to have time callback in O(1)
-    for from_node in xrange(data['num_locations']):
+    for from_node in range(data['num_locations']):
         _total_time[from_node] = {}
-        for to_node in xrange(data['num_locations']):
+        for to_node in range(data['num_locations']):
             if from_node == to_node:
                 _total_time[from_node][to_node] = 0
             else:
@@ -241,7 +240,7 @@ def add_time_window_constraints(routing, manager, data, time_evaluator):
         routing.AddToAssignment(time_dimension.SlackVar(index))
     # Add time window constraints for each vehicle start node
     # and 'copy' the slack var in the solution object (aka Assignment) to print it
-    for vehicle_id in xrange(data['num_vehicles']):
+    for vehicle_id in range(data['num_vehicles']):
         index = routing.Start(vehicle_id)
         time_dimension.CumulVar(index).SetRange(data['time_windows'][0][0],
                                                 data['time_windows'][0][1])
@@ -262,13 +261,13 @@ def print_solution(data, manager, routing, assignment):  # pylint:disable=too-ma
     capacity_dimension = routing.GetDimensionOrDie('Capacity')
     time_dimension = routing.GetDimensionOrDie('Time')
     dropped = []
-    for order in xrange(0, routing.nodes()):
+    for order in range(0, routing.nodes()):
         index = manager.NodeToIndex(order)
         if assignment.Value(routing.NextVar(index)) == index:
             dropped.append(order)
     print('dropped orders: {}'.format(dropped))
 
-    for vehicle_id in xrange(data['num_vehicles']):
+    for vehicle_id in range(data['num_vehicles']):
         index = routing.Start(vehicle_id)
         plan_output = 'Route for vehicle {}:\n'.format(vehicle_id)
         distance = 0

--- a/ortools/constraint_solver/samples/cvrp_reload.py
+++ b/ortools/constraint_solver/samples/cvrp_reload.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# This Python file uses the following encoding: utf-8
 # Copyright 2015 Tin Arm Engineering AB
 # Copyright 2018 Google LLC
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +22,6 @@
    Distances are in meters.
 """
 
-from __future__ import print_function
 
 from functools import partial
 from six.moves import xrange
@@ -277,7 +275,7 @@ def print_solution(data, manager, routing, assignment):  # pylint:disable=too-ma
         while not routing.IsEnd(index):
             load_var = capacity_dimension.CumulVar(index)
             time_var = time_dimension.CumulVar(index)
-            plan_output += ' {0} Load({1}) Time({2},{3}) ->'.format(
+            plan_output += ' {} Load({}) Time({},{}) ->'.format(
                 manager.IndexToNode(index),
                 assignment.Value(load_var),
                 assignment.Min(time_var), assignment.Max(time_var))
@@ -287,7 +285,7 @@ def print_solution(data, manager, routing, assignment):  # pylint:disable=too-ma
                                                      vehicle_id)
         load_var = capacity_dimension.CumulVar(index)
         time_var = time_dimension.CumulVar(index)
-        plan_output += ' {0} Load({1}) Time({2},{3})\n'.format(
+        plan_output += ' {} Load({}) Time({},{})\n'.format(
             manager.IndexToNode(index),
             assignment.Value(load_var),
             assignment.Min(time_var), assignment.Max(time_var))

--- a/ortools/constraint_solver/samples/cvrptw.py
+++ b/ortools/constraint_solver/samples/cvrptw.py
@@ -24,7 +24,6 @@
 
 
 from functools import partial
-from six.moves import xrange
 
 from ortools.constraint_solver import pywrapcp
 from ortools.constraint_solver import routing_enums_pb2
@@ -94,9 +93,9 @@ def create_distance_evaluator(data):
     """Creates callback to return distance between points."""
     _distances = {}
     # precompute distance between location to have distance callback in O(1)
-    for from_node in xrange(data['num_locations']):
+    for from_node in range(data['num_locations']):
         _distances[from_node] = {}
-        for to_node in xrange(data['num_locations']):
+        for to_node in range(data['num_locations']):
             if from_node == to_node:
                 _distances[from_node][to_node] = 0
             else:
@@ -151,9 +150,9 @@ def create_time_evaluator(data):
 
     _total_time = {}
     # precompute total time to have time callback in O(1)
-    for from_node in xrange(data['num_locations']):
+    for from_node in range(data['num_locations']):
         _total_time[from_node] = {}
-        for to_node in xrange(data['num_locations']):
+        for to_node in range(data['num_locations']):
             if from_node == to_node:
                 _total_time[from_node][to_node] = 0
             else:
@@ -190,7 +189,7 @@ def add_time_window_constraints(routing, manager, data, time_evaluator_index):
         routing.AddToAssignment(time_dimension.SlackVar(index))
     # Add time window constraints for each vehicle start node
     # and 'copy' the slack var in the solution object (aka Assignment) to print it
-    for vehicle_id in xrange(data['num_vehicles']):
+    for vehicle_id in range(data['num_vehicles']):
         index = routing.Start(vehicle_id)
         time_dimension.CumulVar(index).SetRange(data['time_windows'][0][0],
                                                 data['time_windows'][0][1])
@@ -210,7 +209,7 @@ def print_solution(data, manager, routing, assignment):  # pylint:disable=too-ma
     total_time = 0
     capacity_dimension = routing.GetDimensionOrDie('Capacity')
     time_dimension = routing.GetDimensionOrDie('Time')
-    for vehicle_id in xrange(data['num_vehicles']):
+    for vehicle_id in range(data['num_vehicles']):
         index = routing.Start(vehicle_id)
         plan_output = 'Route for vehicle {}:\n'.format(vehicle_id)
         distance = 0

--- a/ortools/constraint_solver/samples/cvrptw.py
+++ b/ortools/constraint_solver/samples/cvrptw.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# This Python file uses the following encoding: utf-8
 # Copyright 2015 Tin Arm Engineering AB
 # Copyright 2018 Google LLC
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +22,6 @@
    Distances are in meters and time in minutes.
 """
 
-from __future__ import print_function
 
 from functools import partial
 from six.moves import xrange
@@ -220,7 +218,7 @@ def print_solution(data, manager, routing, assignment):  # pylint:disable=too-ma
             load_var = capacity_dimension.CumulVar(index)
             time_var = time_dimension.CumulVar(index)
             slack_var = time_dimension.SlackVar(index)
-            plan_output += ' {0} Load({1}) Time({2},{3}) Slack({4},{5}) ->'.format(
+            plan_output += ' {} Load({}) Time({},{}) Slack({},{}) ->'.format(
                 manager.IndexToNode(index),
                 assignment.Value(load_var),
                 assignment.Min(time_var),
@@ -233,11 +231,11 @@ def print_solution(data, manager, routing, assignment):  # pylint:disable=too-ma
         load_var = capacity_dimension.CumulVar(index)
         time_var = time_dimension.CumulVar(index)
         slack_var = time_dimension.SlackVar(index)
-        plan_output += ' {0} Load({1}) Time({2},{3})\n'.format(
+        plan_output += ' {} Load({}) Time({},{})\n'.format(
             manager.IndexToNode(index),
             assignment.Value(load_var),
             assignment.Min(time_var), assignment.Max(time_var))
-        plan_output += 'Distance of the route: {0}m\n'.format(distance)
+        plan_output += 'Distance of the route: {}m\n'.format(distance)
         plan_output += 'Load of the route: {}\n'.format(
             assignment.Value(load_var))
         plan_output += 'Time of the route: {}\n'.format(
@@ -246,9 +244,9 @@ def print_solution(data, manager, routing, assignment):  # pylint:disable=too-ma
         total_distance += distance
         total_load += assignment.Value(load_var)
         total_time += assignment.Value(time_var)
-    print('Total Distance of all routes: {0}m'.format(total_distance))
+    print('Total Distance of all routes: {}m'.format(total_distance))
     print('Total Load of all routes: {}'.format(total_load))
-    print('Total Time of all routes: {0}min'.format(total_time))
+    print('Total Time of all routes: {}min'.format(total_time))
 
 
 ########

--- a/ortools/constraint_solver/samples/cvrptw_break.py
+++ b/ortools/constraint_solver/samples/cvrptw_break.py
@@ -24,7 +24,6 @@
 
 
 from functools import partial
-from six.moves import xrange
 
 from ortools.constraint_solver import pywrapcp
 from ortools.constraint_solver import routing_enums_pb2
@@ -95,9 +94,9 @@ def create_distance_evaluator(data):
     """Creates callback to return distance between points."""
     _distances = {}
     # precompute distance between location to have distance callback in O(1)
-    for from_node in xrange(data['num_locations']):
+    for from_node in range(data['num_locations']):
         _distances[from_node] = {}
-        for to_node in xrange(data['num_locations']):
+        for to_node in range(data['num_locations']):
             if from_node == to_node:
                 _distances[from_node][to_node] = 0
             else:
@@ -152,9 +151,9 @@ def create_time_evaluator(data):
 
     _total_time = {}
     # precompute total time to have time callback in O(1)
-    for from_node in xrange(data['num_locations']):
+    for from_node in range(data['num_locations']):
         _total_time[from_node] = {}
-        for to_node in xrange(data['num_locations']):
+        for to_node in range(data['num_locations']):
             if from_node == to_node:
                 _total_time[from_node][to_node] = 0
             else:
@@ -191,7 +190,7 @@ def add_time_window_constraints(routing, manager, data, time_evaluator_index):
         routing.AddToAssignment(time_dimension.SlackVar(index))
     # Add time window constraints for each vehicle start node
     # and 'copy' the slack var in the solution object (aka Assignment) to print it
-    for vehicle_id in xrange(data['num_vehicles']):
+    for vehicle_id in range(data['num_vehicles']):
         index = routing.Start(vehicle_id)
         time_dimension.CumulVar(index).SetRange(data['time_windows'][0][0],
                                                 data['time_windows'][0][1])
@@ -209,7 +208,7 @@ def print_solution(data, manager, routing, assignment):  # pylint:disable=too-ma
 
     print('Breaks:')
     intervals = assignment.IntervalVarContainer()
-    for i in xrange(intervals.Size()):
+    for i in range(intervals.Size()):
         brk = intervals.Element(i)
         if brk.PerformedValue() == 1:
             print('{}: Start({}) Duration({})'.format(
@@ -224,7 +223,7 @@ def print_solution(data, manager, routing, assignment):  # pylint:disable=too-ma
     total_time = 0
     capacity_dimension = routing.GetDimensionOrDie('Capacity')
     time_dimension = routing.GetDimensionOrDie('Time')
-    for vehicle_id in xrange(data['num_vehicles']):
+    for vehicle_id in range(data['num_vehicles']):
         index = routing.Start(vehicle_id)
         plan_output = 'Route for vehicle {}:\n'.format(vehicle_id)
         distance = 0
@@ -296,7 +295,7 @@ def main():
     # Add breaks
     time_dimension = routing.GetDimensionOrDie("Time")
     node_visit_transit = {}
-    for n in xrange(routing.Size()):
+    for n in range(routing.Size()):
         if n >= data['num_locations']:
             node_visit_transit[n] = 0
         else:
@@ -304,7 +303,7 @@ def main():
                 data['demands'][n] * data['time_per_demand_unit'])
 
     break_intervals = {}
-    #for v in xrange(data['num_vehicles']):
+    #for v in range(data['num_vehicles']):
     for v in [0]:
         vehicle_break = data['breaks'][v]
         break_intervals[v] = [

--- a/ortools/constraint_solver/samples/cvrptw_break.py
+++ b/ortools/constraint_solver/samples/cvrptw_break.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# This Python file uses the following encoding: utf-8
 # Copyright 2015 Tin Arm Engineering AB
 # Copyright 2018 Google LLC
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +22,6 @@
    Distances are in meters and time in minutes.
 """
 
-from __future__ import print_function
 
 from functools import partial
 from six.moves import xrange
@@ -234,7 +232,7 @@ def print_solution(data, manager, routing, assignment):  # pylint:disable=too-ma
             load_var = capacity_dimension.CumulVar(index)
             time_var = time_dimension.CumulVar(index)
             slack_var = time_dimension.SlackVar(index)
-            plan_output += ' {0} Load({1}) Time({2},{3}) Slack({4},{5}) ->'.format(
+            plan_output += ' {} Load({}) Time({},{}) Slack({},{}) ->'.format(
                 manager.IndexToNode(index),
                 assignment.Value(load_var),
                 assignment.Min(time_var),
@@ -247,11 +245,11 @@ def print_solution(data, manager, routing, assignment):  # pylint:disable=too-ma
         load_var = capacity_dimension.CumulVar(index)
         time_var = time_dimension.CumulVar(index)
         slack_var = time_dimension.SlackVar(index)
-        plan_output += ' {0} Load({1}) Time({2},{3})\n'.format(
+        plan_output += ' {} Load({}) Time({},{})\n'.format(
             manager.IndexToNode(index),
             assignment.Value(load_var),
             assignment.Min(time_var), assignment.Max(time_var))
-        plan_output += 'Distance of the route: {0}m\n'.format(distance)
+        plan_output += 'Distance of the route: {}m\n'.format(distance)
         plan_output += 'Load of the route: {}\n'.format(
             assignment.Value(load_var))
         plan_output += 'Time of the route: {}\n'.format(
@@ -260,9 +258,9 @@ def print_solution(data, manager, routing, assignment):  # pylint:disable=too-ma
         total_distance += distance
         total_load += assignment.Value(load_var)
         total_time += assignment.Value(time_var)
-    print('Total Distance of all routes: {0}m'.format(total_distance))
+    print('Total Distance of all routes: {}m'.format(total_distance))
     print('Total Load of all routes: {}'.format(total_load))
-    print('Total Time of all routes: {0}min'.format(total_time))
+    print('Total Time of all routes: {}min'.format(total_time))
 
 
 ########

--- a/ortools/constraint_solver/samples/simple_cp_program.py
+++ b/ortools/constraint_solver/samples/simple_cp_program.py
@@ -14,7 +14,6 @@
 """Simple Constraint optimization example."""
 
 # [START import]
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 # [END import]
 

--- a/ortools/constraint_solver/samples/simple_routing_program.py
+++ b/ortools/constraint_solver/samples/simple_routing_program.py
@@ -14,7 +14,6 @@
 """Vehicle Routing example."""
 
 # [START import]
-from __future__ import print_function
 from ortools.constraint_solver import routing_enums_pb2
 from ortools.constraint_solver import pywrapcp
 from ortools.constraint_solver import pywrapcp

--- a/ortools/constraint_solver/samples/tsp.py
+++ b/ortools/constraint_solver/samples/tsp.py
@@ -18,7 +18,6 @@ http://en.wikipedia.org/wiki/Travelling_salesman_problem.
 """
 
 # [START import]
-from __future__ import print_function
 from ortools.constraint_solver import routing_enums_pb2
 from ortools.constraint_solver import pywrapcp
 # [END import]

--- a/ortools/constraint_solver/samples/tsp_circuit_board.py
+++ b/ortools/constraint_solver/samples/tsp_circuit_board.py
@@ -14,7 +14,6 @@
 """Simple travelling salesman problem on a circuit board."""
 
 # [START import]
-from __future__ import print_function
 import math
 from ortools.constraint_solver import routing_enums_pb2
 from ortools.constraint_solver import pywrapcp

--- a/ortools/constraint_solver/samples/tsp_cities.py
+++ b/ortools/constraint_solver/samples/tsp_cities.py
@@ -14,7 +14,6 @@
 """Simple travelling salesman problem between cities."""
 
 # [START import]
-from __future__ import print_function
 from ortools.constraint_solver import routing_enums_pb2
 from ortools.constraint_solver import pywrapcp
 

--- a/ortools/constraint_solver/samples/tsp_distance_matrix.py
+++ b/ortools/constraint_solver/samples/tsp_distance_matrix.py
@@ -14,7 +14,6 @@
 """Simple Travelling Salesman Problem."""
 
 # [START import]
-from __future__ import print_function
 from ortools.constraint_solver import routing_enums_pb2
 from ortools.constraint_solver import pywrapcp
 # [END import]

--- a/ortools/constraint_solver/samples/vrp.py
+++ b/ortools/constraint_solver/samples/vrp.py
@@ -14,7 +14,6 @@
 """Simple Vehicles Routing Problem."""
 
 # [START import]
-from __future__ import print_function
 from ortools.constraint_solver import routing_enums_pb2
 from ortools.constraint_solver import pywrapcp
 # [END import]

--- a/ortools/constraint_solver/samples/vrp_capacity.py
+++ b/ortools/constraint_solver/samples/vrp_capacity.py
@@ -14,7 +14,6 @@
 """Capacited Vehicles Routing Problem (CVRP)."""
 
 # [START import]
-from __future__ import print_function
 from ortools.constraint_solver import routing_enums_pb2
 from ortools.constraint_solver import pywrapcp
 # [END import]
@@ -117,12 +116,12 @@ def print_solution(data, manager, routing, solution):
         while not routing.IsEnd(index):
             node_index = manager.IndexToNode(index)
             route_load += data['demands'][node_index]
-            plan_output += ' {0} Load({1}) -> '.format(node_index, route_load)
+            plan_output += ' {} Load({}) -> '.format(node_index, route_load)
             previous_index = index
             index = solution.Value(routing.NextVar(index))
             route_distance += routing.GetArcCostForVehicle(
                 previous_index, index, vehicle_id)
-        plan_output += ' {0} Load({1})\n'.format(manager.IndexToNode(index),
+        plan_output += ' {} Load({})\n'.format(manager.IndexToNode(index),
                                                  route_load)
         plan_output += 'Distance of the route: {}m\n'.format(route_distance)
         plan_output += 'Load of the route: {}\n'.format(route_load)

--- a/ortools/constraint_solver/samples/vrp_drop_nodes.py
+++ b/ortools/constraint_solver/samples/vrp_drop_nodes.py
@@ -14,7 +14,6 @@
 """Capacited Vehicles Routing Problem (CVRP)."""
 
 # [START import]
-from __future__ import print_function
 from ortools.constraint_solver import routing_enums_pb2
 from ortools.constraint_solver import pywrapcp
 # [END import]
@@ -126,12 +125,12 @@ def print_solution(data, manager, routing, assignment):
         while not routing.IsEnd(index):
             node_index = manager.IndexToNode(index)
             route_load += data['demands'][node_index]
-            plan_output += ' {0} Load({1}) -> '.format(node_index, route_load)
+            plan_output += ' {} Load({}) -> '.format(node_index, route_load)
             previous_index = index
             index = assignment.Value(routing.NextVar(index))
             route_distance += routing.GetArcCostForVehicle(
                 previous_index, index, vehicle_id)
-        plan_output += ' {0} Load({1})\n'.format(manager.IndexToNode(index),
+        plan_output += ' {} Load({})\n'.format(manager.IndexToNode(index),
                                                  route_load)
         plan_output += 'Distance of the route: {}m\n'.format(route_distance)
         plan_output += 'Load of the route: {}\n'.format(route_load)

--- a/ortools/constraint_solver/samples/vrp_global_span.py
+++ b/ortools/constraint_solver/samples/vrp_global_span.py
@@ -14,7 +14,6 @@
 """Vehicles Routing Problem (VRP)."""
 
 # [START import]
-from __future__ import print_function
 from ortools.constraint_solver import routing_enums_pb2
 from ortools.constraint_solver import pywrapcp
 # [END import]

--- a/ortools/constraint_solver/samples/vrp_initial_routes.py
+++ b/ortools/constraint_solver/samples/vrp_initial_routes.py
@@ -14,7 +14,6 @@
 """Vehicles Routing Problem (VRP)."""
 
 # [START import]
-from __future__ import print_function
 from ortools.constraint_solver import pywrapcp
 from ortools.constraint_solver import pywrapcp
 

--- a/ortools/constraint_solver/samples/vrp_pickup_delivery.py
+++ b/ortools/constraint_solver/samples/vrp_pickup_delivery.py
@@ -14,7 +14,6 @@
 """Simple Pickup Delivery Problem (PDP)."""
 
 # [START import]
-from __future__ import print_function
 from ortools.constraint_solver import routing_enums_pb2
 from ortools.constraint_solver import pywrapcp
 # [END import]

--- a/ortools/constraint_solver/samples/vrp_pickup_delivery_fifo.py
+++ b/ortools/constraint_solver/samples/vrp_pickup_delivery_fifo.py
@@ -14,7 +14,6 @@
 """Simple Pickup Delivery Problem (PDP)."""
 
 # [START import]
-from __future__ import print_function
 from ortools.constraint_solver import routing_enums_pb2
 from ortools.constraint_solver import pywrapcp
 # [END import]

--- a/ortools/constraint_solver/samples/vrp_pickup_delivery_lifo.py
+++ b/ortools/constraint_solver/samples/vrp_pickup_delivery_lifo.py
@@ -14,7 +14,6 @@
 """Simple Pickup Delivery Problem (PDP)."""
 
 # [START import]
-from __future__ import print_function
 from ortools.constraint_solver import routing_enums_pb2
 from ortools.constraint_solver import pywrapcp
 # [END import]

--- a/ortools/constraint_solver/samples/vrp_resources.py
+++ b/ortools/constraint_solver/samples/vrp_resources.py
@@ -14,7 +14,6 @@
 """Vehicles Routing Problem (VRP) with Resource Constraints."""
 
 # [START import]
-from __future__ import print_function
 from ortools.constraint_solver import routing_enums_pb2
 from ortools.constraint_solver import pywrapcp
 # [END import]
@@ -83,12 +82,12 @@ def print_solution(data, manager, routing, solution):
         plan_output = 'Route for vehicle {}:\n'.format(vehicle_id)
         while not routing.IsEnd(index):
             time_var = time_dimension.CumulVar(index)
-            plan_output += '{0} Time({1},{2}) -> '.format(
+            plan_output += '{} Time({},{}) -> '.format(
                 manager.IndexToNode(index), solution.Min(time_var),
                 solution.Max(time_var))
             index = solution.Value(routing.NextVar(index))
         time_var = time_dimension.CumulVar(index)
-        plan_output += '{0} Time({1},{2})\n'.format(manager.IndexToNode(index),
+        plan_output += '{} Time({},{})\n'.format(manager.IndexToNode(index),
                                                     solution.Min(time_var),
                                                     solution.Max(time_var))
         plan_output += 'Time of the route: {}min\n'.format(

--- a/ortools/constraint_solver/samples/vrp_starts_ends.py
+++ b/ortools/constraint_solver/samples/vrp_starts_ends.py
@@ -14,7 +14,6 @@
 """Simple Vehicles Routing Problem."""
 
 # [START import]
-from __future__ import print_function
 from ortools.constraint_solver import routing_enums_pb2
 from ortools.constraint_solver import pywrapcp
 # [END import]

--- a/ortools/constraint_solver/samples/vrp_time_windows.py
+++ b/ortools/constraint_solver/samples/vrp_time_windows.py
@@ -14,7 +14,6 @@
 """Vehicles Routing Problem (VRP) with Time Windows."""
 
 # [START import]
-from __future__ import print_function
 from ortools.constraint_solver import routing_enums_pb2
 from ortools.constraint_solver import pywrapcp
 # [END import]
@@ -78,12 +77,12 @@ def print_solution(data, manager, routing, solution):
         plan_output = 'Route for vehicle {}:\n'.format(vehicle_id)
         while not routing.IsEnd(index):
             time_var = time_dimension.CumulVar(index)
-            plan_output += '{0} Time({1},{2}) -> '.format(
+            plan_output += '{} Time({},{}) -> '.format(
                 manager.IndexToNode(index), solution.Min(time_var),
                 solution.Max(time_var))
             index = solution.Value(routing.NextVar(index))
         time_var = time_dimension.CumulVar(index)
-        plan_output += '{0} Time({1},{2})\n'.format(manager.IndexToNode(index),
+        plan_output += '{} Time({},{})\n'.format(manager.IndexToNode(index),
                                                     solution.Min(time_var),
                                                     solution.Max(time_var))
         plan_output += 'Time of the route: {}min\n'.format(

--- a/ortools/constraint_solver/samples/vrp_with_time_limit.py
+++ b/ortools/constraint_solver/samples/vrp_with_time_limit.py
@@ -14,7 +14,6 @@
 """Vehicles Routing Problem (VRP)."""
 
 # [START import]
-from __future__ import print_function
 from ortools.constraint_solver import routing_enums_pb2
 from ortools.constraint_solver import pywrapcp
 # [END import]

--- a/ortools/constraint_solver/samples/vrpgs.py
+++ b/ortools/constraint_solver/samples/vrpgs.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# This Python file uses the following encoding: utf-8
 # Copyright 2015 Tin Arm Engineering AB
 # Copyright 2018 Google LLC
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +22,6 @@
    Distances are in meters.
 """
 
-from __future__ import print_function
 
 from functools import partial
 from six.moves import xrange

--- a/ortools/constraint_solver/samples/vrpgs.py
+++ b/ortools/constraint_solver/samples/vrpgs.py
@@ -24,7 +24,6 @@
 
 
 from functools import partial
-from six.moves import xrange
 
 from ortools.constraint_solver import pywrapcp
 from ortools.constraint_solver import routing_enums_pb2
@@ -71,9 +70,9 @@ def create_distance_evaluator(data):
     """Creates callback to return distance between points."""
     _distances = {}
     # precompute distance between location to have distance callback in O(1)
-    for from_node in xrange(data['num_locations']):
+    for from_node in range(data['num_locations']):
         _distances[from_node] = {}
-        for to_node in xrange(data['num_locations']):
+        for to_node in range(data['num_locations']):
             if from_node == to_node:
                 _distances[from_node][to_node] = 0
             else:
@@ -110,7 +109,7 @@ def print_solution(data, routing, manager, assignment):  # pylint:disable=too-ma
     """Prints assignment on console"""
     print('Objective: {}'.format(assignment.ObjectiveValue()))
     total_distance = 0
-    for vehicle_id in xrange(data['num_vehicles']):
+    for vehicle_id in range(data['num_vehicles']):
         index = routing.Start(vehicle_id)
         plan_output = 'Route for vehicle {}:\n'.format(vehicle_id)
         distance = 0

--- a/ortools/graph/samples/simple_max_flow_program.py
+++ b/ortools/graph/samples/simple_max_flow_program.py
@@ -13,7 +13,6 @@
 # [START program]
 """From Taha 'Introduction to Operations Research', example 6.4-2."""
 # [START import]
-from __future__ import print_function
 from ortools.graph import pywrapgraph
 # [END import]
 

--- a/ortools/graph/samples/simple_min_cost_flow_program.py
+++ b/ortools/graph/samples/simple_min_cost_flow_program.py
@@ -13,7 +13,6 @@
 # [START program]
 """From Bradley, H. and M., 'Applied Mathematical Programming', figure 8.1."""
 # [START import]
-from __future__ import print_function
 from ortools.graph import pywrapgraph
 # [END import]
 

--- a/ortools/linear_solver/linear_solver_natural_api.py
+++ b/ortools/linear_solver/linear_solver_natural_api.py
@@ -30,7 +30,7 @@ from six import iteritems
 inf = float('inf')
 
 
-class _FakeMPVariableRepresentingTheConstantOffset(object):
+class _FakeMPVariableRepresentingTheConstantOffset:
   """A dummy class for a singleton instance used to represent the constant.
 
   To represent linear expressions, we store a dictionary
@@ -56,7 +56,7 @@ def CastToLinExp(v):
     return v
 
 
-class LinearExpr(object):
+class LinearExpr:
   """Holds linear expressions.
 
   A linear expression is essentially an offset (floating-point value), and a
@@ -226,7 +226,7 @@ def Sum(*args):
 SumCst = Sum  # pylint: disable=invalid-name
 
 
-class LinearConstraint(object):
+class LinearConstraint:
   """Represents a linear constraint: LowerBound <= LinearExpr <= UpperBound."""
 
   def __init__(self, expr, lb, ub):
@@ -260,6 +260,6 @@ class LinearConstraint(object):
       ub = self.__ub - constant
 
     constraint = solver.RowConstraint(lb, ub, name)
-    for v, c, in iteritems(coeffs):
+    for v, c, in coeffs.items():
       constraint.SetCoefficient(v, float(c))
     return constraint

--- a/ortools/linear_solver/samples/integer_programming_example.py
+++ b/ortools/linear_solver/samples/integer_programming_example.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 """Small example to illustrate solving a MIP problem."""
 # [START program]
-from __future__ import print_function
 # [START import]
 from ortools.linear_solver import pywraplp
 # [END import]

--- a/ortools/linear_solver/samples/linear_programming_example.py
+++ b/ortools/linear_solver/samples/linear_programming_example.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 """Linear optimization example."""
 # [START program]
-from __future__ import print_function
 # [START import]
 from ortools.linear_solver import pywraplp
 

--- a/ortools/linear_solver/samples/mip_var_array.py
+++ b/ortools/linear_solver/samples/mip_var_array.py
@@ -13,7 +13,6 @@
 """MIP example that uses a variable array."""
 # [START program]
 # [START import]
-from __future__ import print_function
 from ortools.linear_solver import pywraplp
 
 # [END import]

--- a/ortools/linear_solver/samples/simple_lp_program.py
+++ b/ortools/linear_solver/samples/simple_lp_program.py
@@ -13,7 +13,6 @@
 """Minimal example to call the GLOP solver."""
 # [START program]
 # [START import]
-from __future__ import print_function
 from ortools.linear_solver import pywraplp
 # [END import]
 

--- a/ortools/linear_solver/samples/simple_mip_program.py
+++ b/ortools/linear_solver/samples/simple_mip_program.py
@@ -13,7 +13,6 @@
 """Integer programming examples that show how to use the APIs."""
 # [START program]
 # [START import]
-from __future__ import print_function
 from ortools.linear_solver import pywraplp
 # [END import]
 

--- a/ortools/sat/python/cp_model.py
+++ b/ortools/sat/python/cp_model.py
@@ -44,9 +44,6 @@ Other methods and functions listed are primarily used for developing OR-Tools,
 rather than for solving specific optimization problems.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 import numbers
@@ -134,7 +131,7 @@ def ShortName(model, i):
         return '[%s]' % DisplayBounds(v.domain)
 
 
-class LinearExpr(object):
+class LinearExpr:
     """Holds an integer linear expression.
 
   A linear expression is built from integer constants and variables.
@@ -485,7 +482,7 @@ class IntVar(LinearExpr):
         return self.__var.name
 
     def __repr__(self):
-        return '%s(%s)' % (self.__var.name, DisplayBounds(self.__var.domain))
+        return '{}({})'.format(self.__var.name, DisplayBounds(self.__var.domain))
 
     def Name(self):
         return self.__var.name
@@ -524,7 +521,7 @@ class _NotBooleanVariable(LinearExpr):
         return 'not(%s)' % str(self.__boolvar)
 
 
-class BoundedLinearExpression(object):
+class BoundedLinearExpression:
     """Represents a linear constraint: `lb <= linear expression <= ub`.
 
   The only use of this class is to be added to the CpModel through
@@ -564,7 +561,7 @@ class BoundedLinearExpression(object):
         return self.__bounds
 
 
-class Constraint(object):
+class Constraint:
     """Base class for constraints.
 
   Constraints are built by the CpModel through the Add<XXX> methods.
@@ -623,7 +620,7 @@ class Constraint(object):
         return self.__constraint
 
 
-class IntervalVar(object):
+class IntervalVar:
     """Represents an Interval variable.
 
   An interval variable is both a constraint and a variable. It is defined by
@@ -668,13 +665,13 @@ class IntervalVar(object):
     def __repr__(self):
         interval = self.__ct.interval
         if self.__ct.enforcement_literal:
-            return '%s(start = %s, size = %s, end = %s, is_present = %s)' % (
+            return '{}(start = {}, size = {}, end = {}, is_present = {})'.format(
                 self.__ct.name, ShortName(self.__model, interval.start),
                 ShortName(self.__model,
                           interval.size), ShortName(self.__model, interval.end),
                 ShortName(self.__model, self.__ct.enforcement_literal[0]))
         else:
-            return '%s(start = %s, size = %s, end = %s)' % (
+            return '{}(start = {}, size = {}, end = {})'.format(
                 self.__ct.name, ShortName(self.__model, interval.start),
                 ShortName(self.__model,
                           interval.size), ShortName(self.__model, interval.end))
@@ -683,7 +680,7 @@ class IntervalVar(object):
         return self.__ct.name
 
 
-class CpModel(object):
+class CpModel:
     """Methods for building a CP model.
 
   Methods beginning with:
@@ -753,7 +750,7 @@ class CpModel(object):
             ct = Constraint(self.__model.constraints)
             model_ct = self.__model.constraints[ct.Index()]
             coeffs_map, constant = linear_expr.GetVarValueMap()
-            for t in iteritems(coeffs_map):
+            for t in coeffs_map.items():
                 if not isinstance(t[0], IntVar):
                     raise TypeError('Wrong argument' + str(t))
                 cp_model_helper.AssertIsInt64(t[1])
@@ -1460,7 +1457,7 @@ class CpModel(object):
             else:
                 self.__model.objective.scaling_factor = -1
                 self.__model.objective.offset = -constant
-            for v, c, in iteritems(coeffs_map):
+            for v, c, in coeffs_map.items():
                 self.__model.objective.coeffs.append(c)
                 if minimize:
                     self.__model.objective.vars.append(v.Index())
@@ -1570,7 +1567,7 @@ def EvaluateBooleanExpression(literal, solution):
                         literal)
 
 
-class CpSolver(object):
+class CpSolver:
     """Main solver class.
 
   The purpose of this class is to search for a solution to the model provided

--- a/ortools/sat/python/cp_model_helper.py
+++ b/ortools/sat/python/cp_model_helper.py
@@ -12,9 +12,6 @@
 # limitations under the License.
 """helpers methods for the cp_model module."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numbers
 

--- a/ortools/sat/python/visualization.py
+++ b/ortools/sat/python/visualization.py
@@ -38,7 +38,7 @@ def ToDate(v):
     return '2016-01-01 6:%02i:%02i' % (v / 60, v % 60)
 
 
-class ColorManager(object):
+class ColorManager:
     """Utility to create colors to use in visualization."""
 
     def ScaledColor(self, sr, sg, sb, er, eg, eb, num_steps, step):
@@ -97,7 +97,7 @@ def DisplayJobshop(starts, durations, machines, name):
     pyo.iplot(fig)
 
 
-class SvgWrapper(object):
+class SvgWrapper:
     """Simple SVG wrapper to use in colab."""
 
     def __init__(self, sizex, sizey, scaling=20.0):

--- a/ortools/sat/samples/binpacking_problem_sat.py
+++ b/ortools/sat/samples/binpacking_problem_sat.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 """Solves a binpacking problem using the CP-SAT solver."""
 
-from __future__ import print_function
 
 from ortools.sat.python import cp_model
 

--- a/ortools/sat/samples/bool_or_sample_sat.py
+++ b/ortools/sat/samples/bool_or_sample_sat.py
@@ -12,9 +12,6 @@
 # limitations under the License.
 """Code sample to demonstrates a simple Boolean constraint."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from ortools.sat.python import cp_model
 

--- a/ortools/sat/samples/boolean_product_sample_sat.py
+++ b/ortools/sat/samples/boolean_product_sample_sat.py
@@ -12,9 +12,6 @@
 # limitations under the License.
 """Code sample that encodes the product of two Boolean variables."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from ortools.sat.python import cp_model
 

--- a/ortools/sat/samples/channeling_sample_sat.py
+++ b/ortools/sat/samples/channeling_sample_sat.py
@@ -12,9 +12,6 @@
 # limitations under the License.
 """Link integer constraints together."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from ortools.sat.python import cp_model
 

--- a/ortools/sat/samples/cp_is_fun_sat.py
+++ b/ortools/sat/samples/cp_is_fun_sat.py
@@ -20,7 +20,6 @@ This problem has 72 different solutions in base 10.
 """
 
 # [START program]
-from __future__ import print_function
 
 from ortools.sat.python import cp_model
 

--- a/ortools/sat/samples/earliness_tardiness_cost_sample_sat.py
+++ b/ortools/sat/samples/earliness_tardiness_cost_sample_sat.py
@@ -12,9 +12,6 @@
 # limitations under the License.
 """Encodes an convex piecewise linear function."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from ortools.sat.python import cp_model
 

--- a/ortools/sat/samples/interval_sample_sat.py
+++ b/ortools/sat/samples/interval_sample_sat.py
@@ -12,9 +12,6 @@
 # limitations under the License.
 """Code sample to demonstrates how to build an interval."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from ortools.sat.python import cp_model
 

--- a/ortools/sat/samples/literal_sample_sat.py
+++ b/ortools/sat/samples/literal_sample_sat.py
@@ -12,9 +12,6 @@
 # limitations under the License.
 """Code sample to demonstrate Boolean variable and literals."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from ortools.sat.python import cp_model
 

--- a/ortools/sat/samples/minimal_jobshop_sat.py
+++ b/ortools/sat/samples/minimal_jobshop_sat.py
@@ -13,7 +13,6 @@
 """Minimal jobshop example."""
 
 # [START program]
-from __future__ import print_function
 
 import collections
 

--- a/ortools/sat/samples/multiple_knapsack_sat.py
+++ b/ortools/sat/samples/multiple_knapsack_sat.py
@@ -14,9 +14,6 @@
 """Solves a multiple knapsack problem using the CP-SAT solver."""
 
 # [START import]
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from ortools.sat.python import cp_model
 

--- a/ortools/sat/samples/no_overlap_sample_sat.py
+++ b/ortools/sat/samples/no_overlap_sample_sat.py
@@ -12,9 +12,6 @@
 # limitations under the License.
 """Code sample to demonstrate how to build a NoOverlap constraint."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from ortools.sat.python import cp_model
 

--- a/ortools/sat/samples/nurses_sat.py
+++ b/ortools/sat/samples/nurses_sat.py
@@ -14,7 +14,6 @@
 
 # [START program]
 # [START import]
-from __future__ import print_function
 from ortools.sat.python import cp_model
 
 # [END import]

--- a/ortools/sat/samples/optional_interval_sample_sat.py
+++ b/ortools/sat/samples/optional_interval_sample_sat.py
@@ -12,9 +12,6 @@
 # limitations under the License.
 """Code sample to demonstrates how to build an optional interval."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from ortools.sat.python import cp_model
 

--- a/ortools/sat/samples/rabbits_and_pheasants_sat.py
+++ b/ortools/sat/samples/rabbits_and_pheasants_sat.py
@@ -12,9 +12,6 @@
 # limitations under the License.
 """Rabbits and Pheasants quizz."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from ortools.sat.python import cp_model
 

--- a/ortools/sat/samples/ranking_sample_sat.py
+++ b/ortools/sat/samples/ranking_sample_sat.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 """Code sample to demonstrates how to rank intervals."""
 
-from __future__ import print_function
 
 from ortools.sat.python import cp_model
 

--- a/ortools/sat/samples/reified_sample_sat.py
+++ b/ortools/sat/samples/reified_sample_sat.py
@@ -12,9 +12,6 @@
 # limitations under the License.
 """Simple model with a reified constraint."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from ortools.sat.python import cp_model
 

--- a/ortools/sat/samples/schedule_requests_sat.py
+++ b/ortools/sat/samples/schedule_requests_sat.py
@@ -14,7 +14,6 @@
 
 # [START program]
 # [START import]
-from __future__ import print_function
 from ortools.sat.python import cp_model
 # [END import]
 

--- a/ortools/sat/samples/scheduling_with_calendar_sample_sat.py
+++ b/ortools/sat/samples/scheduling_with_calendar_sample_sat.py
@@ -12,9 +12,6 @@
 # limitations under the License.
 """Code sample to demonstrate how an interval can span across a break."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from ortools.sat.python import cp_model
 

--- a/ortools/sat/samples/search_for_all_solutions_sample_sat.py
+++ b/ortools/sat/samples/search_for_all_solutions_sample_sat.py
@@ -13,9 +13,6 @@
 """Code sample that solves a model and displays all solutions."""
 
 # [START program]
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from ortools.sat.python import cp_model
 

--- a/ortools/sat/samples/simple_sat_program.py
+++ b/ortools/sat/samples/simple_sat_program.py
@@ -13,9 +13,6 @@
 """Simple solve."""
 
 # [START program]
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from ortools.sat.python import cp_model
 

--- a/ortools/sat/samples/solution_hinting_sample_sat.py
+++ b/ortools/sat/samples/solution_hinting_sample_sat.py
@@ -13,9 +13,6 @@
 """Code sample that solves a model using solution hinting."""
 
 # [START program]
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from ortools.sat.python import cp_model
 

--- a/ortools/sat/samples/solve_and_print_intermediate_solutions_sample_sat.py
+++ b/ortools/sat/samples/solve_and_print_intermediate_solutions_sample_sat.py
@@ -13,9 +13,6 @@
 """Solves an optimization problem and displays all intermediate solutions."""
 
 # [START program]
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from ortools.sat.python import cp_model
 

--- a/ortools/sat/samples/solve_with_time_limit_sample_sat.py
+++ b/ortools/sat/samples/solve_with_time_limit_sample_sat.py
@@ -12,9 +12,6 @@
 # limitations under the License.
 """Solves a problem with a time limit."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from ortools.sat.python import cp_model
 

--- a/ortools/sat/samples/step_function_sample_sat.py
+++ b/ortools/sat/samples/step_function_sample_sat.py
@@ -12,9 +12,6 @@
 # limitations under the License.
 """Implements a step function."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from ortools.sat.python import cp_model
 

--- a/ortools/sat/samples/stop_after_n_solutions_sample_sat.py
+++ b/ortools/sat/samples/stop_after_n_solutions_sample_sat.py
@@ -12,9 +12,6 @@
 # limitations under the License.
 """Code sample that solves a model and displays a small number of solutions."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from ortools.sat.python import cp_model
 

--- a/tools/doc/doxygen_filter.py
+++ b/tools/doc/doxygen_filter.py
@@ -23,7 +23,7 @@ import re
 import sys
 
 
-class DoxygenFormatter(object):
+class DoxygenFormatter:
   """Transforms lines of a source file to make them doxygen-friendly."""
 
   ANYWHERE = 'anywhere'
@@ -199,7 +199,7 @@ class DoxygenFormatter(object):
 
 def main(argv):
   sourcefile = argv[1]
-  with open(sourcefile, 'r') as infile:
+  with open(sourcefile) as infile:
     formatter = DoxygenFormatter(sys.stdout)
     for line in infile:
       formatter.ProcessLine(line)

--- a/tools/doc/gen_ref_doc.py
+++ b/tools/doc/gen_ref_doc.py
@@ -1,6 +1,5 @@
 """Generate OR-Tools ref doc using Doxygen."""
 
-from __future__ import print_function
 
 import re
 import os
@@ -24,7 +23,7 @@ def main(version_number):
     project_number_string = 'PROJECT_NUMBER = ' + version_number
     html_output_string = 'HTML_OUTPUT = ' + output_dir
     input_string = 'INPUT = ' + input_files
-    f = open(doxyfile, 'r')
+    f = open(doxyfile)
     g = open(doxy_tmp, 'w')
     filedata = f.read()
     filedata = re.sub('PROJECT_NAME', project_name_string, filedata)
@@ -41,7 +40,7 @@ def main(version_number):
     # Edit header file.
     title = section['title']
 
-    f = open(headerfile, 'r')
+    f = open(headerfile)
     g = open(header_tmp, 'w')
     filedata = f.read()
     filedata = re.sub('Banner Text', 'Google OR-Tools ' + version_number, filedata)


### PR DESCRIPTION
This PR removes some Python 2 compatibility code:
- `six.moves.xrange` -> `range`
- remove `__future__` imports via `pyupgrade --py3-only`