### PR TITLE
Updates for OpenBSD build support

### DIFF
--- a/ortools/base/sysinfo.cc
+++ b/ortools/base/sysinfo.cc
@@ -17,7 +17,7 @@
 #if defined(__APPLE__) && defined(__GNUC__)  // MacOS
 #include <mach/mach_init.h>
 #include <mach/task.h>
-#elif defined(__FreeBSD__)  // FreeBSD
+#elif (defined(__FreeBSD__) || defined(__OpenBSD__))  // FreeBSD or OpenBSD
 #include <sys/resource.h>
 #include <sys/time.h>
 // Windows
@@ -49,7 +49,8 @@ int64_t GetProcessMemoryUsage() {
   return resident_memory;
 }
 #elif defined(__GNUC__) && !defined(__FreeBSD__) && \
-    !defined(__EMSCRIPTEN__) && !defined(_WIN32)  // Linux
+    !defined(__OpenBSD__) && !defined(__EMSCRIPTEN__) && \
+    !defined(_WIN32)  // Linux
 int64_t GetProcessMemoryUsage() {
   unsigned size = 0;
   char buf[30];
@@ -61,7 +62,7 @@ int64_t GetProcessMemoryUsage() {
   fclose(pf);
   return int64_t{1024} * size;
 }
-#elif defined(__FreeBSD__)                        // FreeBSD
+#elif (defined(__FreeBSD__) || defined(__OpenBSD__)) // FreeBSD or OpenBSD
 int64_t GetProcessMemoryUsage() {
   int who = RUSAGE_SELF;
   struct rusage rusage;

--- a/ortools/python/setup.py.in
+++ b/ortools/python/setup.py.in
@@ -136,6 +136,7 @@ setup(
         'Operating System :: Unix',
         'Operating System :: POSIX :: Linux',
         'Operating System :: POSIX :: BSD :: FreeBSD',
+        'Operating System :: POSIX :: BSD :: OpenBSD',
         'Operating System :: MacOS',
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: Microsoft :: Windows',

--- a/ortools/util/zvector.h
+++ b/ortools/util/zvector.h
@@ -14,7 +14,8 @@
 #ifndef OR_TOOLS_UTIL_ZVECTOR_H_
 #define OR_TOOLS_UTIL_ZVECTOR_H_
 
-#if (defined(__APPLE__) || defined(__FreeBSD__)) && defined(__GNUC__)
+#if (defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)) && \
+	defined(__GNUC__)
 #include <machine/endian.h>
 #elif !defined(_MSC_VER) && !defined(__MINGW32__) && !defined(__MINGW64__)
 #include <endian.h>


### PR DESCRIPTION
This pull request adds several references to the system identifier `__OpenBSD__` in
checks where `__FreeBSD__` is included. I have validated that each of the FreeBSD
checks are also appropriate for OpenBSD.

It should be noted that I'm still working through a completely successful build, but these changes are necessary to make incremental progress towards that goal.

First, the `fenv` structure definition referenced in `ortools/util/fp_utils.h`

# fenv in `fp_utils`

The `fenv` struct is similar in shape to that of FreeBSD. For reference, the [official CVSWeb repository](https://cvsweb.openbsd.org/src/sys/arch/amd64/include/fenv.h?rev=1.4&content-type=text/x-cvsweb-markup) shows a definition of:

```c
/*
 * fenv_t represents the entire floating-point environment.
 */
typedef	struct {
	struct {
		unsigned int __control;		/* Control word register */
		unsigned int __status;		/* Status word register */
		unsigned int __tag;		/* Tag word register */
		unsigned int __others[4];	/* EIP, Pointer Selector, etc */
	} __x87;
	unsigned int __mxcsr;			/* Control, status register */
} fenv_t;
``` 

This is in alignment with that of the FreeBSD project.

# Changes in sysinfo.cc

The file `ortools/base/sysinfo.cc` uses a number of system calls and
expects a `/proc` filesystem in some cases. Like FreeBSD, OpenBSD also
defines `getrusage` in `sys/resource.h`, has no proc filesystem, and
needs to include `sys/time.h`.

References:

- [getrusage(2)](https://man.openbsd.org/getrusage)

# Update to python package

The `ortools/python/setup.py.in` file has been updated to include OpenBSD
as a classified for the package targets.

# Update zvector

The `ortools/util/zvector.h` header should include `machine/endian.h`,
just like FreeBSD.

References:

- [CVSWeb endian.h](https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/sys/arch/amd64/include/endian.h?rev=1.8&content-type=text/x-cvsweb-markup)

