### PR TITLE
.net CpModel.AddMapDomain: add method summary and tiny fixes

### DIFF
--- a/ortools/sat/csharp/CpModel.cs
+++ b/ortools/sat/csharp/CpModel.cs
@@ -523,11 +523,11 @@ public class CpModel
             model_.Constraints.Add(ct1);
 
             LinearConstraintProto lin2 = new LinearConstraintProto();
-            lin1.Vars.Capacity = 1;
+            lin2.Vars.Capacity = 1;
             lin2.Vars.Add(var_index);
-            lin1.Coeffs.Capacity = 1;
+            lin2.Coeffs.Capacity = 1;
             lin2.Coeffs.Add(1L);
-            lin1.Domain.Capacity = 4;
+            lin2.Domain.Capacity = 4;
             lin2.Domain.Add(Int64.MinValue);
             lin2.Domain.Add(offset + i - 1);
             lin2.Domain.Add(offset + i + 1);

--- a/ortools/sat/csharp/CpModel.cs
+++ b/ortools/sat/csharp/CpModel.cs
@@ -501,6 +501,11 @@ public class CpModel
         return ct;
     }
 
+    /**
+     * <summary>
+     * Adds <c>var == i + offset ⇔ bool_vars[i] == true for all i</c>.
+     * </summary>
+     */
     public void AddMapDomain(IntVar var, IEnumerable<IntVar> bool_vars, long offset = 0)
     {
         int i = 0;


### PR DESCRIPTION
Hi!

This PR adds a summary to `CpModel.AddMapDomain` method.

Also fixes the code, which was probably copy-pasted