### PR TITLE
Bugfixes for cover_rectangle example

### DIFF
--- a/examples/notebook/examples/cover_rectangle_sat.ipynb
+++ b/examples/notebook/examples/cover_rectangle_sat.ipynb
@@ -72,7 +72,7 @@
    "id": "description",
    "metadata": {},
    "source": [
-    "Fill a 72x37 rectangle by a minimum number of non-overlapping squares.\n",
+    "Fill a 60x50 rectangle by a minimum number of non-overlapping squares.\n",
     "\n"
    ]
   },
@@ -88,8 +88,8 @@
     "\n",
     "def cover_rectangle(num_squares):\n",
     "    \"\"\"Try to fill the rectangle with a given number of squares.\"\"\"\n",
-    "    size_x = 72\n",
-    "    size_y = 37\n",
+    "    size_x = 60\n",
+    "    size_y = 50\n",
     "\n",
     "    model = cp_model.CpModel()\n",
     "\n",
@@ -112,7 +112,7 @@
     "        interval_y = model.NewIntervalVar(start_y, size, end_y, 'iy_%i' % i)\n",
     "\n",
     "        area = model.NewIntVar(1, size_y * size_y, 'area_%i' % i)\n",
-    "        model.AddProdEquality(area, [size, size])\n",
+    "        model.AddMultiplicationEquality(area, [size, size])\n",
     "\n",
     "        areas.append(area)\n",
     "        x_intervals.append(interval_x)\n",
@@ -169,12 +169,12 @@
     "\n",
     "        for line in range(size_y):\n",
     "            print(' '.join(display[line]))\n",
-    "    return status == cp_model.FEASIBLE\n",
+    "    return status == cp_model.OPTIMAL\n",
     "\n",
     "\n",
-    "for num in range(1, 15):\n",
-    "    print('Trying with size =', num)\n",
-    "    if cover_rectangle(num):\n",
+    "for num_squares in range(1, 15):\n",
+    "    print('Trying with size =', num_squares)\n",
+    "    if cover_rectangle(num_squares):\n",
     "        break\n",
     "\n"
    ]

--- a/examples/python/cover_rectangle_sat.py
+++ b/examples/python/cover_rectangle_sat.py
@@ -10,7 +10,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Fill a 72x37 rectangle by a minimum number of non-overlapping squares."""
+"""Fill a 60x50 rectangle by a minimum number of non-overlapping squares."""
 
 
 from ortools.sat.python import cp_model
@@ -18,8 +18,8 @@ from ortools.sat.python import cp_model
 
 def cover_rectangle(num_squares):
     """Try to fill the rectangle with a given number of squares."""
-    size_x = 72
-    size_y = 37
+    size_x = 60
+    size_y = 50
 
     model = cp_model.CpModel()
 
@@ -99,10 +99,10 @@ def cover_rectangle(num_squares):
 
         for line in range(size_y):
             print(' '.join(display[line]))
-    return status == cp_model.FEASIBLE
+    return status == cp_model.OPTIMAL
 
 
-for num in range(1, 15):
-    print('Trying with size =', num)
-    if cover_rectangle(num):
+for num_squares in range(1, 15):
+    print('Trying with size =', num_squares)
+    if cover_rectangle(num_squares):
         break


### PR DESCRIPTION
Two bug fixes:

1. The main for loop was intended to terminate upon finding a covering, however this didn't happen as the return value check is incorrect: `return status == cp_model.FEASIBLE`. The check needs to be against `cp_model.OPTIMAL`. But no need to check both values as this will always terminate as optimal.

2. In the notebook version the cp_model object tried to access the now-removed `model.AddProdEquality` function, causing an exception

I also suggest changing the size of the rectangle to 60x50 as shown in this PR, to make the problem much more tractable as appropriate for an example. Using a 72x37 rectangle took almost 2 hours on my machine to find a solution, with size=10. Most of the time was spent searching the infeasible size=9.

I'm happy to make any changes if required.