### PR TITLE
[CP-SAT] Fix build with abseil 20230802

### DIFF
--- a/ortools/sat/cuts.cc
+++ b/ortools/sat/cuts.cc
@@ -46,6 +46,9 @@
 #include "ortools/util/sorted_interval_list.h"
 #include "ortools/util/strong_integers.h"
 
+// abseil 20230802 already provides support for int128 to string type conversion.
+// https://github.com/abseil/abseil-cpp/commit/34eb767645347f100bdd66fc1e35eee96e357961
+#if defined(ABSL_LTS_RELEASE_VERSION) && ABSL_LTS_RELEASE_VERSION < 20230802
 // TODO(user): move to or-tools/base/logging.h
 namespace absl {
 template <typename Sink>
@@ -55,6 +58,7 @@ void AbslStringify(Sink& sink, absl::int128 v) {
   sink.Append(oss.str());
 }
 }  // namespace absl
+#endif  // defined(ABSL_LTS_RELEASE_VERSION) && ABSL_LTS_RELEASE_VERSION < 20230802
 
 namespace operations_research {
 namespace sat {


### PR DESCRIPTION
<!--
Thank you for submitting a PR!

Please make sure you are targeting the main branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->

The latest release of abseil (20230802) provides support for `absl::int128` to string type conversion (https://github.com/abseil/abseil-cpp/commit/34eb767645347f100bdd66fc1e35eee96e357961); now adding a custom `AbslStringify` for `absl::int128` can cause the following build problem (taken from [CI logs](https://github.com/Homebrew/homebrew-core/actions/runs/6016098028/job/16319547857?pr=139025#step:4:1242) in https://github.com/Homebrew/homebrew-core/pull/139025):

<details><summary>Error output</summary>
<pre><code>  [ 79%] Building CXX object ortools/sat/CMakeFiles/ortools_sat.dir/cuts.cc.o
  cd /tmp/or-tools-20230829-202426-ykzj92/or-tools-9.7/build/ortools/sat && /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/shims/linux/super/g++-11 -DOR_TOOLS_AS_DYNAMIC_LIB -DPROTOBUF_USE_DLLS -DUSE_BOP -DUSE_CBC -DUSE_CLP -DUSE_GLOP -DUSE_LP_PARSER -DUSE_PDLP -I/tmp/or-tools-20230829-202426-ykzj92/or-tools-9.7 -I/tmp/or-tools-20230829-202426-ykzj92/or-tools-9.7/build -isystem /home/linuxbrew/.linuxbrew/Cellar/coinutils/2.11.9/include/coinutils/coin -isystem /home/linuxbrew/.linuxbrew/Cellar/osi/0.108.8/include/osi/coin -isystem /home/linuxbrew/.linuxbrew/Cellar/clp/1.17.8/include/clp/coin -isystem /home/linuxbrew/.linuxbrew/Cellar/cgl/0.60.7/include/cgl/coin -isystem /home/linuxbrew/.linuxbrew/Cellar/cbc/2.10.10/include/cbc/coin -O3 -DNDEBUG -std=c++17 -fPIC -fwrapv -MD -MT ortools/sat/CMakeFiles/ortools_sat.dir/cuts.cc.o -MF CMakeFiles/ortools_sat.dir/cuts.cc.o.d -o CMakeFiles/ortools_sat.dir/cuts.cc.o -c /tmp/or-tools-20230829-202426-ykzj92/or-tools-9.7/ortools/sat/cuts.cc
  /tmp/or-tools-20230829-202426-ykzj92/or-tools-9.7/ortools/sat/cuts.cc: In member function ‘std::string operations_research::sat::CutData::DebugString() const’:
  /tmp/or-tools-20230829-202426-ykzj92/or-tools-9.7/ortools/sat/cuts.cc:79:36: error: no matching function for call to ‘StrCat(const char [13], const absl::lts_20230802::int128&, const char [2])’
     79 |   std::string result = absl::StrCat("CutData rhs=", rhs, "\n");
        |                        ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
  In file included from /home/linuxbrew/.linuxbrew/include/absl/container/internal/layout.h:176,
                   from /home/linuxbrew/.linuxbrew/include/absl/container/internal/btree.h:67,
                   from /home/linuxbrew/.linuxbrew/include/absl/container/btree_map.h:56,
                   from /tmp/or-tools-20230829-202426-ykzj92/or-tools-9.7/ortools/sat/cuts.h:27,
                   from /tmp/or-tools-20230829-202426-ykzj92/or-tools-9.7/ortools/sat/cuts.cc:14:
  /home/linuxbrew/.linuxbrew/include/absl/strings/str_cat.h:463:41: note: candidate: ‘template<class ... AV> std::string absl::lts_20230802::StrCat(const absl::lts_20230802::AlphaNum&, const absl::lts_20230802::AlphaNum&, const absl::lts_20230802::AlphaNum&, const absl::lts_20230802::AlphaNum&, const absl::lts_20230802::AlphaNum&, const AV& ...)’
    463 | ABSL_MUST_USE_RESULT inline std::string StrCat(
        |                                         ^~~~~~
  /home/linuxbrew/.linuxbrew/include/absl/strings/str_cat.h:463:41: note:   template argument deduction/substitution failed:
  /tmp/or-tools-20230829-202426-ykzj92/or-tools-9.7/ortools/sat/cuts.cc:79:36: note:   candidate expects at least 5 arguments, 3 provided
     79 |   std::string result = absl::StrCat("CutData rhs=", rhs, "\n");
        |                        ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
  In file included from /home/linuxbrew/.linuxbrew/include/absl/container/internal/layout.h:176,
                   from /home/linuxbrew/.linuxbrew/include/absl/container/internal/btree.h:67,
                   from /home/linuxbrew/.linuxbrew/include/absl/container/btree_map.h:56,
                   from /tmp/or-tools-20230829-202426-ykzj92/or-tools-9.7/ortools/sat/cuts.h:27,
                   from /tmp/or-tools-20230829-202426-ykzj92/or-tools-9.7/ortools/sat/cuts.cc:14:
  /home/linuxbrew/.linuxbrew/include/absl/strings/str_cat.h:449:41: note: candidate: ‘std::string absl::lts_20230802::StrCat()’
    449 | ABSL_MUST_USE_RESULT inline std::string StrCat() { return std::string(); }
        |                                         ^~~~~~
  /home/linuxbrew/.linuxbrew/include/absl/strings/str_cat.h:449:41: note:   candidate expects 0 arguments, 3 provided
  /home/linuxbrew/.linuxbrew/include/absl/strings/str_cat.h:451:41: note: candidate: ‘std::string absl::lts_20230802::StrCat(const absl::lts_20230802::AlphaNum&)’
    451 | ABSL_MUST_USE_RESULT inline std::string StrCat(const AlphaNum& a) {
        |                                         ^~~~~~
  /home/linuxbrew/.linuxbrew/include/absl/strings/str_cat.h:451:41: note:   candidate expects 1 argument, 3 provided
  /home/linuxbrew/.linuxbrew/include/absl/strings/str_cat.h:455:34: note: candidate: ‘std::string absl::lts_20230802::StrCat(const absl::lts_20230802::AlphaNum&, const absl::lts_20230802::AlphaNum&)’
    455 | ABSL_MUST_USE_RESULT std::string StrCat(const AlphaNum& a, const AlphaNum& b);
        |                                  ^~~~~~
  /home/linuxbrew/.linuxbrew/include/absl/strings/str_cat.h:455:34: note:   candidate expects 2 arguments, 3 provided
  /home/linuxbrew/.linuxbrew/include/absl/strings/str_cat.h:456:34: note: candidate: ‘std::string absl::lts_20230802::StrCat(const absl::lts_20230802::AlphaNum&, const absl::lts_20230802::AlphaNum&, const absl::lts_20230802::AlphaNum&)’
    456 | ABSL_MUST_USE_RESULT std::string StrCat(const AlphaNum& a, const AlphaNum& b,
        |                                  ^~~~~~
  /home/linuxbrew/.linuxbrew/include/absl/strings/str_cat.h:456:76: note:   no known conversion for argument 2 from ‘const absl::lts_20230802::int128’ to ‘const absl::lts_20230802::AlphaNum&’
    456 | ABSL_MUST_USE_RESULT std::string StrCat(const AlphaNum& a, const AlphaNum& b,
        |                                                            ~~~~~~~~~~~~~~~~^
  /home/linuxbrew/.linuxbrew/include/absl/strings/str_cat.h:458:34: note: candidate: ‘std::string absl::lts_20230802::StrCat(const absl::lts_20230802::AlphaNum&, const absl::lts_20230802::AlphaNum&, const absl::lts_20230802::AlphaNum&, const absl::lts_20230802::AlphaNum&)’
    458 | ABSL_MUST_USE_RESULT std::string StrCat(const AlphaNum& a, const AlphaNum& b,
        |                                  ^~~~~~
  /home/linuxbrew/.linuxbrew/include/absl/strings/str_cat.h:458:34: note:   candidate expects 4 arguments, 3 provided
  /home/linuxbrew/.linuxbrew/include/absl/strings/str_cat.h: In instantiation of ‘std::string absl::lts_20230802::StrCat(const absl::lts_20230802::AlphaNum&, const absl::lts_20230802::AlphaNum&, const absl::lts_20230802::AlphaNum&, const absl::lts_20230802::AlphaNum&, const absl::lts_20230802::AlphaNum&, const AV& ...) [with AV = {absl::lts_20230802::int128, char [8], int, char [6], int, char [6], int}; std::string = std::__cxx11::basic_string<char>]’:
  /tmp/or-tools-20230829-202426-ykzj92/or-tools-9.7/ortools/sat/cuts.cc:2006:22:   required from here
  /home/linuxbrew/.linuxbrew/include/absl/strings/str_cat.h:468:8: error: invalid ‘static_cast’ from type ‘const absl::lts_20230802::int128’ to type ‘const absl::lts_20230802::AlphaNum&’
    468 |        static_cast<const AlphaNum&>(args).Piece()...});
        |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  /home/linuxbrew/.linuxbrew/include/absl/strings/str_cat.h:466:37: error: could not convert ‘{(& a)->absl::lts_20230802::AlphaNum::Piece(), (& b)->absl::lts_20230802::AlphaNum::Piece(), (& c)->absl::lts_20230802::AlphaNum::Piece(), (& d)->absl::lts_20230802::AlphaNum::Piece(), (& e)->absl::lts_20230802::AlphaNum::Piece(), <expression error>}’ from ‘<brace-enclosed initializer list>’ to ‘std::initializer_list<std::basic_string_view<char> >’
    466 |   return strings_internal::CatPieces(
        |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        |                                     |
        |                                     <brace-enclosed initializer list>
    467 |       {a.Piece(), b.Piece(), c.Piece(), d.Piece(), e.Piece(),
        |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    468 |        static_cast<const AlphaNum&>(args).Piece()...});
        |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  make[2]: *** [ortools/sat/CMakeFiles/ortools_sat.dir/build.make:359: ortools/sat/CMakeFiles/ortools_sat.dir/cuts.cc.o] Error 1
</code></pre>
</details> 

Fix that by guarding the `AbslStringify` definition to pre-abseil 20230802 only.
