### PR TITLE
Export model_exporter_swig_helper.h file in BUILD file, needed for go swig bindings.

### DIFF
--- a/ortools/linear_solver/BUILD
+++ b/ortools/linear_solver/BUILD
@@ -2,6 +2,8 @@ load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["model_exporter_swig_helper.h"])
+
 config_setting(
     name = "with_glpk",
     values = {"define": "USE_GLPK="},


### PR DESCRIPTION
Minor change needed to make the bazel rules work here: https://github.com/gonzojive/or-tools-go