### PR TITLE
Fix CMake package config file

### DIFF
--- a/cmake/FindCbc.cmake
+++ b/cmake/FindCbc.cmake
@@ -22,9 +22,9 @@ Cbc_FOUND          - True if Cbc found.
 #]=======================================================================]
 find_package(PkgConfig REQUIRED)
 
-pkg_check_modules(CBC REQUIRED cbc IMPORTED_TARGET GLOBAL)
-add_library(Coin::Cbc ALIAS PkgConfig::CBC)
-add_library(Coin::CbcSolver ALIAS PkgConfig::CBC)
+pkg_check_modules(Cbc REQUIRED cbc IMPORTED_TARGET GLOBAL)
+add_library(Coin::Cbc ALIAS PkgConfig::Cbc)
+add_library(Coin::CbcSolver ALIAS PkgConfig::Cbc)
 
 pkg_check_modules(OSI_CBC REQUIRED osi-cbc IMPORTED_TARGET GLOBAL)
 add_library(Coin::OsiCbc ALIAS PkgConfig::OSI_CBC)

--- a/cmake/FindClp.cmake
+++ b/cmake/FindClp.cmake
@@ -22,9 +22,9 @@ Clp_FOUND          - True if Clp found.
 #]=======================================================================]
 find_package(PkgConfig REQUIRED)
 
-pkg_check_modules(CLP REQUIRED clp IMPORTED_TARGET GLOBAL)
-add_library(Coin::Clp ALIAS PkgConfig::CLP)
-add_library(Coin::ClpSolver ALIAS PkgConfig::CLP)
+pkg_check_modules(Clp REQUIRED clp IMPORTED_TARGET GLOBAL)
+add_library(Coin::Clp ALIAS PkgConfig::Clp)
+add_library(Coin::ClpSolver ALIAS PkgConfig::Clp)
 
 pkg_check_modules(OSI_CLP REQUIRED osi-clp IMPORTED_TARGET GLOBAL)
 add_library(Coin::OsiClp ALIAS PkgConfig::OSI_CLP)

--- a/cmake/cpp.cmake
+++ b/cmake/cpp.cmake
@@ -279,6 +279,12 @@ install(
   "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
   COMPONENT Devel)
+install(
+  FILES
+  "${PROJECT_SOURCE_DIR}/cmake/FindCbc.cmake"
+  "${PROJECT_SOURCE_DIR}/cmake/FindClp.cmake"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/modules"
+  COMPONENT Devel)
 
 # add_cxx_sample()
 # CMake function to generate and build C++ sample.

--- a/cmake/cpp.cmake
+++ b/cmake/cpp.cmake
@@ -279,12 +279,14 @@ install(
   "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
   COMPONENT Devel)
-install(
-  FILES
-  "${PROJECT_SOURCE_DIR}/cmake/FindCbc.cmake"
-  "${PROJECT_SOURCE_DIR}/cmake/FindClp.cmake"
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/modules"
-  COMPONENT Devel)
+if(USE_COINOR)
+  install(
+    FILES
+    "${PROJECT_SOURCE_DIR}/cmake/FindCbc.cmake"
+    "${PROJECT_SOURCE_DIR}/cmake/FindClp.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/modules"
+    COMPONENT Devel)
+endif()
 
 # add_cxx_sample()
 # CMake function to generate and build C++ sample.

--- a/cmake/ortoolsConfig.cmake.in
+++ b/cmake/ortoolsConfig.cmake.in
@@ -29,11 +29,13 @@ if(@BUILD_LP_PARSER@)
 endif()
 
 if(@USE_COINOR@)
+  # COIN-OR packages don't provide CMake config files
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/modules")
   if(NOT Clp_FOUND AND NOT TARGET Coin::ClpSolver)
-    find_dependency(Clp REQUIRED ${CONFIG_FLAG})
+    find_dependency(Clp REQUIRED)
   endif()
   if(NOT Cbc_FOUND AND NOT TARGET Coin::CbcSolver)
-    find_dependency(Cbc REQUIRED ${CONFIG_FLAG})
+    find_dependency(Cbc REQUIRED)
   endif()
 endif()
 


### PR DESCRIPTION
There are currently a few issues with how the COIN-OR dependencies are resolved when using `find_package(ortools CONFIG)` to add or-tools to an external CMake project.

* With CMake >=3.9.6, we try to find the Clp and Cbc packages using the CONFIG mode of `find_package`. This always fails since neither [coin-or/Clp](https://github.com/coin-or/Clp) nor [coin-or/Cbc](https://github.com/coin-or/Cbc) provides a CMake config file.

* If we address the above issue by instead using the MODULE mode of `find_package`, then we need to add `FindCbc.cmake` and `FindCpl.cmake` scripts to the CMAKE_MODULE_PATH in order to teach CMake how to find these dependencies. I propose that or-tools should install these scripts alongside its config file so that they're available to external CMake projects.

* Finally, the `FindCbc.cmake` script included with or-tools defines the variable `CBC_FOUND` when it's successful, rather than `Cbc_FOUND` as expected ([CMake variables are case-sensitive](https://stackoverflow.com/a/35034125)). The `FindCpl.cmake` script has a similar issue. As a result, even when the above two points are addressed, `find_package(ortools CONFIG)` will still fail because CMake erroneously thinks that these two dependencies weren't succesfully found.

This PR attempts to address the above issues with the following changes:

* The CMake config file is modified to allow searching for Cbc and Cpl using the MODULE mode of `find_package`.

* `FindCbc.cmake` and `FindCpl.cmake` are installed with the CMake package config files and are added to the CMAKE_MODULE_PATH if `USE_COINOR` was truthy.

* The `FindCbc.cmake` and `FindCpl.cmake` files are modified to change the case of the variables they export.



<!--
Thank you for submitting a PR!

Please make sure you are targeting the master branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->