### PR TITLE
CP-SAT Java: take advantage of cached constants in CpModel.indexFromConstant()

### DIFF
--- a/ortools/java/com/google/ortools/sat/CpModel.java
+++ b/ortools/java/com/google/ortools/sat/CpModel.java
@@ -1067,9 +1067,8 @@ public final class CpModel {
   }
 
   int indexFromConstant(long constant) {
-    int index = modelBuilder.getVariablesCount();
-    modelBuilder.addVariablesBuilder().addDomain(constant).addDomain(constant);
-    return index;
+    IntVar constVar = newConstant(constant);
+    return constVar.getIndex();
   }
 
   // Getters.


### PR DESCRIPTION
`CpModel.indexFromConstant()` unnecessarily creates new constants in the model proto instead of using potentially cached ones, that are then immediately pruned during presolve. This patch makes `indexFromConstant` use `newConstant()` under the covers which might use cached constants instead.

From an example model I had (note the 9011 constants in before vs 1003 in after). The overall latency cuts down in roughly half (~31ms to 16ms).

Before:

```
Parameters: max_time_in_seconds: 1 log_search_progress: true num_search_workers: 1 cp_model_probing_level: 0
Optimization model '':
#Variables: 9017 (3 in objective)
 - 1 in [-2147483648,2147483647]
 - 1 in [0,1]
 - 1 in [0,100]
 - 1 in [0,109]
 - 1 in [0,7900]
 - 1 in [2,1001]
 - 9011 constants in {0,1,2,3,4,5,6,7,8,9,10,11,12 ... ,992,993,994,995,996,997,998,999,1000,1001,7900}
#kCumulative: 6
#kInterval: 1001
#kLinear1: 7 (#enforced: 2)
*** starting model presolve at 0.00s
Merged 0 into 0 cliques.
Unsupported constraint type kInterval
- 8008 affine relations were detected.
- 8008 variable equivalence relations were detected.
- rule 'cumulative: removed intervals with no demands' was applied 6 times.
- rule 'false enforcement literal' was applied 1 time.
- rule 'linear: empty' was applied 4 times.
- rule 'linear: fixed or dup variables' was applied 4 times.
- rule 'linear: size one' was applied 2 times.
- rule 'presolve: iteration' was applied 1 time.
- rule 'true enforcement literal' was applied 1 time.
Optimization model '':
#Variables: 1007 (3 in objective)
 - 1 in [0,100]
 - 1 in [0,109]
 - 1 in [0,7900]
 - 1 in [1,1000]
 - 1 in [2,1001]
 - 1002 constants in {1,2,3,4,5,6,7,8,9,10,11,12,1 ... ,992,993,994,995,996,997,998,999,1000,1001,7900}
#kCumulative: 6
#kInterval: 1001
Unsupported constraint type kInterval
#Bound   0.02s best:inf   next:[0,8109]   initial domain
*** starting to load the model at 0.02s
#Bound   0.03s best:inf   next:[119,8109] init
*** starting sequential search at 0.03s
Initial num_bool: 1
#1       0.03s best:120   next:[119,119]   fixed_bools:1/5
#2       0.03s best:119   next:[119,118]   fixed_bools:5/6
#Done    0.03s
CpSolverResponse:
status: OPTIMAL
objective: 119
best_bound: 119
booleans: 6
conflicts: 0
branches: 5
propagations: 5
integer_propagations: 135
restarts: 2
lp_iterations: 0
walltime: 0.0310139
usertime: 0.0310139
deterministic_time: 8.11e-07
primal_integral: 3.66638e-06
```

After

```
Parameters: max_time_in_seconds: 1 log_search_progress: true num_search_workers: 1 cp_model_probing_level: 0
Optimization model '':
#Variables: 1009 (3 in objective)
 - 1 in [-2147483648,2147483647]
 - 1 in [0,1]
 - 1 in [0,100]
 - 1 in [0,109]
 - 1 in [0,7900]
 - 1 in [2,1001]
 - 1003 constants in {0,1,2,3,4,5,6,7,8,9,10,11,12 ... ,992,993,994,995,996,997,998,999,1000,1001,7900}
#kCumulative: 6
#kInterval: 1001
#kLinear1: 7 (#enforced: 2)
*** starting model presolve at 0.00s
Merged 0 into 0 cliques.
Unsupported constraint type kInterval
- 0 affine relations were detected.
- 0 variable equivalence relations were detected.
- rule 'cumulative: removed intervals with no demands' was applied 6 times.
- rule 'false enforcement literal' was applied 1 time.
- rule 'linear: empty' was applied 4 times.
- rule 'linear: fixed or dup variables' was applied 4 times.
- rule 'linear: size one' was applied 2 times.
- rule 'presolve: iteration' was applied 1 time.
- rule 'true enforcement literal' was applied 1 time.
Optimization model '':
#Variables: 1007 (3 in objective)
 - 1 in [0,100]
 - 1 in [0,109]
 - 1 in [0,7900]
 - 1 in [1,1000]
 - 1 in [2,1001]
 - 1002 constants in {1,2,3,4,5,6,7,8,9,10,11,12,1 ... ,992,993,994,995,996,997,998,999,1000,1001,7900}
#kCumulative: 6
#kInterval: 1001
Unsupported constraint type kInterval
#Bound   0.01s best:inf   next:[0,8109]   initial domain
*** starting to load the model at 0.01s
#Bound   0.02s best:inf   next:[119,8109] init
*** starting sequential search at 0.02s
Initial num_bool: 1
#1       0.02s best:120   next:[119,119]   fixed_bools:1/5
#2       0.02s best:119   next:[119,118]   fixed_bools:5/6
#Done    0.02s
CpSolverResponse:
status: OPTIMAL
objective: 119
best_bound: 119
booleans: 6
conflicts: 0
branches: 5
propagations: 5
integer_propagations: 135
restarts: 2
lp_iterations: 0
walltime: 0.0163174
usertime: 0.0163174
deterministic_time: 8.11e-07
primal_integral: 3.66638e-06
```