### PR TITLE
python: fix missing sat related .pyi files

### DIFF
--- a/ortools/python/setup.py.in
+++ b/ortools/python/setup.py.in
@@ -63,6 +63,7 @@ setup(
         '@PROJECT_NAME@.model_builder.python':['$<TARGET_FILE_NAME:pywrap_model_builder_helper>', '*.pyi'],
         '@PROJECT_NAME@.packing':['*.pyi'],
         '@PROJECT_NAME@.pdlp':['*.pyi'],
+        '@PROJECT_NAME@.sat':['*.pyi'],
         '@PROJECT_NAME@.sat.python':['$<TARGET_FILE_NAME:swig_helper>', '*.pyi'],
         '@PROJECT_NAME@.scheduling':['$<TARGET_FILE_NAME:pywraprcpsp>', '*.pyi'],
         '@PROJECT_NAME@.util.python':['$<TARGET_FILE_NAME:sorted_interval_list>', '*.pyi'],


### PR DESCRIPTION
Distribute again the following type hint files that do not live under `ortools.sat.python`:

- `ortools/sat/sat_parameters_pb2.pyi`
- `ortools/sat/cp_model_service_pb2.pyi`
- `ortools/sat/cp_model_pb2.pyi`
- `ortools/sat/boolean_problem_pb2.pyi`

Mainly for autocompletion when using `solver.parameters.[...]`