### PR TITLE
Demonstrate file::GetContents / SetContents memory leak

### DIFF
--- a/ortools/base/BUILD.bazel
+++ b/ortools/base/BUILD.bazel
@@ -217,6 +217,16 @@ cc_library(
     ],
 )
 
+cc_binary(
+    name = "hello_file",
+    srcs = ["hello_file.cc"],
+    deps = [
+        ":file",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+    ],
+)
+
 cc_library(
     name = "filesystem",
     srcs = ["filesystem.cc"],

--- a/ortools/base/file.cc
+++ b/ortools/base/file.cc
@@ -170,6 +170,9 @@ absl::Status GetContents(const absl::string_view& filename, std::string* output,
   const int64_t size = file->Size();
   if (file->ReadToString(output, size) == size) {
     status.Update(file->Close(flags));
+#ifdef FIX_MEMORY_LEAK
+    delete file;
+#endif
     return status;
   }
 #if defined(_MSC_VER)
@@ -187,6 +190,9 @@ absl::Status GetContents(const absl::string_view& filename, std::string* output,
 #endif  // _MSC_VER
 
   file->Close(flags).IgnoreError();  // Even if ReadToString() fails!
+#ifdef FIX_MEMORY_LEAK
+  delete file;
+#endif
   return absl::Status(absl::StatusCode::kInvalidArgument,
                       absl::StrCat("Could not read from '", filename, "'."));
 }
@@ -209,6 +215,9 @@ absl::Status SetContents(const absl::string_view& filename,
   if (!status.ok()) return status;
   status = file::WriteString(file, contents, flags);
   status.Update(file->Close(flags));  // Even if WriteString() fails!
+#ifdef FIX_MEMORY_LEAK
+  delete file;
+#endif
   return status;
 }
 

--- a/ortools/base/file.h
+++ b/ortools/base/file.h
@@ -34,6 +34,8 @@ class File {
  public:
   // Opens file "name" with flags specified by "flag".
   // Flags are defined by fopen(), that is "r", "r+", "w", "w+". "a", and "a+".
+  // The caller should free the File after closing it by passing the returned
+  // pointer to delete.
   static File* Open(const char* const name, const char* const flag);
 
 #ifndef SWIG  // no overloading
@@ -123,6 +125,8 @@ using Options = int;
 inline Options Defaults() { return 0xBABA; }
 
 // As of 2016-01, these methods can only be used with flags = file::Defaults().
+
+// The caller should free the file after closing by passing *f to delete.
 absl::Status Open(const absl::string_view& filename,
                   const absl::string_view& mode, File** f, int flags);
 File* OpenOrDie(const absl::string_view& filename,

--- a/ortools/base/hello_file.cc
+++ b/ortools/base/hello_file.cc
@@ -1,0 +1,24 @@
+#include <string_view>
+
+#include "ortools/base/file.h"
+
+constexpr std::string_view kHelloFile = "/tmp/hello_file.txt";
+
+int main(int argc, char** argv) {
+  absl::Status s;
+  s = file::SetContents(kHelloFile, "hello file", file::Defaults());
+  if (!s.ok()) {
+    LOG(ERROR) << "SetContents failed: " << s;
+    return 1;
+  }
+
+  std::string out;
+  s = file::GetContents(kHelloFile, &out, file::Defaults());
+  if (!s.ok()) {
+    LOG(ERROR) << "GetContents failed: " << s;
+    return 1;
+  }
+
+  LOG(INFO) << "got back contents: " << out;
+  return 0;
+}


### PR DESCRIPTION
To reproduce the memory leak cherry-pick this PR, ensure you have `valgrind` installed and then:

```
bazel build //ortools/base:hello_file
valgrind --leak-check=full ./bazel-bin/ortools/base/hello_file &> leak.out
bazel build --cxxopt=-DFIX_MEMORY_LEAK //ortools/base:hello_file
valgrind --leak-check=full ./bazel-bin/ortools/base/hello_file &> no-leak.out
```

Here's the output I see: [leak.out](https://gist.github.com/pjh/5026217ec5faa84c45bd277d57af7bea), [no-leak.out](https://gist.github.com/pjh/42267ea20493b1e8afe0f1342458cfe5)

valgrind reports "definitely lost: 48 bytes in 2 blocks" for or-tools at head, but "definitely lost: 0 bytes in 0 blocks" when the File is deleted after closing it.