### PR TITLE
Remove redundant isinstance

### DIFF
--- a/ortools/sat/python/cp_model_helper.py
+++ b/ortools/sat/python/cp_model_helper.py
@@ -57,10 +57,6 @@ def CapInt64(v):
 
 def CapSub(x, y):
     """Saturated arithmetics. Returns x - y truncated to the int64 range."""
-    if not isinstance(x, numbers.Integral):
-        raise TypeError('Not integral: ' + str(x))
-    if not isinstance(y, numbers.Integral):
-        raise TypeError('Not integral: ' + str(y))
     AssertIsInt64(x)
     AssertIsInt64(y)
     if y == 0:


### PR DESCRIPTION
Speedup model building in Python.

This check is redudant as AssertIsInt64 is called afterwards.
https://github.com/google/or-tools/blob/e3f500947b1d75dc8fe9fd784acdd88fe06c6557/ortools/sat/python/cp_model_helper.py#L58-L65

https://github.com/google/or-tools/blob/e3f500947b1d75dc8fe9fd784acdd88fe06c6557/ortools/sat/python/cp_model_helper.py#L27-L32

Edit: a very crude benchmark
```python
import datetime as dt
from ortools.sat.python import cp_model

model = cp_model.CpModel()
x = model.NewIntVar(0, 5, "x")

t0 = dt.datetime.now()
for i in range(500_000):
    model.Add(x <= 2)
print(dt.datetime.now() - t0)
```