### PR TITLE
[CMAKE] Required version 3.18 -> 3.20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 # This file is just an orchestration
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.20)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 include(utils)


### PR DESCRIPTION
`cmake_path` was added in CMake 3.20, see https://cmake.org/cmake/help/latest/command/cmake_path.html

It is used in a few places to handle the install directory. Using CMake 3.18 won't work because of this command.

```
File: linear_solver/CMakeLists.txt
66:3:  cmake_path(RELATIVE_PATH CMAKE_INSTALL_FULL_LIBDIR

File: sat/CMakeLists.txt
54:3:  cmake_path(RELATIVE_PATH CMAKE_INSTALL_FULL_LIBDIR

File: packing/CMakeLists.txt
46:3:  cmake_path(RELATIVE_PATH CMAKE_INSTALL_FULL_LIBDIR
```

Example

```cmake
elseif(UNIX)
  cmake_path(RELATIVE_PATH CMAKE_INSTALL_FULL_LIBDIR
             BASE_DIRECTORY ${CMAKE_INSTALL_FULL_BINDIR}
             OUTPUT_VARIABLE libdir_relative_path)
  set_target_properties(solve PROPERTIES INSTALL_RPATH
    "$ORIGIN/${libdir_relative_path}")
endif()
```