### PR TITLE
Fix CMake build in `test` subdirectories

### DIFF
--- a/ortools/pdlp/CMakeLists.txt
+++ b/ortools/pdlp/CMakeLists.txt
@@ -16,9 +16,9 @@ if(NOT USE_PDLP)
 endif()
 
 file(GLOB _SRCS "*.h" "*.cc")
-list(FILTER _SRCS EXCLUDE REGEX ".*/.*_test.cc")
-list(FILTER _SRCS EXCLUDE REGEX ".*/gtest.*")
-list(FILTER _SRCS EXCLUDE REGEX ".*/test.*")
+list(FILTER _SRCS EXCLUDE REGEX "/[^/]*_test\\.cc$")
+list(FILTER _SRCS EXCLUDE REGEX "/gtest[^/]*$")
+list(FILTER _SRCS EXCLUDE REGEX "/test[^/]*$")
 
 set(NAME ${PROJECT_NAME}_pdlp)
 


### PR DESCRIPTION
Due to the regexes, ortools_pdlp fails to build if any of its parent directories starts with `test` or `gtest`:

    CMake Error at test/ortools-src/ortools/pdlp/CMakeLists.txt:27 (add_library):
      No SOURCES given to target: ortools_pdlp

<!--
Thank you for submitting a PR!

Please make sure you are targeting the main branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->
