### PR TITLE
ensure absolute native library path in Java Loader

### DIFF
--- a/ortools/java/com/google/ortools/Loader.java
+++ b/ortools/java/com/google/ortools/Loader.java
@@ -120,6 +120,7 @@ public class Loader {
         // Load the native library
         System.load(tempPath.resolve(RESOURCE_PATH)
                         .resolve(System.mapLibraryName("jniortools"))
+                        .toAbsolutePath()
                         .toString());
         loaded = true;
       } catch (IOException e) {


### PR DESCRIPTION
<!--
Thank you for submitting a PR!

Please make sure you are targeting the main branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->

Ensures that the native library path is absolute before loading to avoid `java.lang.UnsatisfiedLinkError: Expecting an absolute path of the library`.

---------

In my particular case the issue arises when running as part of an application that has `java.io.tmpdir` set to a relative path which results in the constructed tempDir path being relative. We could alternatively force the tempDir path to be absolute immediately on creation, but forcing the path to be absolute immediately before the call that cares seems more future proof. I'm currently using a custom loader to avoid this issue but I figured I'd contribute in case anyone else hits this edge case.
