### PR TITLE
replace CapSub with CapAdd for StartMin value

### DIFF
--- a/ortools/constraint_solver/routing_breaks.cc
+++ b/ortools/constraint_solver/routing_breaks.cc
@@ -945,7 +945,7 @@ void GlobalVehicleBreaksConstraint::PropagateVehicle(int vehicle) {
           interval->SetEndMax(arc_start_max);
           if (interval_is_performed) {
             dimension_->CumulVar(path_[pos])
-                ->SetMin(CapSub(interval_end_min, arc_start_offset));
+                ->SetMin(CapAdd(interval_end_min, arc_start_offset));
           }
         }
         continue;


### PR DESCRIPTION
<!--
Thank you for submitting a PR!

Please make sure you are targeting the main branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->
### What this PR fixes?
Fix VRP with Breaks Constraint Calculation in Routing Solver.
- #4234 

### Explanation -

This PR solves a minor bug where we had **CapSub** instead of **CapAdd**.

The incorrect use of CapSub resulted in a weaker constraint, potentially allowing unrealistic scheduling in vehicle routing problems with breaks. By using CapAdd, we correctly adjust the start time after a break, ensuring that the solver's constraints reflect actual break intervals more accurately.