### PR TITLE
Fix RUNPATHs for libraries and executables

### DIFF
--- a/cmake/cpp.cmake
+++ b/cmake/cpp.cmake
@@ -440,20 +440,23 @@ function(add_cxx_sample FILE_NAME)
   get_filename_component(COMPONENT_DIR ${SAMPLE_DIR} DIRECTORY)
   get_filename_component(COMPONENT_NAME ${COMPONENT_DIR} NAME)
 
-  if(APPLE)
-    set(CMAKE_INSTALL_RPATH
-      "@loader_path/../${CMAKE_INSTALL_LIBDIR};@loader_path")
-  elseif(UNIX)
-    set(CMAKE_INSTALL_RPATH
-      "$ORIGIN/../${CMAKE_INSTALL_LIBDIR}:$ORIGIN/../lib64:$ORIGIN/../lib:$ORIGIN")
-  endif()
-
   add_executable(${SAMPLE_NAME} ${FILE_NAME})
   target_include_directories(${SAMPLE_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
   target_compile_features(${SAMPLE_NAME} PRIVATE cxx_std_17)
   target_link_libraries(${SAMPLE_NAME} PRIVATE ${PROJECT_NAMESPACE}::ortools)
 
   include(GNUInstallDirs)
+  if(APPLE)
+    set_target_properties(${SAMPLE_NAME} PROPERTIES INSTALL_RPATH
+      "@loader_path/../${CMAKE_INSTALL_LIBDIR};@loader_path")
+  elseif(UNIX)
+    cmake_path(RELATIVE_PATH CMAKE_INSTALL_FULL_LIBDIR
+               BASE_DIRECTORY ${CMAKE_INSTALL_FULL_BINDIR}
+               OUTPUT_VARIABLE libdir_relative_path)
+    set_target_properties(${SAMPLE_NAME} PROPERTIES
+                          INSTALL_RPATH "$ORIGIN/${libdir_relative_path}")
+  endif()
+
   install(TARGETS ${SAMPLE_NAME})
 
   if(BUILD_TESTING)
@@ -474,19 +477,23 @@ function(add_cxx_example FILE_NAME)
   get_filename_component(COMPONENT_DIR ${FILE_NAME} DIRECTORY)
   get_filename_component(COMPONENT_NAME ${COMPONENT_DIR} NAME)
 
-  if(APPLE)
-    set(CMAKE_INSTALL_RPATH
-      "@loader_path/../${CMAKE_INSTALL_LIBDIR};@loader_path")
-  elseif(UNIX)
-    set(CMAKE_INSTALL_RPATH "$ORIGIN/../${CMAKE_INSTALL_LIBDIR}:$ORIGIN/../lib64:$ORIGIN/../lib:$ORIGIN")
-  endif()
-
   add_executable(${EXAMPLE_NAME} ${FILE_NAME})
   target_include_directories(${EXAMPLE_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
   target_compile_features(${EXAMPLE_NAME} PRIVATE cxx_std_17)
   target_link_libraries(${EXAMPLE_NAME} PRIVATE ${PROJECT_NAMESPACE}::ortools)
 
   include(GNUInstallDirs)
+  if(APPLE)
+    set_target_properties(${EXAMPLE_NAME} PROPERTIES INSTALL_RPATH
+      "@loader_path/../${CMAKE_INSTALL_LIBDIR};@loader_path")
+  elseif(UNIX)
+    cmake_path(RELATIVE_PATH CMAKE_INSTALL_FULL_LIBDIR
+               BASE_DIRECTORY ${CMAKE_INSTALL_FULL_BINDIR}
+               OUTPUT_VARIABLE libdir_relative_path)
+    set_target_properties(${EXAMPLE_NAME} PROPERTIES
+                          INSTALL_RPATH "$ORIGIN/${libdir_relative_path}")
+  endif()
+
   install(TARGETS ${EXAMPLE_NAME})
 
   if(BUILD_TESTING)

--- a/cmake/flatzinc.cmake
+++ b/cmake/flatzinc.cmake
@@ -93,6 +93,9 @@ target_compile_options(flatzinc PUBLIC ${FLATZINC_COMPILE_OPTIONS})
 ## Properties
 if(NOT APPLE)
   set_target_properties(flatzinc PROPERTIES VERSION ${PROJECT_VERSION})
+  if(UNIX)
+    set_target_properties(flatzinc PROPERTIES INSTALL_RPATH "$ORIGIN")
+  endif()
 else()
   # Clang don't support version x.y.z with z > 255
   set_target_properties(flatzinc PROPERTIES
@@ -113,14 +116,6 @@ if(WIN32)
 endif()
 ## Alias
 add_library(${PROJECT_NAMESPACE}::flatzinc ALIAS flatzinc)
-
-
-if(APPLE)
-  set(CMAKE_INSTALL_RPATH
-    "@loader_path/../${CMAKE_INSTALL_LIBDIR};@loader_path")
-elseif(UNIX)
-  set(CMAKE_INSTALL_RPATH "$ORIGIN/../${CMAKE_INSTALL_LIBDIR}:$ORIGIN/../lib64:$ORIGIN/../lib:$ORIGIN")
-endif()
 
 
 # fzn-ortools Binary
@@ -146,6 +141,17 @@ target_compile_options(fzn PUBLIC ${FLATZINC_COMPILE_OPTIONS})
 target_link_libraries(fzn PRIVATE ${PROJECT_NAMESPACE}::flatzinc)
 ## Alias
 add_executable(${PROJECT_NAME}::fzn ALIAS fzn)
+## INSTALL_RPATH
+if(APPLE)
+  set_target_properties(fzn PROPERTIES
+                        INSTALL_RPATH "@loader_path/../${CMAKE_INSTALL_LIBDIR};@loader_path")
+elseif(UNIX)
+  cmake_path(RELATIVE_PATH CMAKE_INSTALL_FULL_LIBDIR
+             BASE_DIRECTORY ${CMAKE_INSTALL_FULL_BINDIR}
+             OUTPUT_VARIABLE libdir_relative_path)
+  set_target_properties(fzn PROPERTIES
+                        INSTALL_RPATH "$ORIGIN/${libdir_relative_path}")
+endif()
 
 
 # Parser-main Binary

--- a/ortools/linear_solver/CMakeLists.txt
+++ b/ortools/linear_solver/CMakeLists.txt
@@ -48,19 +48,22 @@ target_link_libraries(${NAME} PRIVATE
 #add_library(${PROJECT_NAME}::linear_solver ALIAS ${NAME})
 
 # solve
-include(GNUInstallDirs)
-if(APPLE)
-  set(CMAKE_INSTALL_RPATH
-    "@loader_path/../${CMAKE_INSTALL_LIBDIR};@loader_path")
-elseif(UNIX)
-  set(CMAKE_INSTALL_RPATH
-    "$ORIGIN/../${CMAKE_INSTALL_LIBDIR}:$ORIGIN/../lib64:$ORIGIN/../lib:$ORIGIN")
-endif()
-
 add_executable(solve)
 target_sources(solve PRIVATE "solve.cc")
 target_include_directories(solve PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_features(solve PRIVATE cxx_std_17)
 target_link_libraries(solve PRIVATE ${PROJECT_NAMESPACE}::ortools)
+
+include(GNUInstallDirs)
+if(APPLE)
+  set_target_properties(solve PROPERTIES INSTALL_RPATH
+    "@loader_path/../${CMAKE_INSTALL_LIBDIR};@loader_path")
+elseif(UNIX)
+  cmake_path(RELATIVE_PATH CMAKE_INSTALL_FULL_LIBDIR
+             BASE_DIRECTORY ${CMAKE_INSTALL_FULL_BINDIR}
+             OUTPUT_VARIABLE libdir_relative_path)
+  set_target_properties(solve PROPERTIES
+                        INSTALL_RPATH "$ORIGIN/${libdir_relative_path}")
+endif()
 
 install(TARGETS solve)

--- a/ortools/sat/CMakeLists.txt
+++ b/ortools/sat/CMakeLists.txt
@@ -40,19 +40,22 @@ target_link_libraries(${NAME} PRIVATE
 #add_library(${PROJECT_NAME}::sat ALIAS ${NAME})
 
 # Sat Runner
-include(GNUInstallDirs)
-if(APPLE)
-  set(CMAKE_INSTALL_RPATH
-    "@loader_path/../${CMAKE_INSTALL_LIBDIR};@loader_path")
-elseif(UNIX)
-  set(CMAKE_INSTALL_RPATH
-    "$ORIGIN/../${CMAKE_INSTALL_LIBDIR}:$ORIGIN/../lib64:$ORIGIN/../lib:$ORIGIN")
-endif()
-
 add_executable(sat_runner)
 target_sources(sat_runner PRIVATE "sat_runner.cc")
 target_include_directories(sat_runner PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_features(sat_runner PRIVATE cxx_std_17)
 target_link_libraries(sat_runner PRIVATE ${PROJECT_NAMESPACE}::ortools)
+
+include(GNUInstallDirs)
+if(APPLE)
+  set_target_properties(sat_runner PROPERTIES INSTALL_RPATH
+    "@loader_path/../${CMAKE_INSTALL_LIBDIR};@loader_path")
+elseif(UNIX)
+  cmake_path(RELATIVE_PATH CMAKE_INSTALL_FULL_LIBDIR
+             BASE_DIRECTORY ${CMAKE_INSTALL_FULL_BINDIR}
+             OUTPUT_VARIABLE libdir_relative_path)
+  set_target_properties(sat_runner PROPERTIES
+                        INSTALL_RPATH "$ORIGIN/${libdir_relative_path}")
+endif()
 
 install(TARGETS sat_runner)


### PR DESCRIPTION
The RUNPATH should be limited to the entries actually required, instead of trying to cover all possible scenarios by adding an entry for each.

Instead of modifying the default RUNPATH by repeatedly setting CMAKE_INSTALL_RPATH, set the correct minimal INSTALL_RPATH property for each executable and library.

Only tested on Linux. Windows should not be affected, MacOS may be wrong.