### PR TITLE
fix the bug in cvrptw_break.py

### DIFF
--- a/ortools/constraint_solver/samples/cvrptw_break.py
+++ b/ortools/constraint_solver/samples/cvrptw_break.py
@@ -296,23 +296,20 @@ def main():
     # Add breaks
     time_dimension = routing.GetDimensionOrDie("Time")
     node_visit_transit = {}
-    for n in range(routing.Size()):
-        if n >= data['num_locations']:
-            node_visit_transit[n] = 0
-        else:
-            node_visit_transit[n] = int(
-                data['demands'][n] * data['time_per_demand_unit'])
+    for index in range(routing.Size()):
+        node = manager.IndexToNode(index)
+        node_visit_transit[index] = int(
+            data['demands'][node] * data['time_per_demand_unit'])
 
     break_intervals = {}
-    #for v in range(data['num_vehicles']):
-    for v in [0]:
+    for v in range(data['num_vehicles']):
         vehicle_break = data['breaks'][v]
         break_intervals[v] = [
             routing.solver().FixedDurationIntervalVar(
-                15, 100, vehicle_break[0], vehicle_break[1], 'Break for vehicle {}'.format(v))
+                15, 100, vehicle_break[0], vehicle_break[1], f'Break for vehicle {v}')
             ]
         time_dimension.SetBreakIntervalsOfVehicle(
-            break_intervals[v], v, node_visit_transit)
+            break_intervals[v], v, node_visit_transit.values())
 
     # Setting first solution heuristic (cheapest addition).
     search_parameters = pywrapcp.DefaultRoutingSearchParameters()


### PR DESCRIPTION
core bug is passing the dict rather than a list to the
SetBreakIntervalsOfVehicle API call.

Also fixed the ad hoc approach to setting the node_visit_transit
values that relied on knowledge of the ORTools internal
implementation.  Instead, use the IndexToNode call.

Example now works for more than one vehicle.

Should close #1730
<!--
Thank you for submitting a PR!

Please make sure you are targeting the master branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->