### PR TITLE
[XPRESS] Extract variable & constraint names only before writing MPS + fix a test

### DIFF
--- a/ortools/linear_solver/xpress_interface.cc
+++ b/ortools/linear_solver/xpress_interface.cc
@@ -2056,7 +2056,6 @@ template <class T>
 // T = MPVariable | MPConstraint
 // or any class that has a public method name() const
 void ExtractNames(XPRSprob mLp, const std::vector<T*>& objects) {
-  MPObjective o;
   const bool have_names =
       std::any_of(objects.begin(), objects.end(),
                   [](const T* x) { return !x->name().empty(); });

--- a/ortools/linear_solver/xpress_interface.cc
+++ b/ortools/linear_solver/xpress_interface.cc
@@ -277,12 +277,13 @@ class MPCallbackWrapper {
     for (const std::exception_ptr& ex : caught_exceptions_) {
       try {
         std::rethrow_exception(ex);
-      } catch (std::exception &ex) {
+      } catch (std::exception& ex) {
         // We don't want the interface to throw exceptions, plus it causes
         // SWIG issues in Java & Python. Instead, we'll only log them.
         // (The use cases where the user has to raise an exception inside their
         // call-back does not seem to be frequent, anyway.)
-        LOG(ERROR) << "Caught exception during user-defined call-back: " << ex.what();
+        LOG(ERROR) << "Caught exception during user-defined call-back: "
+                   << ex.what();
       }
     }
     caught_exceptions_.clear();
@@ -1243,8 +1244,7 @@ int64_t XpressInterface::nodes() const {
 }
 
 // Transform a XPRESS basis status to an MPSolver basis status.
-MPSolver::BasisStatus XpressToMPSolverBasisStatus(
-    int xpress_basis_status) {
+MPSolver::BasisStatus XpressToMPSolverBasisStatus(int xpress_basis_status) {
   switch (xpress_basis_status) {
     case XPRS_AT_LOWER:
       return MPSolver::AT_LOWER_BOUND;
@@ -1728,13 +1728,14 @@ std::vector<int> XpressBasisStatusesFrom(
 
 void XpressInterface::SetStartingLpBasis(
     const std::vector<MPSolver::BasisStatus>& variable_statuses,
-    const std::vector<MPSolver::BasisStatus>& constraint_statuses){
+    const std::vector<MPSolver::BasisStatus>& constraint_statuses) {
   if (mMip) {
     LOG(DFATAL) << __FUNCTION__ << " is only available for LP problems";
     return;
   }
   initial_variables_basis_status_ = XpressBasisStatusesFrom(variable_statuses);
-  initial_constraint_basis_status_ = XpressBasisStatusesFrom(constraint_statuses);
+  initial_constraint_basis_status_ =
+      XpressBasisStatusesFrom(constraint_statuses);
 }
 
 bool XpressInterface::readParameters(std::istream& is, char sep) {
@@ -1847,7 +1848,8 @@ MPSolver::ResultStatus XpressInterface::Solve(MPSolverParameters const& param) {
 
   // Load basis if present
   // TODO : check number of variables / constraints
-  if (!mMip && !initial_variables_basis_status_.empty() && !initial_constraint_basis_status_.empty()) {
+  if (!mMip && !initial_variables_basis_status_.empty() &&
+      !initial_constraint_basis_status_.empty()) {
     CHECK_STATUS(XPRSloadbasis(mLp, initial_constraint_basis_status_.data(),
                                initial_variables_basis_status_.data()));
   }
@@ -1871,10 +1873,10 @@ MPSolver::ResultStatus XpressInterface::Solve(MPSolverParameters const& param) {
 
   int xpress_stat = 0;
   if (mMip) {
-    status = XPRSmipoptimize(mLp,"");
+    status = XPRSmipoptimize(mLp, "");
     XPRSgetintattrib(mLp, XPRS_MIPSTATUS, &xpress_stat);
   } else {
-    status = XPRSlpoptimize(mLp,"");
+    status = XPRSlpoptimize(mLp, "");
     XPRSgetintattrib(mLp, XPRS_LPSTATUS, &xpress_stat);
   }
 
@@ -2054,6 +2056,7 @@ template <class T>
 // T = MPVariable | MPConstraint
 // or any class that has a public method name() const
 void ExtractNames(XPRSprob mLp, const std::vector<T*>& objects) {
+  MPObjective o;
   const bool have_names =
       std::any_of(objects.begin(), objects.end(),
                   [](const T* x) { return !x->name().empty(); });
@@ -2087,8 +2090,8 @@ void XpressInterface::Write(const std::string& filename) {
   }
   ExtractModel();
 
-  ExtractNames(mLp, solver_->constraints_);
   ExtractNames(mLp, solver_->variables_);
+  ExtractNames(mLp, solver_->constraints_);
 
   VLOG(1) << "Writing Xpress MPS \"" << filename << "\".";
   const int status = XPRSwriteprob(mLp, filename.c_str(), "");

--- a/ortools/linear_solver/xpress_interface_test.cc
+++ b/ortools/linear_solver/xpress_interface_test.cc
@@ -706,11 +706,11 @@ TEST_F(XpressFixtureMIP, SolverVersion) {
 
 TEST_F(XpressFixtureMIP, Write) {
   MPVariable* x1 = solver.MakeIntVar(-1.2, 9.3, "C1");
-  MPVariable* x2 = solver.MakeNumVar(-1, 5.147593849384714, "C2");
+  MPVariable* x2 = solver.MakeNumVar(-1, 5.147593849384714, "SomeColumnName");
   MPConstraint* c1 = solver.MakeRowConstraint(-solver.infinity(), 1, "R1");
   c1->SetCoefficient(x1, 3);
   c1->SetCoefficient(x2, 1.5);
-  MPConstraint* c2 = solver.MakeRowConstraint(3, 5, "R2");
+  MPConstraint* c2 = solver.MakeRowConstraint(3, 5, "SomeRowName");
   c2->SetCoefficient(x2, -1.1122334455667788);
   MPObjective* obj = solver.MutableObjective();
   obj->SetMaximization();
@@ -730,30 +730,32 @@ TEST_F(XpressFixtureMIP, Write) {
   tmpFile.close();
   std::filesystem::remove_all(temporary_working_dir);
 
-  EXPECT_EQ(tmpBuffer.str(), R"(NAME          newProb
-OBJSENSE  MAXIMIZE
-ROWS
- N  __OBJ___
- L  R1
- L  R2
-COLUMNS
-    C1        __OBJ___  1
-    C1        R1        3
-    C2        __OBJ___  2
-    C2        R1        1.5
-    C2        R2        -1.1122334455667788
-RHS
-    RHS00001  R1        1
-    RHS00001  R2        5
-RANGES
-    RNG00001  R2        2
-BOUNDS
- UI BND00001  C1        9
- LO BND00001  C1        -1
- UP BND00001  C2        5.147593849384714
- LO BND00001  C2        -1
-ENDATA
-)");
+  std::string expectedMps = std::string("") +
+                            "NAME          newProb" + "\n" +
+                            "OBJSENSE  MAXIMIZE" + "\n" +
+                            "ROWS" + "\n" +
+                            " N  __OBJ___        " + "\n" +
+                            " L  R1              " + "\n" +
+                            " L  SomeRowName     " + "\n" +
+                            "COLUMNS" + "\n" +
+                            "    C1                __OBJ___          1" + "\n" +
+                            "    C1                R1                3" + "\n" +
+                            "    SomeColumnName    __OBJ___          2" + "\n" +
+                            "    SomeColumnName    R1                1.5" + "\n" +
+                            "    SomeColumnName    SomeRowName       -1.1122334455667788" + "\n" +
+                            "RHS" + "\n" +
+                            "    RHS00001          R1                1" + "\n" +
+                            "    RHS00001          SomeRowName       5" + "\n" +
+                            "RANGES" + "\n" +
+                            "    RNG00001          SomeRowName       2" + "\n" +
+                            "BOUNDS" + "\n" +
+                            " UI BND00001          C1                9" + "\n" +
+                            " LO BND00001          C1                -1" + "\n" +
+                            " UP BND00001          SomeColumnName    5.147593849384714" + "\n" +
+                            " LO BND00001          SomeColumnName    -1" + "\n" +
+                            "ENDATA" + "\n";
+
+  EXPECT_EQ(tmpBuffer.str(), expectedMps);
 }
 
 TEST_F(XpressFixtureLP, SetPrimalTolerance) {

--- a/ortools/linear_solver/xpress_interface_test.cc
+++ b/ortools/linear_solver/xpress_interface_test.cc
@@ -730,23 +730,33 @@ TEST_F(XpressFixtureMIP, Write) {
   tmpFile.close();
   std::filesystem::remove_all(temporary_working_dir);
 
-  std::string expectedMps =
-      std::string("") + "NAME          newProb" + "\n" + "OBJSENSE  MAXIMIZE" +
-      "\n" + "ROWS" + "\n" + " N  __OBJ___        " + "\n" +
-      " L  R1              " + "\n" + " L  SomeRowName     " + "\n" +
-      "COLUMNS" + "\n" + "    C1                __OBJ___          1" + "\n" +
-      "    C1                R1                3" + "\n" +
-      "    SomeColumnName    __OBJ___          2" + "\n" +
-      "    SomeColumnName    R1                1.5" + "\n" +
-      "    SomeColumnName    SomeRowName       -1.1122334455667788" + "\n" +
-      "RHS" + "\n" + "    RHS00001          R1                1" + "\n" +
-      "    RHS00001          SomeRowName       5" + "\n" + "RANGES" + "\n" +
-      "    RNG00001          SomeRowName       2" + "\n" + "BOUNDS" + "\n" +
-      " UI BND00001          C1                9" + "\n" +
-      " LO BND00001          C1                -1" + "\n" +
-      " UP BND00001          SomeColumnName    5.147593849384714" + "\n" +
-      " LO BND00001          SomeColumnName    -1" + "\n" + "ENDATA" + "\n";
-
+  // disable formatting to keep the expected MPS readable
+  // clang-format off
+  std::string expectedMps = std::string("") +
+                            "NAME          newProb" + "\n" +
+                            "OBJSENSE  MAXIMIZE" + "\n" +
+                            "ROWS" + "\n" +
+                            " N  __OBJ___        " + "\n" +
+                            " L  R1              " + "\n" +
+                            " L  SomeRowName     " + "\n" +
+                            "COLUMNS" + "\n" +
+                            "    C1                __OBJ___          1" + "\n" +
+                            "    C1                R1                3" + "\n" +
+                            "    SomeColumnName    __OBJ___          2" + "\n" +
+                            "    SomeColumnName    R1                1.5" + "\n" +
+                            "    SomeColumnName    SomeRowName       -1.1122334455667788" + "\n" +
+                            "RHS" + "\n" +
+                            "    RHS00001          R1                1" + "\n" +
+                            "    RHS00001          SomeRowName       5" + "\n" +
+                            "RANGES" + "\n" +
+                            "    RNG00001          SomeRowName       2" + "\n" +
+                            "BOUNDS" + "\n" +
+                            " UI BND00001          C1                9" + "\n" +
+                            " LO BND00001          C1                -1" + "\n" +
+                            " UP BND00001          SomeColumnName    5.147593849384714" + "\n" +
+                            " LO BND00001          SomeColumnName    -1" + "\n" +
+                            "ENDATA" + "\n";
+  // clang-format on
   EXPECT_EQ(tmpBuffer.str(), expectedMps);
 }
 

--- a/ortools/linear_solver/xpress_interface_test.cc
+++ b/ortools/linear_solver/xpress_interface_test.cc
@@ -730,30 +730,22 @@ TEST_F(XpressFixtureMIP, Write) {
   tmpFile.close();
   std::filesystem::remove_all(temporary_working_dir);
 
-  std::string expectedMps = std::string("") +
-                            "NAME          newProb" + "\n" +
-                            "OBJSENSE  MAXIMIZE" + "\n" +
-                            "ROWS" + "\n" +
-                            " N  __OBJ___        " + "\n" +
-                            " L  R1              " + "\n" +
-                            " L  SomeRowName     " + "\n" +
-                            "COLUMNS" + "\n" +
-                            "    C1                __OBJ___          1" + "\n" +
-                            "    C1                R1                3" + "\n" +
-                            "    SomeColumnName    __OBJ___          2" + "\n" +
-                            "    SomeColumnName    R1                1.5" + "\n" +
-                            "    SomeColumnName    SomeRowName       -1.1122334455667788" + "\n" +
-                            "RHS" + "\n" +
-                            "    RHS00001          R1                1" + "\n" +
-                            "    RHS00001          SomeRowName       5" + "\n" +
-                            "RANGES" + "\n" +
-                            "    RNG00001          SomeRowName       2" + "\n" +
-                            "BOUNDS" + "\n" +
-                            " UI BND00001          C1                9" + "\n" +
-                            " LO BND00001          C1                -1" + "\n" +
-                            " UP BND00001          SomeColumnName    5.147593849384714" + "\n" +
-                            " LO BND00001          SomeColumnName    -1" + "\n" +
-                            "ENDATA" + "\n";
+  std::string expectedMps =
+      std::string("") + "NAME          newProb" + "\n" + "OBJSENSE  MAXIMIZE" +
+      "\n" + "ROWS" + "\n" + " N  __OBJ___        " + "\n" +
+      " L  R1              " + "\n" + " L  SomeRowName     " + "\n" +
+      "COLUMNS" + "\n" + "    C1                __OBJ___          1" + "\n" +
+      "    C1                R1                3" + "\n" +
+      "    SomeColumnName    __OBJ___          2" + "\n" +
+      "    SomeColumnName    R1                1.5" + "\n" +
+      "    SomeColumnName    SomeRowName       -1.1122334455667788" + "\n" +
+      "RHS" + "\n" + "    RHS00001          R1                1" + "\n" +
+      "    RHS00001          SomeRowName       5" + "\n" + "RANGES" + "\n" +
+      "    RNG00001          SomeRowName       2" + "\n" + "BOUNDS" + "\n" +
+      " UI BND00001          C1                9" + "\n" +
+      " LO BND00001          C1                -1" + "\n" +
+      " UP BND00001          SomeColumnName    5.147593849384714" + "\n" +
+      " LO BND00001          SomeColumnName    -1" + "\n" + "ENDATA" + "\n";
 
   EXPECT_EQ(tmpBuffer.str(), expectedMps);
 }


### PR DESCRIPTION
- Fix a unit test in XPRESS interface (it was failing because of difficult-to-handle trailing spaces)
- XPRESS interface: extract variable & constraint names, only before writing MPS, in order to have an MPS with clear names while avoiding extracting the names too often (extraction in XPRESS is costly)
