### PR TITLE
PDLP: Log corrected_dual_objective

### DIFF
--- a/ortools/pdlp/primal_dual_hybrid_gradient.cc
+++ b/ortools/pdlp/primal_dual_hybrid_gradient.cc
@@ -906,6 +906,13 @@ SolverResult Solver::ConstructSolverResult(VectorXd primal_solution,
     LOG(INFO) << IterationStatsLabelString();
     LOG(INFO) << ToString(stats, params_.termination_criteria(),
                           original_bound_norms_, solve_log.solution_type());
+    const auto& convergence_info = GetConvergenceInformation(stats, solve_log.solution_type());
+    if (convergence_info.has_value()) {
+      if (std::isfinite(convergence_info->corrected_dual_objective())) {
+        LOG(INFO) << "Dual objective after infeasibility correction: " <<
+          convergence_info->corrected_dual_objective();
+      }
+    }
   }
   solve_log.set_iteration_count(stats.iteration_number());
   solve_log.set_termination_reason(termination_reason);


### PR DESCRIPTION
This issue came up in private discussion with a user. Calling PDLP via examples/cpp/solve.cc doesn't provide an easy mechanism to access the corrected_dual_objective. Here we at least log the information so that someone experimenting with PDLP can evaluate whether it's providing useful bounds before getting involved with more complex APIs.

(The code may not pass linters. I'm not sure how to run these when developing on open source or-tools.)