### PR TITLE
improve performance of Xpress interface and fix bug

### DIFF
--- a/ortools/linear_solver/xpress_interface.cc
+++ b/ortools/linear_solver/xpress_interface.cc
@@ -840,8 +840,7 @@ XpressInterface::XpressInterface(MPSolver* const solver, bool mip)
       mLp(nullptr),
       mMip(mip),
       supportIncrementalExtraction(false),
-      slowUpdates(static_cast<SlowUpdates>(SlowSetObjectiveCoefficient |
-                                           SlowClearObjective)),
+      slowUpdates(SlowClearObjective),
       mapStringControls_(getMapStringControls()),
       mapDoubleControls_(getMapDoubleControls()),
       mapIntegerControls_(getMapIntControls()),
@@ -1728,7 +1727,7 @@ void XpressInterface::SetLpAlgorithm(int value) {
 std::vector<int> XpressBasisStatusesFrom(
     const std::vector<MPSolver::BasisStatus>& statuses) {
   std::vector<int> result;
-  result.reserve(statuses.size());
+  result.resize(statuses.size());
   std::transform(statuses.cbegin(), statuses.cend(), result.begin(),
                  MPSolverToXpressBasisStatus);
   return result;


### PR DESCRIPTION
This PR concerns the Xpress interface of MPSolver.

We discovered a silly mistake with the memory allocation when setting a starting LP basis, 

We considerably improved the performances of the Xpress interface by updating all variables' objective coefficients at once, when it is possible.