### PR TITLE
Avoid Domain if not needed

### DIFF
--- a/ortools/constraint_solver/csharp/IntVarArrayHelper.cs
+++ b/ortools/constraint_solver/csharp/IntVarArrayHelper.cs
@@ -76,7 +76,7 @@ public static class IntVarArrayHelper
     // get solver from array of integer variables
     private static Solver GetSolver(IntVar[] vars)
     {
-        if (vars == null || vars.Length <= 0)
+        if (vars is null || vars.Length <= 0)
             throw new ArgumentException("Array <vars> cannot be null or empty");
 
         return vars[0].solver();
@@ -84,14 +84,14 @@ public static class IntVarArrayHelper
     // get solver from array of integer expressions
     private static Solver GetSolver(IntExpr[] expressions)
     {
-        if (expressions == null || expressions.Length <= 0)
+        if (expressions is null || expressions.Length <= 0)
             throw new ArgumentException("Array <expr> cannot be null or empty");
 
         return expressions[0].solver();
     }
     private static Solver GetSolver(IConstraintWithStatus[] cts)
     {
-        if (cts == null || cts.Length <= 0)
+        if (cts is null || cts.Length <= 0)
             throw new ArgumentException("Array <cts> cannot be null or empty");
 
         return cts[0].solver();

--- a/ortools/constraint_solver/csharp/IntervalVarArrayHelper.cs
+++ b/ortools/constraint_solver/csharp/IntervalVarArrayHelper.cs
@@ -22,7 +22,7 @@ public static class IntervalVarArrayHelper
     // get solver from array of interval variables
     private static Solver GetSolver(IntervalVar[] vars)
     {
-        if (vars == null || vars.Length <= 0)
+        if (vars is null || vars.Length <= 0)
             throw new ArgumentException("Array <vars> cannot be null or empty");
 
         return vars[0].solver();

--- a/ortools/dotnet/Google.OrTools.csproj.in
+++ b/ortools/dotnet/Google.OrTools.csproj.in
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
+    <LangVersion>9.0</LangVersion>
     <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
     <AssemblyName>@DOTNET_PROJECT@</AssemblyName>

--- a/ortools/sat/csharp/CpSolver.cs
+++ b/ortools/sat/csharp/CpSolver.cs
@@ -23,15 +23,15 @@ public class CpSolver
     {
         // Setup search.
         CreateSolveWrapper();
-        if (string_parameters_ != null)
+        if (string_parameters_ is not null)
         {
             solve_wrapper_.SetStringParameters(string_parameters_);
         }
-        if (log_callback_ != null)
+        if (log_callback_ is not null)
         {
             solve_wrapper_.AddLogCallbackFromClass(log_callback_);
         }
-        if (cb != null)
+        if (cb is not null)
         {
             solve_wrapper_.AddSolutionCallback(cb);
         }
@@ -39,7 +39,7 @@ public class CpSolver
         response_ = solve_wrapper_.Solve(model.Model);
 
         // Cleanup search.
-        if (cb != null)
+        if (cb is not null)
         {
             solve_wrapper_.ClearSolutionCallback(cb);
         }
@@ -66,7 +66,7 @@ public class CpSolver
     [MethodImpl(MethodImplOptions.Synchronized)]
     public void StopSearch()
     {
-        if (solve_wrapper_ != null)
+        if (solve_wrapper_ is not null)
         {
             solve_wrapper_.StopSearch();
         }

--- a/ortools/sat/csharp/IntegerExpressions.cs
+++ b/ortools/sat/csharp/IntegerExpressions.cs
@@ -281,7 +281,7 @@ public class LinearExpr
     public static long GetVarValueMap(LinearExpr e, long initial_coeff, Dictionary<IntVar, long> dict)
     {
         List<Term> terms = new List<Term>();
-        if ((Object)e != null)
+        if (e is not null)
         {
             terms.Add(new Term(e, initial_coeff));
         }
@@ -291,7 +291,7 @@ public class LinearExpr
         {
             Term term = terms[0];
             terms.RemoveAt(0);
-            if (term.coefficient == 0 || (Object)term.expr == null)
+            if (term.coefficient == 0 || term.expr is null)
             {
                 continue;
             }
@@ -524,7 +524,7 @@ public class LinearExprBuilder : LinearExpr
         foreach (Term term in terms_)
         {
             bool first = String.IsNullOrEmpty(result);
-            if ((Object)term.expr == null || term.coefficient == 0)
+            if (term.expr is null || term.coefficient == 0)
             {
                 continue;
             }
@@ -616,7 +616,6 @@ public class IntVar : LinearExpr
 {
     public IntVar(CpModelProto model, Domain domain, string name)
     {
-        model_ = model;
         index_ = model.Variables.Count;
         var_ = new IntegerVariableProto();
         var_.Name = name;
@@ -626,7 +625,6 @@ public class IntVar : LinearExpr
 
     public IntVar(CpModelProto model, long lb, long ub, string name)
     {
-        model_ = model;
         index_ = model.Variables.Count;
         var_ = new IntegerVariableProto();
         var_.Name = name;
@@ -637,7 +635,6 @@ public class IntVar : LinearExpr
 
     public IntVar(CpModelProto model, int index)
     {
-        model_ = model;
         index_ = index;
         var_ = model.Variables[index];
     }
@@ -673,14 +670,7 @@ public class IntVar : LinearExpr
 
     public override string ToString()
     {
-        if (var_.Name != null)
-        {
-            return var_.Name;
-        }
-        else
-        {
-            return var_.ToString();
-        }
+        return var_.Name is not null ? var_.Name : var_.ToString();
     }
 
     public string Name()
@@ -688,8 +678,7 @@ public class IntVar : LinearExpr
         return var_.Name;
     }
 
-    protected CpModelProto model_;
-    protected int index_;
+    protected readonly int index_;
     protected IntegerVariableProto var_;
 }
 
@@ -706,11 +695,7 @@ public class BoolVar : IntVar, ILiteral
 
     public ILiteral Not()
     {
-        if (negation_ == null)
-        {
-            negation_ = new NotBoolVar(this);
-        }
-        return negation_;
+        return negation_ ??= new NotBoolVar(this);
     }
 
     public LinearExpr NotAsExpr()
@@ -755,7 +740,7 @@ public class NotBoolVar : LinearExpr, ILiteral
         return String.Format("Not({0})", boolvar_.ToString());
     }
 
-    private BoolVar boolvar_;
+    private readonly BoolVar boolvar_;
 }
 
 public class BoundedLinearExpression

--- a/ortools/util/csharp/NestedArrayHelper.cs
+++ b/ortools/util/csharp/NestedArrayHelper.cs
@@ -58,7 +58,7 @@ public static class NestedArrayHelper
         var result = new int[arr.GetLength(0)];
         for (var i = 0; i < arr.GetLength(0); i++)
         {
-            if (arr[i] != null)
+            if (arr[i] is not null)
                 result[i] = arr[i].Length;
         }
         return result;


### PR DESCRIPTION
My first batch of changes, I have a few more locally, but since there were a lot of changes in this area the last days, I wanted to open up smaller PRs to get the ball rolling and not constantly having to incorporate changes from master :) 

This PR contains 3 changes:
1. Updates C# project to 9.0 (needed for next point)
2. Change null / not null checks to `is null`/`is not null` (Justification [see here](https://www.thomasclaudiushuber.com/2020/03/19/c-why-you-should-prefer-the-is-keyword-over-the-operator/): TLDR: is null avoid the == or != operator override)
3. Adding more shortcuts that avoid the Domain object

Effect of these changes:
|                     Method |     Mean |     Error |    StdDev |   Gen 0 |   Gen 1 | Allocated |
|--------------------------- |---------:|----------:|----------:|--------:|--------:|----------:|
| NursesSat_WithOutputToNull_pr | 1.097 ms | 0.0100 ms | 0.0088 ms | 29.2969 | 13.6719 |    140 KB |
| NursesSat_WithOutputToNull_master | 1.143 ms | 0.0172 ms | 0.0160 ms | 29.2969 | 13.6719 |    141 KB |

So around a 4% overall improvement and some small managed allocation gains.