### PR TITLE
Move attributes to beginning in function declarations to allow it to build on GCC 12

### DIFF
--- a/ortools/graph/topologicalsorter.h
+++ b/ortools/graph/topologicalsorter.h
@@ -77,12 +77,12 @@ namespace util {
 // Returns true if the graph was a DAG, and outputs the topological order in
 // "topological_order". Returns false if the graph is cyclic.
 // Works in O(num_nodes + arcs.size()), and is pretty fast.
-inline ABSL_MUST_USE_RESULT bool DenseIntTopologicalSort(
+ABSL_MUST_USE_RESULT inline bool DenseIntTopologicalSort(
     int num_nodes, const std::vector<std::pair<int, int>>& arcs,
     std::vector<int>* topological_order);
 
 // Like DenseIntTopologicalSort, but stable.
-inline ABSL_MUST_USE_RESULT bool DenseIntStableTopologicalSort(
+ABSL_MUST_USE_RESULT inline bool DenseIntStableTopologicalSort(
     int num_nodes, const std::vector<std::pair<int, int>>& arcs,
     std::vector<int>* topological_order);
 


### PR DESCRIPTION
Hey there! GCC 12 apparently cares more about attribute order than GCC 11, and these two declarations caused the build to error out. It looks like just these two function declarations were misordered, at least with default build settings

<!--
Thank you for submitting a PR!

Please make sure you are targeting the master branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->