### PR TITLE
Fix memory leaks in file::GetContents and file::SetContents

### DIFF
--- a/ortools/base/file.cc
+++ b/ortools/base/file.cc
@@ -170,11 +170,13 @@ absl::Status GetContents(const absl::string_view& filename, std::string* output,
   const int64_t size = file->Size();
   if (file->ReadToString(output, size) == size) {
     status.Update(file->Close(flags));
+    delete file;
     return status;
   }
 #if defined(_MSC_VER)
   // On windows, binary files needs to be opened with the "rb" flags.
   file->Close();
+  delete file;
   // Retry in binary mode.
   status = file::Open(filename, "rb", &file, flags);
   if (!status.ok()) return status;
@@ -182,11 +184,13 @@ absl::Status GetContents(const absl::string_view& filename, std::string* output,
   const int64_t b_size = file->Size();
   if (file->ReadToString(output, b_size) == b_size) {
     status.Update(file->Close(flags));
+    delete file;
     return status;
   }
 #endif  // _MSC_VER
 
   file->Close(flags).IgnoreError();  // Even if ReadToString() fails!
+  delete file;
   return absl::Status(absl::StatusCode::kInvalidArgument,
                       absl::StrCat("Could not read from '", filename, "'."));
 }
@@ -209,6 +213,7 @@ absl::Status SetContents(const absl::string_view& filename,
   if (!status.ok()) return status;
   status = file::WriteString(file, contents, flags);
   status.Update(file->Close(flags));  // Even if WriteString() fails!
+  delete file;
   return status;
 }
 

--- a/ortools/base/file.h
+++ b/ortools/base/file.h
@@ -34,6 +34,8 @@ class File {
  public:
   // Opens file "name" with flags specified by "flag".
   // Flags are defined by fopen(), that is "r", "r+", "w", "w+". "a", and "a+".
+  // The caller should free the File after closing it by passing the returned
+  // pointer to delete.
   static File* Open(const char* const name, const char* const flag);
 
 #ifndef SWIG  // no overloading
@@ -45,6 +47,8 @@ class File {
 
   // Opens file "name" with flags specified by "flag".
   // If open failed, program will exit.
+  // The caller should free the File after closing it by passing the returned
+  // pointer to delete.
   static File* OpenOrDie(const char* const name, const char* const flag);
 
 #ifndef SWIG  // no overloading
@@ -123,8 +127,12 @@ using Options = int;
 inline Options Defaults() { return 0xBABA; }
 
 // As of 2016-01, these methods can only be used with flags = file::Defaults().
+
+// The caller should free the File after closing it by passing *f to delete.
 absl::Status Open(const absl::string_view& filename,
                   const absl::string_view& mode, File** f, int flags);
+// The caller should free the File after closing it by passing the returned
+// pointer to delete.
 File* OpenOrDie(const absl::string_view& filename,
                 const absl::string_view& mode, int flags);
 absl::Status GetTextProto(const absl::string_view& filename,


### PR DESCRIPTION
Calls `delete file` after closing opened files in `file::GetContents` and `file::SetContents`. Documents the need to do so for callers of `file::Open` and its variants.

Fixes https://github.com/google/or-tools/issues/4010

I've verified this fix using the minimal `hello_file` example in https://github.com/google/or-tools/pull/4009 but reviewers please let me know how else this should be tested.