### PR TITLE
Replace deprecated SCIP cons_quadratic.h

### DIFF
--- a/ortools/linear_solver/scip_proto_solver.cc
+++ b/ortools/linear_solver/scip_proto_solver.cc
@@ -42,7 +42,7 @@
 #include "ortools/util/lazy_mutable_copy.h"
 #include "scip/cons_disjunction.h"
 #include "scip/cons_linear.h"
-#include "scip/cons_quadratic.h"
+#include "scip/cons_nonlinear.h"
 #include "scip/pub_var.h"
 #include "scip/scip.h"
 #include "scip/scip_param.h"
@@ -240,7 +240,7 @@ absl::Status AddQuadraticConstraint(
   }
 
   RETURN_IF_SCIP_ERROR(
-      SCIPcreateConsBasicQuadratic(scip,
+      SCIPcreateConsBasicQuadraticNonlinear(scip,
                                    /*cons=*/scip_cst,
                                    /*name=*/gen_cst.name().c_str(),
                                    /*nlinvars=*/lsize,
@@ -489,7 +489,7 @@ absl::Status AddQuadraticObjective(const MPQuadraticObjective& quadobj,
     quadvars2[i] = scip_variables->at(quadobj.qvar2_index(i));
     quadcoefs[i] = quadobj.coefficient(i);
   }
-  RETURN_IF_SCIP_ERROR(SCIPcreateConsBasicQuadratic(
+  RETURN_IF_SCIP_ERROR(SCIPcreateConsBasicQuadraticNonlinear(
       scip, /*cons=*/&scip_constraints->back(), /*name=*/"quadobj",
       /*nlinvars=*/1, /*linvars=*/linvars, /*lincoefs=*/lincoefs,
       /*nquadterms=*/size, /*quadvars1=*/quadvars1.data(),


### PR DESCRIPTION
The function `SCIPcreateConsBasicQuadratic()` along with the entire `cons_quadratic.h` file are deprecated -- instead, we should use `SCIPcreateConsBasicQuadraticNonlinear()` which takes the same arguments. Right now, attempting to use quadratic constraints or objectives results in all variables taking a zero value.

For reference see the SCIP docs:
SCIPcreateConsBasicQuadratic: https://www.scipopt.org/doc/html/group__CONSHDLRS.php#gad3707e7f7166bea83b7713cf2e52b0db
SCIPcreateConsBasicQuadraticNonlinear: https://www.scipopt.org/doc/html/group__CONSHDLRS.php#gabef6770f404754e7503f68a7da9ad6da

<!--
Thank you for submitting a PR!

Please make sure you are targeting the master branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->