### PR TITLE
Help CMake resolve protobuf::protoc when not building it.

### DIFF
--- a/cmake/FindProtobuf.cmake
+++ b/cmake/FindProtobuf.cmake
@@ -24,3 +24,9 @@ find_package(PkgConfig REQUIRED)
 
 pkg_check_modules(PROTOBUF REQUIRED protobuf IMPORTED_TARGET GLOBAL)
 add_library(protobuf::libprotobuf ALIAS PkgConfig::PROTOBUF)
+
+find_program(PROTOC_EXEC protoc REQUIRED)
+add_executable(protobuf::protoc IMPORTED GLOBAL)
+set_target_properties(protobuf::protoc PROPERTIES
+  IMPORTED_LOCATION ${PROTOC_EXEC}
+)


### PR DESCRIPTION
I required this change to build or-tools using cmake with the `-DBUILD_DEPS=0` option. Without this change, I get this at build time:

```
CMakeFiles/ortools_proto.dir/build.make:61: *** target pattern contains no '%'.  Stop.
make[1]: *** [CMakeFiles/Makefile2:590: CMakeFiles/ortools_proto.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
```