### PR TITLE
Enable Emscripten builds

### DIFF
--- a/ortools/base/raw_logging.cc
+++ b/ortools/base/raw_logging.cc
@@ -25,13 +25,17 @@
 #include "ortools/base/logging.h"
 #include "ortools/base/logging_utilities.h"
 
-#if !defined(_MSC_VER)
+#if !defined(_MSC_VER) && !defined(__EMSCRIPTEN__)
 #include <sys/syscall.h>  // for syscall()
 #define safe_write(fd, s, len) syscall(SYS_write, fd, s, len)
 #else
+#if !defined(__EMSCRIPTEN__)
 #include <io.h>  // _write()
 // Not so safe, but what can you do?
 #define safe_write(fd, s, len) _write(fd, s, len)
+#else
+#define safe_write(fd, s, len) write(fd, s, len)
+#endif
 #endif
 
 #if defined(_MSC_VER) && !defined(__MINGW32__)

--- a/ortools/glop/lp_solver.cc
+++ b/ortools/glop/lp_solver.cc
@@ -160,6 +160,7 @@ ProblemStatus LPSolver::SolveWithTimeLimit(const LinearProgram& lp,
   // Note that we only activate the floating-point exceptions after we are sure
   // that the program is valid. This way, if we have input NaNs, we will not
   // crash.
+#ifndef __EMSCRIPTEN__  
   ScopedFloatingPointEnv scoped_fenv;
   if (absl::GetFlag(FLAGS_lp_solver_enable_fp_exceptions)) {
 #ifdef _MSC_VER
@@ -168,6 +169,7 @@ ProblemStatus LPSolver::SolveWithTimeLimit(const LinearProgram& lp,
     scoped_fenv.EnableExceptions(FE_DIVBYZERO | FE_INVALID);
 #endif
   }
+#endif
 
   // Make an internal copy of the problem for the preprocessing.
   VLOG(1) << "Initial problem: " << lp.GetDimensionString();


### PR DESCRIPTION
To enable Emscripten builds, we need to fence off a couple of elements that creates unrecoverable errors during build process.

<!--
Thank you for submitting a PR!

Please make sure you are targeting the master branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->