### PR TITLE
Evaluate LinearExp for the found solution

### DIFF
--- a/ortools/linear_solver/csharp/LinearExpr.cs
+++ b/ortools/linear_solver/csharp/LinearExpr.cs
@@ -23,6 +23,11 @@ public class LinearExpr
         return 0;
     }
 
+    public virtual double SolutionValue()
+    {
+        return 0;
+    }
+
     public double Visit(Dictionary<Variable, double> coefficients)
     {
         return DoVisit(coefficients, 1.0);
@@ -185,6 +190,11 @@ class ProductCst : LinearExpr
         }
     }
 
+    public override double SolutionValue()
+    {
+        return expr_.SolutionValue() * coeff_;
+    }
+    
     private LinearExpr expr_;
     private double coeff_;
 }
@@ -212,6 +222,11 @@ class SumCst : LinearExpr
         {
             return 0.0;
         }
+    }
+    
+    public override double SolutionValue()
+    {
+        return expr_.SolutionValue() + coeff_;
     }
 
     private LinearExpr expr_;
@@ -246,6 +261,11 @@ class VarWrapper : LinearExpr
         return 0.0;
     }
 
+    public override double SolutionValue()
+    {
+        return var_.SolutionValue();
+    }
+
     private Variable var_;
 }
 
@@ -272,6 +292,11 @@ class Sum : LinearExpr
         {
             return 0.0;
         }
+    }
+
+    public override double SolutionValue()
+    {
+        return left_.SolutionValue() + right_.SolutionValue();
     }
 
     private LinearExpr left_;
@@ -302,6 +327,15 @@ public class SumArray : LinearExpr
         }
     }
 
+    public override double SolutionValue()
+    {
+        double sum = 0.0;
+        foreach (LinearExpr expr in array_)
+        {
+            sum += expr.SolutionValue();
+        }
+    }
+
     private LinearExpr[] array_;
 }
 
@@ -329,6 +363,15 @@ public class SumVarArray : LinearExpr
             }
         }
         return 0.0;
+    }
+
+    public override double SolutionValue()
+    {
+        double sum = 0.0;
+        foreach (Variable var in array_)
+        {
+            sum += var.SolutionValue();
+        }
     }
 
     private Variable[] array_;

--- a/ortools/linear_solver/csharp/LinearExpr.cs
+++ b/ortools/linear_solver/csharp/LinearExpr.cs
@@ -334,6 +334,7 @@ public class SumArray : LinearExpr
         {
             sum += expr.SolutionValue();
         }
+        return sum;
     }
 
     private LinearExpr[] array_;
@@ -372,6 +373,7 @@ public class SumVarArray : LinearExpr
         {
             sum += var.SolutionValue();
         }
+        return sum;
     }
 
     private Variable[] array_;

--- a/ortools/linear_solver/csharp/LinearSolverTests.cs
+++ b/ortools/linear_solver/csharp/LinearSolverTests.cs
@@ -442,5 +442,28 @@ public class LinearSolverTest
 
         solver.SetHint(new Variable[] { x, y }, new double[] { 2.0, 3.0 });
     }
+
+    [Fact]
+    static void Given_a_LinearExpr_and_a_solution_When_SolutionValue_is_called_then_the_result_is_correct()
+    {
+        Console.WriteLine(nameof(Given_a_LinearExpr_and_a_solution_When_SolutionValue_is_called_then_the_result_is_correct));
+        Solver solver = Solver.CreateSolver("glop");
+        // x, y and z are fixed; we don't want to test the solver here.
+        Variable x = solver.MakeIntVar(3, 3, "x");
+        Variable y = solver.MakeIntVar(4, 4, "y");
+        Variable z = solver.MakeIntVar(5, 5, "z");
+
+        LinearExpr part1 = x * 2;         // 6
+        LinearExpr part2 = y * 3 + z + 4; // 21
+        LinearExpr objective = part1 + part2;   // 27
+        LinearExpr anew = new();
+        solver.Maximize(objective);
+        solver.Solve();
+        Assert.Equal(27, objective.SolutionValue(), precision: 9);
+        Assert.Equal(6, part1.SolutionValue(), precision: 9);
+        Assert.Equal(21, part2.SolutionValue(), precision: 9);
+        Assert.Equal(0, anew.SolutionValue(), precision: 9);
+        Assert.Equal(27, (objective + anew).SolutionValue(), precision: 9);
+    }
 }
 } // namespace Google.OrTools.Tests


### PR DESCRIPTION
This PR adds a `SolutionValue()` method to the `LinearExp` class, similar to the `SolutionValue()` method of `Variable`.
This allows easy reconstruction of all partial constraints when a solution is found.