### PR TITLE
Use bazel workspace target for zlib

### DIFF
--- a/ortools/base/BUILD.bazel
+++ b/ortools/base/BUILD.bazel
@@ -184,24 +184,14 @@ cc_library(
     hdrs = [
         "recordio.h",
     ],
-    linkopts = select({
-        "on_linux": ["-lz"],
-        "on_macos": ["-lz"],
-        "on_windows": [],
-        "//conditions:default": ["-lz"],
-    }),
     deps = [
         ":base",
         ":file",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_protobuf//:protobuf",
-    ] + select({
-        "on_linux": [],
-        "on_macos": [],
-        "on_windows": ["@zlib//:zlib"],
-        "//conditions:default": [],
-    }),
+        "@zlib",
+    ],
 )
 
 cc_library(
@@ -429,8 +419,8 @@ cc_library(
 cc_library(
     name = "gzipstring",
     hdrs = ["gzipstring.h"],
-    deps = [":base"] + select({
-        "on_windows": ["@zlib//:zlib"],
-        "//conditions:default": [],
-    }),
+    deps = [
+        ":base",
+        "@zlib",
+    ],
 )


### PR DESCRIPTION
Fixes https://github.com/google/or-tools/issues/3060

Without this, linux builds will fail at runtime if z.so is not
installed on the deploy platform. This is problematic for example, when
using rules_docker to create a minimal image for a cc_binary to run.

NOTE: Users who want to use a system-installed version of zlib can still
do so by creating a library in their workspace called `@zlib:zlib` with
`-lz` in its linkopts. This gives flexibility at the workspace level for
choosing how to build zlib.