### PR TITLE
Add special error message for .cpp SOURCE

### DIFF
--- a/tools/Makefile.cc.java.dotnet
+++ b/tools/Makefile.cc.java.dotnet
@@ -304,6 +304,15 @@ run: build
 	$(BIN_DIR)$S$(SOURCE_NAME)$E $(ARGS)
 endif # ifeq ($(SOURCE_SUFFIX),.cc)
 
+# Special error message for the common case of using ".cpp" instead of ".cc"
+ifeq ($(SOURCE_SUFFIX),.cpp)
+.PHONY: build
+build:
+	@echo Error: SOURCE has a .cpp extension, for C++ please use .cc
+.PHONY: run
+run: build
+endif # ifeq ($(SOURCE_SUFFIX),.cpp)
+
 endif # ifndef CXX_BIN
 
 $(OBJ_DIR):


### PR DESCRIPTION
Before this change, when a user of an or-tools release tries to use a
".cpp" file with e.g.:

    make run SOURCE=./foo.cpp

The error message is:

    make: *** No rule to make target 'run'.  Stop.

This message does not really help to understand that the makefile is
designed to recognize only ".cc" files as C++ sources.

This change adds a specific error message when the source is a ".cpp"
file, inviting the user to use ".cc" instead.

<!--
Thank you for submitting a PR!

Please make sure you are targeting the master branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->