### PR TITLE
closed model in vrp_initial_routes and minor comment fix 

### DIFF
--- a/ortools/constraint_solver/samples/vrp_initial_routes.cc
+++ b/ortools/constraint_solver/samples/vrp_initial_routes.cc
@@ -147,7 +147,17 @@ void VrpInitialRoutes() {
   routing.GetMutableDimension("Distance")->SetGlobalSpanCostCoefficient(100);
   // [END distance_constraint]
 
-  // Get initial solution from routes.
+  // [START parameters]
+  RoutingSearchParameters searchParameters = DefaultRoutingSearchParameters();
+  searchParameters.set_first_solution_strategy(FirstSolutionStrategy_Value_PATH_CHEAPEST_ARC);
+  searchParameters.set_local_search_metaheuristic(LocalSearchMetaheuristic::GUIDED_LOCAL_SEARCH);
+  searchParameters.mutable_time_limit()->set_seconds(5);
+  // When an initial solution is given for search, the model should be closed, 
+  // otherwise the solver will ignore the search parameters.
+  routing.CloseModelWithParameters(searchParameters);
+  // [END parameters]
+
+  // Get initial solution from routes after closing the model.
   // [START print_initial_solution]
   const Assignment* initial_solution =
       routing.ReadAssignmentFromRoutes(data.initial_routes, true);
@@ -155,16 +165,12 @@ void VrpInitialRoutes() {
   LOG(INFO) << "Initial solution: ";
   PrintSolution(data, manager, routing, *initial_solution);
   // [END print_initial_solution]
-  // Setting first solution heuristic.
-  // [START parameters]
-  RoutingSearchParameters searchParameters = DefaultRoutingSearchParameters();
-  // [END parameters]
 
   // Solve from initial solution.
   // [START solve]
   const Assignment* solution = routing.SolveFromAssignmentWithParameters(
       initial_solution, searchParameters);
-  // [START solve]
+  // [END solve]
 
   // Print solution on console.
   // [START print_solution]

--- a/ortools/constraint_solver/samples/vrp_initial_routes.py
+++ b/ortools/constraint_solver/samples/vrp_initial_routes.py
@@ -16,6 +16,7 @@
 """Vehicles Routing Problem (VRP)."""
 
 # [START import]
+from ortools.constraint_solver import routing_enums_pb2
 from ortools.constraint_solver import pywrapcp
 # [END import]
 
@@ -181,17 +182,26 @@ def main():
     distance_dimension.SetGlobalSpanCostCoefficient(100)
     # [END distance_constraint]
 
+    # Set default search parameters.
+    # [START parameters]
+    search_parameters = pywrapcp.DefaultRoutingSearchParameters()
+    search_parameters.first_solution_strategy = (
+        routing_enums_pb2.FirstSolutionStrategy.PATH_CHEAPEST_ARC)
+    search_parameters.local_search_metaheuristic = (
+        routing_enums_pb2.LocalSearchMetaheuristic.GUIDED_LOCAL_SEARCH)
+    search_parameters.time_limit.FromSeconds(5)
+    # When an initial solution is given for search, the model should be closed, 
+    # otherwise the solver will ignore the search parameters.
+    routing.CloseModelWithParameters(search_parameters)
+    # [END parameters]
+
+    # Get initial solution from routes after closing the model.
     # [START print_initial_solution]
     initial_solution = routing.ReadAssignmentFromRoutes(data['initial_routes'],
                                                         True)
     print('Initial solution:')
     print_solution(data, manager, routing, initial_solution)
     # [END print_initial_solution]
-
-    # Set default search parameters.
-    # [START parameters]
-    search_parameters = pywrapcp.DefaultRoutingSearchParameters()
-    # [END parameters]
 
     # Solve the problem.
     # [START solve]

--- a/ortools/sat/cp_model_presolve.cc
+++ b/ortools/sat/cp_model_presolve.cc
@@ -2881,7 +2881,7 @@ void CpModelPresolver::DetectAndProcessAtMostOneInLinear(
   }
 
   // Extract enforcement or fix literal.
-  // TODO(user): Do not use domain fonction, can be slow.
+  // TODO(user): Do not use domain function, can be slow.
   std::vector<int> new_enforcement;
   std::vector<int> must_be_true;
   for (int i = 0; i < tmp_terms_.size(); ++i) {

--- a/ortools/sat/util.cc
+++ b/ortools/sat/util.cc
@@ -97,7 +97,7 @@ void QuotientAndRemainder(int64_t a, int64_t b, int64_t& q, int64_t& r) {
 
 }  // namespace
 
-// Using the extended Euclidian algo, we find a and b such that a x + b m = gcd.
+// Using the extended Euclidian algo, we find a and b such that a x + b m = gcd(x, m).
 // https://en.wikipedia.org/wiki/Extended_Euclidean_algorithm
 int64_t ModularInverse(int64_t x, int64_t m) {
   DCHECK_GE(x, 0);


### PR DESCRIPTION
Hello,

- When using an initial solution in routing, the model has to be closed, or else the solver will ignore the search parameters. This is a known issue (for lack of a better word) actually. 
- The model was not closed in the `vrp_initial_routes` file, so made the necessary changes. 

Thanks Very Much.