### PR TITLE
C#

### DIFF
--- a/ortools/sat/csharp/CpModel.cs
+++ b/ortools/sat/csharp/CpModel.cs
@@ -636,10 +636,10 @@ public class CpModel
             objective.Offset = 0L;
             objective.ScalingFactor = minimize ? 1L : -1;
         }
-        else if (obj is IntVar)
+        else if (obj is IntVar intVar)
         {
             objective.Offset = 0L;
-            objective.Vars.Add(((IntVar)obj).Index);
+            objective.Vars.Add(intVar.Index);
             if (minimize)
             {
                 objective.Coeffs.Add(1L);

--- a/ortools/sat/csharp/CpSolver.cs
+++ b/ortools/sat/csharp/CpSolver.cs
@@ -140,9 +140,8 @@ public class CpSolver
                 continue;
             }
 
-            if (term.expr is LinearExprBuilder)
+            if (term.expr is LinearExprBuilder a)
             {
-                LinearExprBuilder a = (LinearExprBuilder)term.expr;
                 constant += term.coefficient * a.Offset;
                 foreach (Term sub in a.Terms)
                 {
@@ -156,9 +155,9 @@ public class CpSolver
                     }
                 }
             }
-            else if (term.expr is IntVar)
+            else if (term.expr is IntVar intVar)
             {
-                int index = ((IntVar)term.expr).GetIndex();
+                int index = intVar.GetIndex();
                 long value = index >= 0 ? response_.Solution[index] : -response_.Solution[-index - 1];
                 constant += term.coefficient * value;
             }

--- a/ortools/sat/csharp/SearchHelpers.cs
+++ b/ortools/sat/csharp/SearchHelpers.cs
@@ -32,9 +32,8 @@ public class CpSolverSolutionCallback : SolutionCallback
             if (term.coefficient == 0)
                 continue;
 
-            if (term.expr is LinearExprBuilder)
+            if (term.expr is LinearExprBuilder a)
             {
-                LinearExprBuilder a = (LinearExprBuilder)term.expr;
                 constant += term.coefficient * a.Offset;
                 foreach (Term sub in a.Terms)
                 {
@@ -48,9 +47,9 @@ public class CpSolverSolutionCallback : SolutionCallback
                     }
                 }
             }
-            else if (term.expr is IntVar)
+            else if (term.expr is IntVar intVar)
             {
-                int index = ((IntVar)term.expr).GetIndex();
+                int index = intVar.GetIndex();
                 long value = SolutionIntegerValue(index);
                 constant += term.coefficient * value;
             }


### PR DESCRIPTION
This PR contains the following 2 changes:

1. use var in is type check and seal classes that have no derived class ([Justification](https://devblogs.microsoft.com/dotnet/performance-improvements-in-net-6/#peanut-butter))
2. simplify AddOrIncrement function
  For .NET 6 I used `GetValueRefOrAddDefault`, which either gets the value by ref or adds the default (0) and then returns the ref, which we then increase (avoids some hash calculation). For the other frameworks I used TryGetValue to remove one hash calculation in case there was already a value in.

Effect of these changes (only taken very seldom in this example):
|                     Method |     Mean |     Error |    StdDev |   Gen 0 |   Gen 1 | Allocated |
|--------------------------- |---------:|----------:|----------:|--------:|--------:|----------:|
| NursesSat_WithOutputToNull_pr | 1.099 ms | 0.0099 ms | 0.0093 ms | 29.2969 | 13.6719 |    135 KB |
| NursesSat_WithOutputToNull_master | 1.113 ms | 0.0095 ms | 0.0089 ms | 29.2969 | 13.6719 |    135 KB |

=> ~1% improvement

PS: Your latest changes on master has shaved off another 5 KB allocation =)