### PR TITLE
Disable well compacted assert on MinGW

### DIFF
--- a/ortools/sat/linear_propagation.h
+++ b/ortools/sat/linear_propagation.h
@@ -332,10 +332,10 @@ class LinearPropagator : public PropagatorInterface, ReversibleInterface {
     IntegerValue rev_rhs;  // The current rhs, updated on fixed terms.
   };
 
-#if !defined(_MSC_VER)
+#if !defined(_MSC_VER) && !defined(__MINGW32__) && !defined(__MINGW64__)
   static_assert(sizeof(ConstraintInfo) == 24,
                 "ERROR_ConstraintInfo_is_not_well_compacted");
-#endif  // !defined(_MSC_VER)
+#endif  // !defined(_MSC_VER) && !defined(__MINGW32__) && !defined(__MINGW64__)
 
   absl::Span<IntegerValue> GetCoeffs(const ConstraintInfo& info);
   absl::Span<IntegerVariable> GetVariables(const ConstraintInfo& info);


### PR DESCRIPTION
MinGW build fails, as in #4132. This pull requests implements removal of assertion for MinGW, like suggested in the linked issue.

Alternatively, `bool all_coeffs_are_one : 1` could be changed to `unsigned int all_coeffs_are_one : 1`. With this change, both MSVC and MinGW will pack the `ConstraintInfo` struct to expected 24 bytes.