### PR TITLE
Ignore the close error when reading fails in file.cc

### DIFF
--- a/ortools/base/file.cc
+++ b/ortools/base/file.cc
@@ -186,7 +186,7 @@ absl::Status GetContents(const absl::string_view& filename, std::string* output,
   }
 #endif  // _MSC_VER
 
-  file->Close(flags);  // Even if ReadToString() fails!
+  file->Close(flags).IgnoreError();  // Even if ReadToString() fails!
   return absl::Status(absl::StatusCode::kInvalidArgument,
                       absl::StrCat("Could not read from '", filename, "'."));
 }


### PR DESCRIPTION
<!--
Thank you for submitting a PR!

Please make sure you are targeting the main branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->

Ignoring `file->Close` errors explicitly to appease the compiler.
