### PR TITLE
Update fp_utils.h for OpenBSD compatibility

### DIFF
--- a/ortools/util/fp_utils.h
+++ b/ortools/util/fp_utils.h
@@ -89,7 +89,7 @@ class ScopedFloatingPointEnv {
     excepts &= FE_ALL_EXCEPT;
 #if defined(__APPLE__)
     fenv_.__control &= ~excepts;
-#elif defined(__FreeBSD__)
+#elif (defined(__FreeBSD__) || defined(__OpenBSD__)
     fenv_.__x87.__control &= ~excepts;
 #else  // Linux
     fenv_.__control_word &= ~excepts;


### PR DESCRIPTION
The `fenv` struct is similar in shape to that of FreeBSD. For reference, the [official CVSWeb repository](https://cvsweb.openbsd.org/src/sys/arch/amd64/include/fenv.h?rev=1.4&content-type=text/x-cvsweb-markup) shows a definition of:

```c
/*
 * fenv_t represents the entire floating-point environment.
 */
typedef	struct {
	struct {
		unsigned int __control;		/* Control word register */
		unsigned int __status;		/* Status word register */
		unsigned int __tag;		/* Tag word register */
		unsigned int __others[4];	/* EIP, Pointer Selector, etc */
	} __x87;
	unsigned int __mxcsr;			/* Control, status register */
} fenv_t;
``` 

This is in alignment with that of the FreeBSD project.

<!--
Thank you for submitting a PR!

Please make sure you are targeting the main branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->
