### PR TITLE
[CMake] Install MiniZinc solver interface

### DIFF
--- a/cmake/flatzinc.cmake
+++ b/cmake/flatzinc.cmake
@@ -132,6 +132,10 @@ target_link_libraries(fz PRIVATE ortools::flatzinc)
 ## Alias
 add_executable(${PROJECT_NAME}::fz ALIAS fz)
 
+# MiniZinc solver configuration
+file(RELATIVE_PATH FZ_REL_INSTALL_BINARY ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/minizinc/solvers ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/fz)
+configure_file(ortools/flatzinc/ortools.msc.in ortools.msc)
+
 # Install rules
 include(GNUInstallDirs)
 install(TARGETS flatzinc fz
@@ -141,3 +145,6 @@ install(TARGETS flatzinc fz
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   )
+
+install(DIRECTORY ortools/flatzinc/mznlib/ DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/minizinc/ortools FILES_MATCHING PATTERN "*.mzn")
+install(FILES ${CMAKE_BINARY_DIR}/ortools.msc DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/minizinc/solvers)

--- a/ortools/flatzinc/ortools.msc.in
+++ b/ortools/flatzinc/ortools.msc.in
@@ -1,0 +1,21 @@
+{
+  "id": "com.google.or-tools",
+  "name": "OR Tools",
+  "description": "Google's Operations Research tools FlatZinc interface",
+  "version": "${ortools_VERSION_MAJOR}.${ortools_VERSION_MINOR}.${ortools_VERSION_PATCH}",
+  "mznlib": "../ortools",
+  "executable": "${FZ_REL_INSTALL_BINARY}",
+  "tags": ["ortools", "cp", "lcg", "float", "int"],
+  "stdFlags": ["-a","-f","-n","-p","-r","-s","-v"],
+  "extraFlags": [
+    ["--cp_model_params", "Provide parameters interpreted as a text SatParameters proto", "string", ""],
+    ["--fz_floats_are_ints", "Interpret floats as integers", "bool:false:true", "true"],
+    ["-l", "Print logging information", "bool", "false"]
+  ],
+  "supportsMzn": false,
+  "supportsFzn": true,
+  "needsSolns2Out": true,
+  "needsMznExecutable": false,
+  "needsStdlibDir": false,
+  "isGUIApplication": false
+}


### PR DESCRIPTION
This PR slightly extends the build configuration of the FlatZinc executable in CMake(bc35d331f7fadac96a9166b8eb184109ce0ae40a). It adds the installation of both the MiniZinc library and a MiniZinc Solver configuration in a standard directory. 

This means that if a user installs OR Tools using CMake in a default location, then the OR Tools solver will immediately show up in the MiniZincIDE and when running `minizinc --solvers` (and you will be able to solve MiniZinc instances from the command line using for example `minizinc --solver ortools model.mzn data.dzn`).

If the user choose a non-default installation location, then the user can extend the `MZN_SOLVER_PATH` to include `<ORTools_INSTALL>/share/minizinc/solvers`.