### PR TITLE
Fix build with re2 20230601

### DIFF
--- a/ortools/lp_data/lp_parser.cc
+++ b/ortools/lp_data/lp_parser.cc
@@ -184,8 +184,9 @@ bool LPParser::ParseIntegerVariablesList(StringPiece line) {
 }
 
 bool LPParser::ParseConstraint(StringPiece constraint) {
+  std::string constraint_as_string{constraint};
   const StatusOr<ParsedConstraint> parsed_constraint_or_status =
-      ::operations_research::glop::ParseConstraint(constraint.as_string());
+      ::operations_research::glop::ParseConstraint(constraint_as_string);
   if (!parsed_constraint_or_status.ok()) return false;
   const ParsedConstraint& parsed_constraint =
       parsed_constraint_or_status.value();
@@ -413,8 +414,9 @@ StatusOr<ParsedConstraint> ParseConstraint(absl::string_view constraint_view) {
     right_bound = consumed_coeff;
     if (ConsumeToken(&constraint, &consumed_name, &consumed_coeff) !=
         TokenType::END) {
+      std::string constraint_as_string{constraint};
       return absl::InvalidArgumentError(absl::StrCat(
-          "End of input was expected, found: ", constraint.as_string()));
+          "End of input was expected, found: ", constraint_as_string));
     }
   }
 


### PR DESCRIPTION
re2's `StringPiece` is now just an alias for `absl::string_view` after google/re2@49d776b9d29d79b6e2876d5f091d2207d8123dfa, so the `constraint` variable no longer has an `as_string` function.

The original `as_string` function simply returned the `StringPiece` as a `std::string`[^1], so we can just handle the creation of a new `std::string` here.

[^1]: https://github.com/google/re2/blob/f6834581a8913c03d087de1e5d5b479f8a870400/re2/stringpiece.h#L116-L118

<!--
Thank you for submitting a PR!

Please make sure you are targeting the main branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->
