### PR TITLE
Fix build with debug GNU STL

### DIFF
--- a/ortools/sat/encoding.h
+++ b/ortools/sat/encoding.h
@@ -138,6 +138,10 @@ class EncodingNode {
 // In debug, with msvc, std::Vector<T> is 32
 static_assert(sizeof(EncodingNode) == 72,
               "ERROR_EncodingNode_is_not_well_compacted");
+#elif defined(_GLIBCXX_DEBUG)
+// In debug GNU libstdc++ std::Vector<T> is up to 56
+static_assert(sizeof(EncodingNode) <= 96,
+              "ERROR_EncodingNode_is_not_well_compacted");
 #else
 // Note that we use <= because on 32 bits architecture, the size will actually
 // be smaller than 64 bytes.


### PR DESCRIPTION
Minimal working example:
```bash
cmake  -S. -Bbuild -DCMAKE_BUILD_TYPE=Debug -DBUILD_SAMPLES=OFF -DBUILD_EXAMPLES=OFF -DBUILD_FLATZINC=OFF -DUSE_SCIP=OFF -DUSE_COINOR=OFF -DBUILD_TESTING=OFF -DCMAKE_CXX_FLAGS=-D_GLIBCXX_DEBUG
cd build
make -j$(nproc)
```