### PR TITLE
Downgrade to C# 8 compatible code

### DIFF
--- a/ortools/sat/csharp/CpModel.cs
+++ b/ortools/sat/csharp/CpModel.cs
@@ -142,8 +142,8 @@ public class CpModel
     {
         long constant = FillLinearConstraint(expr, out var linear);
         linear.Domain.Capacity = 2;
-        linear.Domain.Add(lb is Int64.MinValue or Int64.MaxValue ? lb : lb - constant);
-        linear.Domain.Add(ub is Int64.MinValue or Int64.MaxValue ? ub : ub - constant);
+        linear.Domain.Add(lb == Int64.MinValue || lb == Int64.MaxValue ? lb : lb - constant);
+        linear.Domain.Add(ub == Int64.MinValue || lb == Int64.MaxValue ? ub : ub - constant);
 
         Constraint ct = new Constraint(model_);
         ct.Proto.Linear = linear;
@@ -162,7 +162,7 @@ public class CpModel
         linear.Domain.Capacity = array.Length;
         foreach (long value in array)
         {
-            linear.Domain.Add(value is Int64.MinValue or Int64.MaxValue ? value : value - constant);
+            linear.Domain.Add(value == Int64.MinValue || value == Int64.MaxValue ? value : value - constant);
         }
 
         Constraint ct = new Constraint(model_);
@@ -1012,7 +1012,7 @@ public class CpModel
     /** <summary>Returns whether the model contains an objective.</summary>*/
     bool HasObjective()
     {
-        return model_.Objective is not null || model_.FloatingPointObjective is not null;
+        return model_.Objective != null || model_.FloatingPointObjective != null;
     }
 
     // Search Decision.

--- a/ortools/sat/csharp/CpSolver.cs
+++ b/ortools/sat/csharp/CpSolver.cs
@@ -33,15 +33,15 @@ public class CpSolver
     {
         // Setup search.
         CreateSolveWrapper();
-        if (string_parameters_ is not null)
+        if (string_parameters_ != null)
         {
             solve_wrapper_.SetStringParameters(string_parameters_);
         }
-        if (log_callback_ is not null)
+        if (log_callback_ != null)
         {
             solve_wrapper_.AddLogCallbackFromClass(log_callback_);
         }
-        if (cb is not null)
+        if (cb != null)
         {
             solve_wrapper_.AddSolutionCallback(cb);
         }
@@ -49,7 +49,7 @@ public class CpSolver
         response_ = solve_wrapper_.Solve(model.Model);
 
         // Cleanup search.
-        if (cb is not null)
+        if (cb != null)
         {
             solve_wrapper_.ClearSolutionCallback(cb);
         }
@@ -81,7 +81,7 @@ public class CpSolver
     [MethodImpl(MethodImplOptions.Synchronized)]
     public void StopSearch()
     {
-        if (solve_wrapper_ is not null)
+        if (solve_wrapper_ != null)
         {
             solve_wrapper_.StopSearch();
         }
@@ -205,7 +205,7 @@ public class CpSolver
                 long value = index >= 0 ? response_.Solution[index] : -response_.Solution[-index - 1];
                 constant += coefficient * value;
                 break;
-            case NotBoolVar:
+            case NotBoolVar _:
                 throw new ArgumentException("Cannot evaluate a literal in an integer expression.");
             default:
                 throw new ArgumentException("Cannot evaluate '" + expr + "' in an integer expression");

--- a/ortools/sat/csharp/SearchHelpers.cs
+++ b/ortools/sat/csharp/SearchHelpers.cs
@@ -69,7 +69,7 @@ public class CpSolverSolutionCallback : SolutionCallback
                 long value = SolutionIntegerValue(index);
                 constant += coefficient * value;
                 break;
-            case NotBoolVar:
+            case NotBoolVar _:
                 throw new ArgumentException("Cannot evaluate a literal in an integer expression.");
             default:
                 throw new ArgumentException("Cannot evaluate '" + expr + "' in an integer expression");

--- a/ortools/util/csharp/NestedArrayHelper.cs
+++ b/ortools/util/csharp/NestedArrayHelper.cs
@@ -58,7 +58,7 @@ public static class NestedArrayHelper
         var result = new int[arr.GetLength(0)];
         for (var i = 0; i < arr.GetLength(0); i++)
         {
-            if (arr[i] is not null)
+            if (arr[i] != null)
                 result[i] = arr[i].Length;
         }
         return result;


### PR DESCRIPTION
With the modifications in this PR, it should be sufficient to build *Google.OrTools.csproj* for C# 8.0 language version. This should ensure that *or-tools* reliably can be built for legacy target frameworks, such as .NET Framework 4.6.1 and later or .NET Standard 2.0. 

Prior to forwarding this PR, I have successfully build the project for .NET Framework 4.6.1, .NET Core 3.1 and .NET 6 with C# language version set to 8.0.

The code changes are also compatible with .NET Standard 2.0, although another issue on that target framework requires separate handling. The fixes to fully support .NET Standard 2.0 will be issued in a separate pull request.

This PR corresponds to the discussion in issue #3503.

Before providing this PR, I have signed a personal CLA.