### PR TITLE
[Python] Type Hint for CpSolver.ResponseProto

### DIFF
--- a/ortools/sat/python/cp_model.py
+++ b/ortools/sat/python/cp_model.py
@@ -1601,7 +1601,7 @@ class CpSolver(object):
 
     def __init__(self):
         self.__model = None
-        self.__solution = None
+        self.__solution: cp_model_pb2.CpSolverResponse = None
         self.parameters = sat_parameters_pb2.SatParameters()
 
     def Solve(self, model):


### PR DESCRIPTION
Enable autocompletion for solver.ResponseProto().

![Screenshot from 2021-02-04 03-57-49](https://user-images.githubusercontent.com/19752586/106838829-4e085680-669d-11eb-93eb-c64f6abef282.png)
