### PR TITLE
In CMake, install python to install prefix.

### DIFF
--- a/cmake/python-install.cmake.in
+++ b/cmake/python-install.cmake.in
@@ -1,0 +1,7 @@
+execute_process(
+  WORKING_DIRECTORY @PROJECT_BINARY_DIR@/python
+  COMMAND @Python_EXECUTABLE@ setup.py install
+    --root=/
+    --prefix=@CMAKE_INSTALL_PREFIX@
+    @SETUPTOOLS_INSTALL_LAYOUT@
+)

--- a/cmake/python-install.cmake.in
+++ b/cmake/python-install.cmake.in
@@ -1,7 +1,13 @@
+if (DEFINED ENV{DESTDIR})
+  set(ROOT $ENV{DESTDIR})
+else()
+  set(ROOT /)
+endif()
+
 execute_process(
   WORKING_DIRECTORY @PROJECT_BINARY_DIR@/python
   COMMAND @Python_EXECUTABLE@ setup.py install
-    --root=/
+    --root=${ROOT}
     --prefix=@CMAKE_INSTALL_PREFIX@
     @SETUPTOOLS_INSTALL_LAYOUT@
 )

--- a/cmake/python.cmake
+++ b/cmake/python.cmake
@@ -157,6 +157,22 @@ add_custom_target(python_package ALL
   )
 add_dependencies(python_package ortools::ortools Py${PROJECT_NAME}_proto)
 
+# Check if we have system Python on Debian/Ubuntu, if so tell setuptools
+# to use the deb layout (dist-packages instead of site-packages).
+execute_process(
+  COMMAND ${Python_EXECUTABLE} -c "import sys; sys.stdout.write(sys.path[-1])"
+  OUTPUT_VARIABLE Python_STDLIB_DIR
+)
+if (Python_STDLIB_DIR MATCHES ".*/dist-packages$")
+  set(SETUPTOOLS_INSTALL_LAYOUT "--install-layout=deb")
+endif()
+
+configure_file(
+  ${PROJECT_SOURCE_DIR}/cmake/python-install.cmake.in
+  ${PROJECT_BINARY_DIR}/python/python-install.cmake
+  @ONLY)
+install(SCRIPT ${PROJECT_BINARY_DIR}/python/python-install.cmake)
+
 # Test
 if(BUILD_TESTING)
   # Look for python module virtualenv


### PR DESCRIPTION
Currently the CMake build prepares the `build/python` directory as a source Python package, and by default does a test install of it into `build/venv` when `BUILD_TESTING` is enabled.

This change enables a conventional `cmake ..; make; sudo make install` to actually install the package into the specified prefix (default `/usr/local`), where it will be seen by the system python. This also needed to support conventional packaging workflows where the DESTDIR envvar is specified at install time.