### PR TITLE
Cmake tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ bazel-*
 tools/docker/export
 
 # IDE stuff
+CMakeLists.txt.user
 *.userprefs
 .idea/*
 .idea/
@@ -88,7 +89,6 @@ examples/dotnet/obj
 .cmake/
 CMakeCache.txt
 CMakeFiles
-CMakeLists.txt.user
 DartConfiguration.tcl
 *build*/*
 build/

--- a/.gitignore
+++ b/.gitignore
@@ -57,12 +57,9 @@ bazel-*
 tools/docker/export
 
 # IDE stuff
-CMakeLists.txt.user
 *.userprefs
-*build*/*
 .idea/*
 .idea/
-build/
 cache/
 **/.vscode/*
 .DS_Store
@@ -87,3 +84,11 @@ examples/contrib/obj
 examples/dotnet/bin
 examples/dotnet/obj
 
+# cmake code gen (assumes -Bbuild)
+.cmake/
+CMakeCache.txt
+CMakeFiles
+CMakeLists.txt.user
+DartConfiguration.tcl
+*build*/*
+build/

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -103,12 +103,11 @@ For all of these options and parameters you have to use `-D<Parameter_name>=<val
 
 For example, to generate build files including dependencies in a new subdirectory called 'build', run:
 ```sh
-cmake -DBUILD_DEPS:BOOL=ON -H. -Bbuild
+cmake -S. -Bbuild  -DBUILD_DEPS:BOOL=ON
 ```
 and then build with:
 ```sh
-cd build
-cmake --build .
+cmake --build build
 ```
 
 Following is a list of available options, for the full list run:

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -100,7 +100,18 @@ test it on public CI and support can be broken.**
 
 There are several options that can be passed to CMake to modify how the code is built.<br>
 For all of these options and parameters you have to use `-D<Parameter_name>=<value>`.<br>
-Following a list of available options, for the full list run:
+
+For example, to generate build files including dependencies in a new subdirectory called 'build', run:
+```sh
+cmake -DBUILD_DEPS:BOOL=ON -H. -Bbuild
+```
+and then build with:
+```sh
+cd build
+cmake --build .
+```
+
+Following is a list of available options, for the full list run:
 
 ```sh
 cmake -S. -Bbuild -LH


### PR DESCRIPTION
Provide example cmake commands to build the project and dependencies and place the build files and build products in a new subdirectory, as is recommended by the maintainers.

Also tweak the .gitignore file to avoid the last few spurious diffs caused by cmake, and re-organize some cmake related ignores from the IDE section.

Proposed as progress towards answering #1435  