### PR TITLE
Depend on @zlib//:zlib regardless of platform

### DIFF
--- a/bazel/scip.BUILD
+++ b/bazel/scip.BUILD
@@ -45,7 +45,7 @@ PLATFORM_FLAGS = select({
 PLATFORM_DEPS = select({
     "on_linux": ["@bliss//:libbliss"],
     "on_macos": ["@bliss//:libbliss"],
-    "on_windows": ["@zlib//:zlib"],
+    "on_windows": [],
     "//conditions:default": [],
 })
 
@@ -117,5 +117,6 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         #"@cppad:cppad_includes",
+        "@zlib//:zlib",
     ] + PLATFORM_DEPS,
 )


### PR DESCRIPTION
Without this, I get a compilation error about missing <zlib.h> on a fresh linux install.

<!--
Thank you for submitting a PR!

Please make sure you are targeting the master branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->