### PR TITLE
Avoid leaking the MPSolver object in some samples

### DIFF
--- a/examples/tests/lp_test.cc
+++ b/examples/tests/lp_test.cc
@@ -132,7 +132,7 @@ void RunBooleanProgrammingExample(
 void MutableObjectiveCrash() {
   LOG(INFO) << "MutableObjectiveCrash";
   // Create the linear solver with the GLOP backend.
-  MPSolver* solver = MPSolver::CreateSolver("GLOP");
+  std::unique_ptr<MPSolver> solver(MPSolver::CreateSolver("GLOP"));
 
   // Create the variables x and y.
   MPVariable* const x = solver->MakeNumVar(0.0, 1, "x");

--- a/ortools/linear_solver/samples/basic_example.cc
+++ b/ortools/linear_solver/samples/basic_example.cc
@@ -21,7 +21,7 @@ namespace operations_research {
 void BasicExample() {
   // [START solver]
   // Create the linear solver with the GLOP backend.
-  MPSolver* solver = MPSolver::CreateSolver("GLOP");
+  std::unique_ptr<MPSolver> solver(MPSolver::CreateSolver("GLOP"));
   // [END solver]
 
   // [START variables]

--- a/ortools/linear_solver/samples/simple_lp_program.cc
+++ b/ortools/linear_solver/samples/simple_lp_program.cc
@@ -21,7 +21,7 @@ namespace operations_research {
 void SimpleLpProgram() {
   // [START solver]
   // Create the linear solver with the GLOP backend.
-  MPSolver* solver = MPSolver::CreateSolver("GLOP");
+  std::unique_ptr<MPSolver> solver(MPSolver::CreateSolver("GLOP"));
   // [END solver]
 
   // [START variables]

--- a/ortools/linear_solver/samples/simple_mip_program.cc
+++ b/ortools/linear_solver/samples/simple_mip_program.cc
@@ -21,7 +21,7 @@ namespace operations_research {
 void SimpleMipProgram() {
   // [START solver]
   // Create the mip solver with the SCIP backend.
-  MPSolver* solver = MPSolver::CreateSolver("SCIP");
+  std::unique_ptr<MPSolver> solver(MPSolver::CreateSolver("SCIP"));
   // [END solver]
 
   // [START variables]


### PR DESCRIPTION
In samples using MPSolver::CreateSolver(), track the resulting solver
with a std::unique_ptr to avoid leaking it.

Fix #2411