### PR TITLE
Replace TryDequeue with Count == 0 check

### DIFF
--- a/ortools/sat/csharp/CpSolver.cs
+++ b/ortools/sat/csharp/CpSolver.cs
@@ -211,10 +211,11 @@ public class CpSolver
                 throw new ArgumentException("Cannot evaluate '" + expr + "' in an integer expression");
             }
 
-            if (!terms_.TryDequeue(out var term))
+            if (terms_.Count == 0)
             {
                 break;
             }
+            var term = terms_.Dequeue();
             expr = term.expr;
             coefficient = term.coefficient;
         } while (true);

--- a/ortools/sat/csharp/IntegerExpressions.cs
+++ b/ortools/sat/csharp/IntegerExpressions.cs
@@ -399,10 +399,11 @@ public class LinearExpr
                 throw new ArgumentException("Cannot evaluate '" + expr + "' in an integer expression");
             }
 
-            if (!terms.TryDequeue(out var term))
+            if (terms.Count == 0)
             {
                 break;
             }
+            var term = terms.Dequeue();
             expr = term.expr;
             coefficient = term.coefficient;
         } while (true);

--- a/ortools/sat/csharp/SearchHelpers.cs
+++ b/ortools/sat/csharp/SearchHelpers.cs
@@ -75,10 +75,11 @@ public class CpSolverSolutionCallback : SolutionCallback
                 throw new ArgumentException("Cannot evaluate '" + expr + "' in an integer expression");
             }
 
-            if (!terms_.TryDequeue(out var term))
+            if (terms_.Count == 0)
             {
                 break;
             }
+            var term = terms_.Dequeue();
             expr = term.expr;
             coefficient = term.coefficient;
         } while (true);


### PR DESCRIPTION
This PR addresses a limitation in .NET Standard 2.0, where the method `Queue.TryDequeue` is not implemented. I have refactored the associated code to instead check if the queue is empty (`Queue.Count == 0`), which should mimic the behavior of the `TryDequeue` method.

This fix is only relevant in case it is decided to target .NET Standard 2.0, see discussion in #3503 . 