### PR TITLE
Expose packCumulsOfOptimizerDimensionsFromAssignment methods to Java

### DIFF
--- a/ortools/constraint_solver/java/routing.i
+++ b/ortools/constraint_solver/java/routing.i
@@ -227,6 +227,15 @@ import java.util.function.LongUnaryOperator;
                           const std::string& name) {
     $self->AddMatrixDimension(values, capacity, fix_start_cumul_to_zero, name);
   }
+
+  const Assignment* packCumulsOfOptimizerDimensionsFromAssignment(const Assignment* original_assignment) {
+    return $self->PackCumulsOfOptimizerDimensionsFromAssignment(original_assignment, absl::InfiniteDuration());
+  }
+
+  const Assignment* packCumulsOfOptimizerDimensionsFromAssignment(const Assignment* original_assignment,
+                                                                  int64 duration_limit_ms) {
+    return $self->PackCumulsOfOptimizerDimensionsFromAssignment(original_assignment, absl::Milliseconds(duration_limit_ms));
+  }
 }
 
 // RoutingDimension


### PR DESCRIPTION
This changeset provides to the java language the ability to call the C++ PackCumulsOfOptimizerDimensionsFromAssignment methods on RoutingModel.

There are two methods exposed, one that takes a timeout in milliseconds and another that does not and will, therefore, have an infinite timeout.
