### PR TITLE
Build Python modules as CMake MODULEs

### DIFF
--- a/cmake/docs/swig.md
+++ b/cmake/docs/swig.md
@@ -194,7 +194,7 @@ You can use `OUTPUT_DIR` to change the output directory for the `.py` file e.g.:
 
 ```cmake
 swig_add_library(pyFoo
-  TYPE SHARED
+  TYPE MODULE
   LANGUAGE python
   OUTPUT_DIR ${CMAKE_BINARY_DIR}/python/${PROJECT_NAME}/Foo
   SOURCES foo.i)

--- a/ortools/algorithms/python/CMakeLists.txt
+++ b/ortools/algorithms/python/CMakeLists.txt
@@ -3,7 +3,7 @@ set_property(SOURCE knapsack_solver.i PROPERTY SWIG_MODULE_NAME pywrapknapsack_s
 set_property(SOURCE knapsack_solver.i PROPERTY COMPILE_DEFINITIONS
   ${OR_TOOLS_COMPILE_DEFINITIONS} ABSL_MUST_USE_RESULT)
 swig_add_library(pywrapknapsack_solver
-  TYPE SHARED
+  TYPE MODULE
   LANGUAGE python
   OUTPUT_DIR  ${PYTHON_PROJECT_DIR}/algorithms
   SOURCES knapsack_solver.i)

--- a/ortools/constraint_solver/python/CMakeLists.txt
+++ b/ortools/constraint_solver/python/CMakeLists.txt
@@ -4,7 +4,7 @@ set_property(SOURCE routing.i PROPERTY COMPILE_DEFINITIONS
   ${OR_TOOLS_COMPILE_DEFINITIONS} ABSL_MUST_USE_RESULT)
 set_property(SOURCE routing.i PROPERTY COMPILE_OPTIONS -nofastunpack)
 swig_add_library(pywrapcp
-  TYPE SHARED
+  TYPE MODULE
   LANGUAGE python
   OUTPUT_DIR ${PYTHON_PROJECT_DIR}/constraint_solver
   SOURCES routing.i)

--- a/ortools/init/python/CMakeLists.txt
+++ b/ortools/init/python/CMakeLists.txt
@@ -3,7 +3,7 @@ set_property(SOURCE init.i PROPERTY SWIG_MODULE_NAME pywrapinit)
 set_property(SOURCE init.i PROPERTY COMPILE_DEFINITIONS
   ${OR_TOOLS_COMPILE_DEFINITIONS} ABSL_MUST_USE_RESULT)
 swig_add_library(pywrapinit
-  TYPE SHARED
+  TYPE MODULE
   LANGUAGE python
   OUTPUT_DIR  ${PYTHON_PROJECT_DIR}/init
   SOURCES init.i)

--- a/ortools/linear_solver/python/CMakeLists.txt
+++ b/ortools/linear_solver/python/CMakeLists.txt
@@ -3,7 +3,7 @@ set_property(SOURCE linear_solver.i PROPERTY SWIG_MODULE_NAME pywraplp)
 set_property(SOURCE linear_solver.i PROPERTY COMPILE_DEFINITIONS
   ${OR_TOOLS_COMPILE_DEFINITIONS} ABSL_MUST_USE_RESULT)
 swig_add_library(pywraplp
-  TYPE SHARED
+  TYPE MODULE
   LANGUAGE python
   OUTPUT_DIR ${PYTHON_PROJECT_DIR}/linear_solver
   SOURCES linear_solver.i)

--- a/ortools/scheduling/python/CMakeLists.txt
+++ b/ortools/scheduling/python/CMakeLists.txt
@@ -3,7 +3,7 @@ set_property(SOURCE rcpsp.i PROPERTY SWIG_MODULE_NAME pywraprcpsp)
 set_property(SOURCE rcpsp.i PROPERTY COMPILE_DEFINITIONS
   ${OR_TOOLS_COMPILE_DEFINITIONS} ABSL_MUST_USE_RESULT)
 swig_add_library(pywraprcpsp
-  TYPE SHARED
+  TYPE MODULE
   LANGUAGE python
   OUTPUT_DIR ${PYTHON_PROJECT_DIR}/scheduling
   SOURCES rcpsp.i)


### PR DESCRIPTION
Python since 3.8 no longer links to the interpreter library, so
symbols like `PyExc_AttributeError` will be undefined at link time.

This causes build failures when shared libraries are linked with
`-Wl,--no-undefined`. Use `TYPE MODULE` for python extension modules,
which allows to specify distinct flags via CMAKE_MODULE_LINKER_FLAGS
vs CMAKE_SHARED_LINKER_FLAGS. (The same is already used by
`pybind11_add_module(... MODULE ...)`).

Fixes #3258.