### PR TITLE
Move positivity check to a variable

### DIFF
--- a/ortools/constraint_solver/routing.cc
+++ b/ortools/constraint_solver/routing.cc
@@ -1255,13 +1255,13 @@ int RegisterUnaryCallback(RoutingTransitCallback1 callback, bool is_positive,
 }  // namespace
 
 int RoutingModel::RegisterUnaryTransitVector(std::vector<int64_t> values) {
+  bool is_positive=std::all_of(std::cbegin(values), std::cend(values),
+    [](int64_t transit) { return transit >= 0; });
   return RegisterUnaryCallback(
       [this, values = std::move(values)](int64_t i) {
         return values[manager_.IndexToNode(i).value()];
       },
-      /*is_positive=*/
-      std::all_of(std::cbegin(values), std::cend(values),
-                  [](int64_t transit) { return transit >= 0; }),
+      is_positive,
       this);
 }
 


### PR DESCRIPTION
- On some systems, the vector `values` would be empty when resolving the second argument of the `RegisterUnaryCallback` call. This meant that the callback was always treated as positive. This caused issues if registering a transit vector with negative values. Creating an `is_positive` variable and resolving before the call fixes the issue.
