### PR TITLE
Add Wasm32 as target for cross compiling

### DIFF
--- a/ortools/base/raw_logging.cc
+++ b/ortools/base/raw_logging.cc
@@ -25,13 +25,17 @@
 #include "ortools/base/logging.h"
 #include "ortools/base/logging_utilities.h"
 
-#if !defined(_MSC_VER)
+#if !defined(_MSC_VER) && !defined(__EMSCRIPTEN__)
 #include <sys/syscall.h>  // for syscall()
 #define safe_write(fd, s, len) syscall(SYS_write, fd, s, len)
 #else
+#if !defined(__EMSCRIPTEN__)
 #include <io.h>  // _write()
 // Not so safe, but what can you do?
 #define safe_write(fd, s, len) _write(fd, s, len)
+#else
+#define safe_write(fd, s, len) write(fd, s, len)
+#endif
 #endif
 
 #if defined(_MSC_VER) && !defined(__MINGW32__)

--- a/ortools/glop/lp_solver.cc
+++ b/ortools/glop/lp_solver.cc
@@ -160,6 +160,7 @@ ProblemStatus LPSolver::SolveWithTimeLimit(const LinearProgram& lp,
   // Note that we only activate the floating-point exceptions after we are sure
   // that the program is valid. This way, if we have input NaNs, we will not
   // crash.
+#ifndef __EMSCRIPTEN__  
   ScopedFloatingPointEnv scoped_fenv;
   if (absl::GetFlag(FLAGS_lp_solver_enable_fp_exceptions)) {
 #ifdef _MSC_VER
@@ -168,6 +169,7 @@ ProblemStatus LPSolver::SolveWithTimeLimit(const LinearProgram& lp,
     scoped_fenv.EnableExceptions(FE_DIVBYZERO | FE_INVALID);
 #endif
   }
+#endif
 
   // Make an internal copy of the problem for the preprocessing.
   const bool log_info = parameters_.log_search_progress() || VLOG_IS_ON(1);

--- a/tools/cross_compile.sh
+++ b/tools/cross_compile.sh
@@ -95,6 +95,19 @@ function clean_build() {
   mkdir -p "${BUILD_DIR}"
 }
 
+function expand_wasm_config() {
+  declare -r EMSDK_VERSION=2.0.14
+  declare -r EMSDK_URL=https://github.com/emscripten-core/emsdk/archive/${EMSDK_VERSION}.tar.gz 
+  declare -r EMSDK_RELATIVE_DIR="emsdk-${EMSDK_VERSION}"
+  declare -r EMSDK="${ARCHIVE_DIR}/${EMSDK_RELATIVE_DIR}"
+  if [ ! -d "${EMSDK}" ]; then
+    install_emscripten
+  fi
+
+  declare -r TOOLCHAIN_FILE=${EMSDK}/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake
+  CMAKE_ADDITIONAL_ARGS+=( -DCMAKE_TOOLCHAIN_FILE="${TOOLCHAIN_FILE}" -DBUILD_SAMPLES=OFF -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF)
+}
+
 function expand_linaro_config() {
   #ref: https://releases.linaro.org/components/toolchain/binaries/
   local -r LINARO_VERSION=7.5-2019.12
@@ -322,6 +335,9 @@ function main() {
     mips64el)
       expand_codescape_config
       declare -r QEMU_ARCH=mips64el ;;
+    wasm32)
+      expand_wasm_config
+      declare -r QEMU_ARCH=DISABLED ;;
     *)
       >&2 echo "Unknown TARGET '${TARGET}'..."
       exit 1 ;;


### PR DESCRIPTION
This PR adds Wasm32 as target for cross compiling, Emscripten setup,  and fences off some Emscripten-incompatible elements.

See Feature request #1670

<!--
Thank you for submitting a PR!

Please make sure you are targeting the master branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->