### PR TITLE
simplify reading from returned buffer

### DIFF
--- a/ortools/util/csharp/ProtoHelper.cs
+++ b/ortools/util/csharp/ProtoHelper.cs
@@ -14,18 +14,16 @@
 namespace Google.OrTools
 {
 
-using System;
 using Google.Protobuf;
 
 public static class ProtoHelper
 {
-    public static byte[] ProtoToByteArray(IMessage message)
+    public static int ProtoToByteArray(IMessage message, out byte[] buffer)
     {
         int size = message.CalculateSize();
-        byte[] buffer = new byte[size];
-        CodedOutputStream output = new CodedOutputStream(buffer);
-        message.WriteTo(output);
-        return buffer;
+        buffer = new byte[size];
+        message.WriteTo(buffer);
+        return size;
     }
 }
 } // namespace Google.OrTools


### PR DESCRIPTION
``This pr contains optimization around (de)serializing proto messages.

- avoid calling message.CalculateSize() twice
- instead of copying 4 bytes to array and read it as int, read directly from unmanaged memory
- instead of allocating the array to copy from unmanged, it is now using the arraypool
- using <messagetype>.Parser.ParseFrom instead of CodedInputStream and MergeFrom

Two outstanding questions:
- What about this comment 
> TODO(user): delete the C++ buffer.

Does that mean we're constantly "leaking" memory? Is this fixable?
- I was unable to optimize it further due to my lack of understanding of the code generation. Optimal would be in my opinion:
For methods with input/output
```cs
public Google.OrTools.Sat.CpSolverResponse Solve(Google.OrTools.Sat.CpModelProto model_proto) {
    System.IntPtr data = operations_research_satPINVOKE.SolveWrapper_Solve(swigCPtr, ProtoHelper.ProtoToByteArray(model_proto, out var buf), buf);
    int size = System.Runtime.InteropServices.Marshal.ReadInt32(data);
    if (size > buffer.Length) {
        System.Buffers.ArrayPool<byte>.Shared.Return(buf);
        buf = System.Buffers.ArrayPool<byte>.Shared.Rent(size);
    }
    data += sizeof(int);
    System.Runtime.InteropServices.Marshal.Copy(data, buf, 0, size);
    // TODO(user): delete the C++ buffer.
    try {
      return Google.OrTools.Sat.CpSolverResponse.Parser.ParseFrom(System.MemoryExtensions.AsSpan(buf, 0, size));
    } catch (Google.Protobuf.InvalidProtocolBufferException /*e*/) {
      throw new System.Exception("Unable to parse Google.OrTools.Sat.CpSolverResponse protocol message.");
    }
    finally {
      System.Buffers.ArrayPool<byte>.Shared.Return(buf);
    }
  }
```