### PR TITLE
fix logging timestamps

### DIFF
--- a/ortools/base/logging.cc
+++ b/ortools/base/logging.cc
@@ -1140,10 +1140,10 @@ void LogMessage::Init(const char* file, int line, LogSeverity severity,
   data_->send_method_ = send_method;
   data_->sink_ = NULL;
   data_->outvec_ = NULL;
-  double now = ToUDate(absl::Now());
-  data_->timestamp_ = static_cast<time_t>(now);
+  timespec now_ts = absl::ToTimespec(absl::Now());
+  data_->timestamp_ = now_ts.tv_sec;
   localtime_r(&data_->timestamp_, &data_->tm_time_);
-  int usecs = static_cast<int>((now - data_->timestamp_) * 1000000);
+  int usecs = now_ts.tv_nsec / 1000;
 
   data_->num_chars_to_log_ = 0;
   data_->num_chars_to_syslog_ = 0;


### PR DESCRIPTION
The old code was incorrectly casting a double milliseconds value to
the integer seconds time_t type, which caused incorrect month/day and
timestamp values in log output.

Instead use absl::ToTimespec() to access the tv_sec and tv_nsec values
directly.

<!--
Thank you for submitting a PR!

Please make sure you are targeting the master branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->