### PR TITLE
Use <AllowUnsafeBlocks> to avoid copying to a temp array

### DIFF
--- a/ortools/dotnet/Google.OrTools.csproj.in
+++ b/ortools/dotnet/Google.OrTools.csproj.in
@@ -4,6 +4,7 @@
     <LangVersion>9.0</LangVersion>
     <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>@DOTNET_PROJECT@</AssemblyName>
     <Version>@PROJECT_VERSION@</Version>
 


### PR DESCRIPTION
From #3093

[What does the unsafe switch do?](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/unsafe-code) 
> Other than establishing an unsafe context, thus permitting the use of pointer types, the unsafe modifier has no effect on a type or a member.

The change basically avoids the temporary array and directly enables the reading from the ReadOnlySpan over the native array returned.