### PR TITLE
Update Makefile.port.mk

### DIFF
--- a/makefiles/Makefile.port.mk
+++ b/makefiles/Makefile.port.mk
@@ -118,7 +118,7 @@ ifeq ($(SYSTEM),unix)
     else
       JAVA_HOME ?= $(shell /usr/libexec/java_home)
     endif
-    MAC_MIN_VERSION = 10.9
+    MAC_MIN_VERSION = 10.14
   endif # ($(OS),Darwin)
 endif # ($(SYSTEM),unix)
 


### PR DESCRIPTION
I get failures building on my M1 macbook pro (with USE_SCIP=OFF) without changing this.  The error occurs during `gmake python USE_SCIP=OFF`

```
In file included from ./ortools/bop/bop_base.cc:14:
In file included from ./ortools/bop/bop_base.h:25:
In file included from ./ortools/bop/bop_solution.h:21:
In file included from ./ortools/sat/boolean_problem.h:26:
In file included from ./ortools/sat/pb_constraint.h:31:
./ortools/sat/model.h:185:12: error: aligned allocation function of type 'void *(std::size_t, std::align_val_t)' is only available on macOS 10.14 or newer
    return new T(this);
```
