### PR TITLE
Add ILiteral.AsExpr() method

### DIFF
--- a/ortools/sat/csharp/IntegerExpressions.cs
+++ b/ortools/sat/csharp/IntegerExpressions.cs
@@ -28,6 +28,8 @@ public interface ILiteral
     ILiteral Not();
     /** <summary>Returns the logical index of the literal. </summary> */
     int GetIndex();
+    /** <summary>Returns the literal as a linear expression.</summary> */
+    LinearExpr AsExpr();
     /** <summary>Returns the Boolean negation of the literal as a linear expression.</summary> */
     LinearExpr NotAsExpr();
 }
@@ -803,6 +805,12 @@ public sealed class BoolVar : IntVar, ILiteral
         return negation_ ??= new NotBoolVar(this);
     }
 
+    /** <summary>Returns the literal as a linear expression.</summary> */
+    public LinearExpr AsExpr()
+    {
+        return this;
+    }
+
     /** <summary> Returns the Boolean negation of that variable as a linear expression.</summary> */
     public LinearExpr NotAsExpr()
     {
@@ -834,6 +842,11 @@ public sealed class NotBoolVar : LinearExpr, ILiteral
     public ILiteral Not()
     {
         return boolvar_;
+    }
+
+    public LinearExpr AsExpr()
+    {
+        return this;
     }
 
     public LinearExpr NotAsExpr()

--- a/ortools/sat/csharp/IntegerExpressions.cs
+++ b/ortools/sat/csharp/IntegerExpressions.cs
@@ -846,7 +846,7 @@ public sealed class NotBoolVar : LinearExpr, ILiteral
 
     public LinearExpr AsExpr()
     {
-        return this;
+        return 1 - boolvar_;
     }
 
     public LinearExpr NotAsExpr()

--- a/ortools/sat/csharp/SatSolverTests.cs
+++ b/ortools/sat/csharp/SatSolverTests.cs
@@ -496,6 +496,54 @@ public class SatSolverTest
     }
 
     [Fact]
+    public void TrueLiteralAsExpressionTest()
+    {
+        Console.WriteLine("TrueLiteralAsExpressionTest");
+        CpModel model = new CpModel();
+        ILiteral v = model.TrueLiteral();
+        LinearExpr e = v.AsExpr() * 2;
+        Console.WriteLine(e);
+        e = 2 * v.AsExpr();
+        Console.WriteLine(e);
+        e = v.AsExpr() + 2;
+        Console.WriteLine(e);
+        e = 2 + v.AsExpr();
+        Console.WriteLine(e);
+        e = v.AsExpr();
+        Console.WriteLine(e);
+        e = -v.AsExpr();
+        Console.WriteLine(e);
+        e = 1 - v.AsExpr();
+        Console.WriteLine(e);
+        e = v.AsExpr() - 1;
+        Console.WriteLine(e);
+    }
+
+    [Fact]
+    public void FalseLiteralAsExpressionTest()
+    {
+        Console.WriteLine("FalseLiteralAsExpressionTest");
+        CpModel model = new CpModel();
+        ILiteral v = model.FalseLiteral();
+        LinearExpr e = v.AsExpr() * 2;
+        Console.WriteLine(e);
+        e = 2 * v.AsExpr();
+        Console.WriteLine(e);
+        e = v.AsExpr() + 2;
+        Console.WriteLine(e);
+        e = 2 + v.AsExpr();
+        Console.WriteLine(e);
+        e = v.AsExpr();
+        Console.WriteLine(e);
+        e = -v.AsExpr();
+        Console.WriteLine(e);
+        e = 1 - v.AsExpr();
+        Console.WriteLine(e);
+        e = v.AsExpr() - 1;
+        Console.WriteLine(e);
+    }
+
+    [Fact]
     public void LinearExprNotBoolVarOperatorTest()
     {
         Console.WriteLine("LinearExprBoolVarNotOperatorTest");


### PR DESCRIPTION
Hi!

This PR extends ILiteral interface with a new `AsExpr()` method. It allows to simplify the user code and allows to eliminate direct casts `ILiteral` -> `LinearExpr` or constructions like `LinearExpr.NewBuilder().Add(literal)` or `-1*coefficient*literal.NotAsExpr()`