### PR TITLE
Remove redundant CapInt64

### DIFF
--- a/ortools/sat/python/cp_model.py
+++ b/ortools/sat/python/cp_model.py
@@ -285,7 +285,7 @@ class LinearExpr(object):
             if arg == INT_MIN:
                 raise ArithmeticError('< INT_MIN is not supported')
             return BoundedLinearExpression(
-                self, [INT_MIN, cp_model_helper.CapInt64(arg - 1)])
+                self, [INT_MIN, arg - 1])
         else:
             return BoundedLinearExpression(self - arg, [INT_MIN, -1])
 
@@ -295,7 +295,7 @@ class LinearExpr(object):
             if arg == INT_MAX:
                 raise ArithmeticError('> INT_MAX is not supported')
             return BoundedLinearExpression(
-                self, [cp_model_helper.CapInt64(arg + 1), INT_MAX])
+                self, [arg + 1, INT_MAX])
         else:
             return BoundedLinearExpression(self - arg, [1, INT_MAX])
 
@@ -311,8 +311,8 @@ class LinearExpr(object):
             else:
                 return BoundedLinearExpression(self, [
                     INT_MIN,
-                    cp_model_helper.CapInt64(arg - 1),
-                    cp_model_helper.CapInt64(arg + 1), INT_MAX
+                    arg - 1,
+                    arg + 1, INT_MAX
                 ])
         else:
             return BoundedLinearExpression(self - arg,


### PR DESCRIPTION
There is no need to Cap because it is handled by:
* `AssertIsInt64(arg)` (arg in [INT_MIN, INT_MAX])
* `if arg == INT_MAX`
* `if arg == INT_MIN`.

https://github.com/google/or-tools/blob/532635de74c83d619fe957b3fd0eca1e94ac5b99/ortools/sat/python/cp_model.py#L284-L288

https://github.com/google/or-tools/blob/532635de74c83d619fe957b3fd0eca1e94ac5b99/ortools/sat/python/cp_model.py#L294-L298

https://github.com/google/or-tools/blob/532635de74c83d619fe957b3fd0eca1e94ac5b99/ortools/sat/python/cp_model.py#L306-L316

PS: Will try to find a more tangible and meaninful improvement in the next PR...