### PR TITLE
CP-SAT non-linear optimization sample with AddMultiplicationEquality

### DIFF
--- a/ortools/sat/samples/NonLinearSat.cs
+++ b/ortools/sat/samples/NonLinearSat.cs
@@ -1,0 +1,52 @@
+﻿// Copyright 2010-2022 Google LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Finds a rectangle with maximum available area for given perimeter
+// using AddMultiplicationEquality
+
+using System;
+using Google.OrTools.Sat;
+
+public class NonLinearSat
+{
+    public static void Main()
+    {
+        const int perimeter = 20;
+
+        var model = new CpModel();
+
+        var x = model.NewIntVar(0, perimeter, "x");
+        var y = model.NewIntVar(0, perimeter, "y");
+
+        model.Add(2 * (x + y) == perimeter);
+
+        var area = model.NewIntVar(0, perimeter * perimeter, "s");
+
+        model.AddMultiplicationEquality(area, x, y);
+
+        model.Maximize(area);
+
+        var solver = new CpSolver();
+
+        var status = solver.Solve(model);
+
+        if (status == CpSolverStatus.Optimal || status == CpSolverStatus.Feasible)
+        {
+            Console.WriteLine($"x = {solver.Value(x)}");
+            Console.WriteLine($"y = {solver.Value(y)}");
+            Console.WriteLine($"s = {solver.Value(area)}");
+        }
+        else
+            Console.WriteLine("No solution found");
+    }
+}

--- a/ortools/sat/samples/non_linear_sat.cc
+++ b/ortools/sat/samples/non_linear_sat.cc
@@ -1,0 +1,62 @@
+// Copyright 2010-2022 Google LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Finds a rectangle with maximum available area for given perimeter
+// using AddMultiplicationEquality
+
+#include <stdlib.h>
+#include "ortools/sat/cp_model.h"
+#include "ortools/sat/cp_model_solver.h"
+
+namespace operations_research {
+namespace sat {
+
+void NonLinearSatProgram() {
+    CpModelBuilder cp_model;
+
+    const int perimeter = 20;
+    const Domain sides_domain(0, perimeter);
+    
+    const IntVar x = cp_model.NewIntVar(sides_domain);
+    const IntVar y = cp_model.NewIntVar(sides_domain);
+
+    cp_model.AddEquality(2 * (x + y), perimeter);
+
+    const Domain area_domain(0, perimeter * perimeter);
+    const IntVar area = cp_model.NewIntVar(area_domain);
+
+    cp_model.AddMultiplicationEquality(area, x, y);
+
+    cp_model.Maximize(area);
+
+    const CpSolverResponse response = Solve(cp_model.Build());
+    
+    if (response.status() == CpSolverStatus::OPTIMAL ||
+        response.status() == CpSolverStatus::FEASIBLE) {
+      // Get the value of x in the solution.
+      LOG(INFO) << "x = " << SolutionIntegerValue(response, x);
+      LOG(INFO) << "y = " << SolutionIntegerValue(response, y);
+      LOG(INFO) << "s = " << SolutionIntegerValue(response, area);
+    } else {
+      LOG(INFO) << "No solution found.";
+    }
+}
+
+}  // namespace sat
+}  // namespace operations_research
+
+int main() {
+  operations_research::sat::NonLinearSatProgram();
+  return EXIT_SUCCESS;
+}
+// [END program]

--- a/ortools/sat/samples/non_linear_sat.py
+++ b/ortools/sat/samples/non_linear_sat.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# Copyright 2010-2022 Google LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Finds a rectangle with maximum available area for given perimeter
+# using AddMultiplicationEquality
+
+from ortools.sat.python import cp_model
+
+
+def NonLinearSat():
+    perimeter = 20
+
+    model = cp_model.CpModel()
+
+    x = model.NewIntVar(0, perimeter, "x")
+    y = model.NewIntVar(0, perimeter, "y")
+    model.Add(2 * (x + y) == perimeter)
+
+    area = model.NewIntVar(0, perimeter * perimeter, "s")
+    model.AddMultiplicationEquality(area, x, y)
+
+    model.Maximize(area)
+
+    solver = cp_model.CpSolver()
+
+    status = solver.Solve(model)
+
+    if status == cp_model.OPTIMAL or status == cp_model.FEASIBLE:
+        print('x = %i' % solver.Value(x))
+        print('y = %i' % solver.Value(y))
+        print('s = %i' % solver.Value(area))
+    else:
+        print('No solution found.')
+
+
+NonLinearSat()


### PR DESCRIPTION
Hi!

I've been using OR-Tools for years, but I was really surprised that CP-Sat could be used for non-linear optimization (except well-known (for me of course) `.OnlyEnfoceIf`. I didn't find any examples of `AddMultiplicationEquality` method, so I decided to make my own and submit this PR.

Added samples solve a simple problem: for given perimeter it finds a rectangle with maximum area, e.g.:

constraint: `2 * (x + y) = p`
objective function: `x * y -> max`

There are C++, C# and Python versions