### PR TITLE
CI: Use `zypper refresh` to update repository metadata

### DIFF
--- a/bazel/docker/opensuse/Dockerfile
+++ b/bazel/docker/opensuse/Dockerfile
@@ -4,20 +4,20 @@ FROM opensuse/tumbleweed AS env
 LABEL maintainer="corentinl@google.com"
 # Install system build dependencies
 ENV PATH=/usr/local/bin:$PATH
-RUN zypper update -y \
+RUN zypper refresh \
 && zypper install -y git gcc gcc-c++ zlib-devel \
 && zypper clean -a
 ENV CC=gcc CXX=g++
 
 # https://software.opensuse.org/package/bazel4.2
-RUN zypper ar -Gf \
+RUN zypper addrepo -Gf \
 https://download.opensuse.org/repositories/devel:tools:building/openSUSE_Factory/devel:tools:building.repo \
+&& zypper refresh \
 && zypper install -y bazel4.2 findutils \
 && zypper clean -a
 
 # Install Python
-RUN zypper update -y \
-&& zypper install -y python3 python3-pip python3-devel \
+RUN zypper install -y python3 python3-pip python3-devel \
 && zypper clean -a
 
 FROM env AS devel

--- a/makefiles/docker/opensuse/Dockerfile
+++ b/makefiles/docker/opensuse/Dockerfile
@@ -4,7 +4,7 @@ FROM opensuse/tumbleweed AS base
 LABEL maintainer="corentinl@google.com"
 # Install system build dependencies
 ENV PATH=/usr/local/bin:$PATH
-RUN zypper update -y \
+RUN zypper refresh \
 && zypper install -y git gcc gcc-c++ cmake \
  wget which lsb-release util-linux pkgconfig autoconf libtool zlib-devel \
 && zypper clean -a

--- a/makefiles/docker/opensuse/dotnet.Dockerfile
+++ b/makefiles/docker/opensuse/dotnet.Dockerfile
@@ -1,5 +1,5 @@
 FROM ortools/make:opensuse_swig AS env
-RUN zypper update -y \
+RUN zypper refresh \
 && zypper install -y wget tar libicu-devel
 
 # .NET install

--- a/makefiles/docker/opensuse/java.Dockerfile
+++ b/makefiles/docker/opensuse/java.Dockerfile
@@ -1,5 +1,5 @@
 FROM ortools/make:opensuse_swig AS env
-RUN zypper update -y \
+RUN zypper refresh \
 && zypper install -y java-1_8_0-openjdk java-1_8_0-openjdk-devel maven \
 && zypper clean -a
 

--- a/makefiles/docker/opensuse/python.Dockerfile
+++ b/makefiles/docker/opensuse/python.Dockerfile
@@ -1,5 +1,5 @@
 FROM ortools/make:opensuse_swig AS env
-RUN zypper update -y \
+RUN zypper refresh \
 && zypper install -y python3-devel python3-pip \
  python3-wheel \
  python3-numpy python3-pandas \

--- a/tools/docker/images/opensuse-leap.Dockerfile
+++ b/tools/docker/images/opensuse-leap.Dockerfile
@@ -4,7 +4,7 @@ FROM opensuse/leap AS env
 LABEL maintainer="corentinl@google.com"
 # Install system build dependencies
 ENV PATH=/usr/local/bin:$PATH
-RUN zypper update -y \
+RUN zypper refresh \
 && zypper install -y git gcc11 gcc11-c++ cmake \
  wget which lsb-release util-linux pkgconfig autoconf libtool gzip zlib-devel \
 && zypper clean -a
@@ -19,24 +19,20 @@ RUN wget -q "https://cmake.org/files/v3.21/cmake-3.21.1-linux-x86_64.sh" \
 && rm cmake-3.21.1-linux-x86_64.sh
 
 # Swig Install
-RUN zypper update -y \
-&& zypper install -y swig \
+RUN zypper install -y swig \
 && zypper clean -a
 
 # Java install (openjdk-8)
-RUN zypper update -y \
-&& zypper install -y java-1_8_0-openjdk java-1_8_0-openjdk-devel maven \
+RUN zypper install -y java-1_8_0-openjdk java-1_8_0-openjdk-devel maven \
 && zypper clean -a
 
 # Python Install
-RUN zypper update -y \
-&& zypper install -y python3-devel python3-pip python3-wheel \
+RUN zypper install -y python3-devel python3-pip python3-wheel \
 && zypper clean -a
 RUN python3 -m pip install absl-py mypy-protobuf
 
-# .Net Instal
-RUN zypper update -y \
-&& zypper install -y wget tar gzip libicu-devel
+# .Net Install
+RUN zypper install -y wget tar gzip libicu-devel
 
 RUN mkdir -p /usr/share/dotnet \
 && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/tools/docker/test/opensuse-leap/cpp.Dockerfile
+++ b/tools/docker/test/opensuse-leap/cpp.Dockerfile
@@ -4,7 +4,7 @@ FROM opensuse/leap
 
 # Install system build dependencies
 ENV PATH=/usr/local/bin:$PATH
-RUN zypper update -y \
+RUN zypper refresh \
 && zypper install -y git gcc11 gcc11-c++ \
  wget which lsb-release util-linux pkgconfig autoconf libtool zlib-devel \
 && zypper clean -a

--- a/tools/docker/test/opensuse-leap/dotnet.Dockerfile
+++ b/tools/docker/test/opensuse-leap/dotnet.Dockerfile
@@ -4,7 +4,7 @@ FROM opensuse/leap
 
 # Install system build dependencies
 ENV PATH=/usr/local/bin:$PATH
-RUN zypper update -y \
+RUN zypper refresh \
 && zypper install -y git gcc gcc-c++ \
  wget which lsb-release util-linux pkgconfig autoconf libtool zlib-devel \
 && zypper clean -a
@@ -12,9 +12,8 @@ ENV CC=gcc CXX=g++
 ENTRYPOINT ["/usr/bin/bash", "-c"]
 CMD ["/usr/bin/bash"]
 
-# .Net Instal
-RUN zypper update -y \
-&& zypper install -y wget tar gzip libicu-devel
+# .Net Install
+RUN zypper install -y wget tar gzip libicu-devel
 
 RUN mkdir -p /usr/share/dotnet \
 && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet

--- a/tools/docker/test/opensuse-leap/java.Dockerfile
+++ b/tools/docker/test/opensuse-leap/java.Dockerfile
@@ -4,7 +4,7 @@ FROM opensuse/leap
 
 # Install system build dependencies
 ENV PATH=/usr/local/bin:$PATH
-RUN zypper update -y \
+RUN zypper refresh \
 && zypper install -y git gcc gcc-c++ \
  wget which lsb-release util-linux pkgconfig autoconf libtool zlib-devel \
 && zypper clean -a
@@ -13,8 +13,7 @@ ENTRYPOINT ["/usr/bin/bash", "-c"]
 CMD ["/usr/bin/bash"]
 
 # Java install (openjdk-8)
-RUN zypper update -y \
-&& zypper install -y java-1_8_0-openjdk java-1_8_0-openjdk-devel maven \
+RUN zypper install -y java-1_8_0-openjdk java-1_8_0-openjdk-devel maven \
 && zypper clean -a
 
 WORKDIR /root


### PR DESCRIPTION
`update` updates packages, which is not intended here.

Also call refresh just once.

Fixes #3314.
