### PR TITLE
Fix reference to solve_wrapper in Solve method

### DIFF
--- a/ortools/sat/python/cp_model.py
+++ b/ortools/sat/python/cp_model.py
@@ -2197,22 +2197,22 @@ class CpSolver(object):
     def Solve(self, model, solution_callback=None):
         """Solves a problem and passes each solution to the callback if not null."""
         with self.__lock:
-            solve_wrapper = swig_helper.SolveWrapper()
+            self.__solve_wrapper = swig_helper.SolveWrapper()
 
         swig_helper.SolveWrapper.SetSerializedParameters(
-            self.parameters.SerializeToString(), solve_wrapper)
+            self.parameters.SerializeToString(), self.__solve_wrapper)
         if solution_callback is not None:
-            solve_wrapper.AddSolutionCallback(solution_callback)
+            self.__solve_wrapper.AddSolutionCallback(solution_callback)
 
         if self.log_callback is not None:
-            solve_wrapper.AddLogCallback(self.log_callback)
+            self.__solve_wrapper.AddLogCallback(self.log_callback)
 
         self.__solution = cp_model_pb2.CpSolverResponse.FromString(
             swig_helper.SolveWrapper.SerializedSolve(
-                model.Proto().SerializeToString(), solve_wrapper))
+                model.Proto().SerializeToString(), self.__solve_wrapper))
 
         if solution_callback is not None:
-            solve_wrapper.ClearSolutionCallback(solution_callback)
+            self.__solve_wrapper.ClearSolutionCallback(solution_callback)
 
         with self.__lock:
             self.__solve_wrapper = None


### PR DESCRIPTION
<!--
Thank you for submitting a PR!

Please make sure you are targeting the main branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->

Calling `solver.StopSearch()` (as opposed to from within the solution callback) does not work:

    solver=CPSolver()
    def stopper():
        solver.StopSearch()
    threading.Timer(30,stopper) #in real life would be some external event
    solver.Solve()

because self.__solve_wrapper is never set in Solve method

