### PR TITLE
Typo in clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,7 @@
 ---
 Language:        Cpp
 BasedOnStyle:  Google
-# Forse pointer to the type for C++
+# Force pointer to align on the type for C++
 DerivePointerAlignment: false
 PointerAlignment: Left
 ---


### PR DESCRIPTION
I also made the comment a bit more explicit, it was hard to read without knowing the option beforehand