### PR TITLE
 Use absl's locale-independent conversion functions in XPRESS MPSolver interface

### DIFF
--- a/ortools/linear_solver/xpress_interface.cc
+++ b/ortools/linear_solver/xpress_interface.cc
@@ -22,6 +22,7 @@
 #include <mutex>
 #include <string>
 
+#include "absl/strings/numbers.h"
 #include "absl/strings/str_format.h"
 #include "ortools/base/logging.h"
 #include "ortools/base/timer.h"
@@ -227,7 +228,7 @@ class XpressMPCallbackContext : public MPCallbackContext {
       : xprsprob_(xprsprob),
         event_(event),
         num_nodes_(num_nodes),
-        variable_values_(0) {};
+        variable_values_(0){};
 
   // Implementation of the interface.
   MPCallbackEvent Event() override { return event_; };
@@ -260,7 +261,7 @@ class XpressMPCallbackContext : public MPCallbackContext {
 // Wraps the MPCallback in order to catch and store exceptions
 class MPCallbackWrapper {
  public:
-  explicit MPCallbackWrapper(MPCallback* callback) : callback_(callback) {};
+  explicit MPCallbackWrapper(MPCallback* callback) : callback_(callback){};
   MPCallback* GetCallback() const { return callback_; }
   // Since our (C++) call-back functions are called from the XPRESS (C) code,
   // exceptions thrown in our call-back code are not caught by XPRESS.
@@ -2106,29 +2107,21 @@ void splitMyString(const std::string& str, Container& cont, char delim = ' ') {
   }
 }
 
-const char* stringToCharPtr(std::string& var) { return var.c_str(); }
+bool stringToCharPtr(const std::string& var, const char** out) {
+  *out = var.c_str();
+  return true;
+}
 
-// Save the existing locale, use the "C" locale to ensure that
-// string -> double conversion is done ignoring the locale.
-struct ScopedLocale {
-  ScopedLocale() {
-    oldLocale = std::setlocale(LC_NUMERIC, nullptr);
-    auto newLocale = std::setlocale(LC_NUMERIC, "C");
-    CHECK_EQ(std::string(newLocale), "C");
-  }
-  ~ScopedLocale() { std::setlocale(LC_NUMERIC, oldLocale); }
-
- private:
-  const char* oldLocale;
-};
-
-#define setParamIfPossible_MACRO(target_map, setter, converter)          \
+#define setParamIfPossible_MACRO(target_map, setter, converter, type)    \
   {                                                                      \
     auto matchingParamIter = (target_map).find(paramAndValuePair.first); \
     if (matchingParamIter != (target_map).end()) {                       \
-      const auto convertedValue = converter(paramAndValuePair.second);   \
-      VLOG(1) << "Setting parameter " << paramAndValuePair.first         \
-              << " to value " << convertedValue << std::endl;            \
+      type convertedValue;                                               \
+      bool ret = converter(paramAndValuePair.second, &convertedValue);   \
+      if (ret) {                                                         \
+        VLOG(1) << "Setting parameter " << paramAndValuePair.first       \
+                << " to value " << convertedValue << std::endl;          \
+      }                                                                  \
       setter(mLp, matchingParamIter->second, convertedValue);            \
       continue;                                                          \
     }                                                                    \
@@ -2153,14 +2146,15 @@ bool XpressInterface::SetSolverSpecificParametersAsString(
     }
   }
 
-  ScopedLocale locale;
   for (auto& paramAndValuePair : paramAndValuePairList) {
-    setParamIfPossible_MACRO(mapIntegerControls_, XPRSsetintcontrol, std::stoi);
-    setParamIfPossible_MACRO(mapDoubleControls_, XPRSsetdblcontrol, std::stod);
+    setParamIfPossible_MACRO(mapIntegerControls_, XPRSsetintcontrol,
+                             absl::SimpleAtoi<int>, int);
+    setParamIfPossible_MACRO(mapDoubleControls_, XPRSsetdblcontrol,
+                             absl::SimpleAtod, double);
     setParamIfPossible_MACRO(mapStringControls_, XPRSsetstrcontrol,
-                             stringToCharPtr);
+                             stringToCharPtr, const char*);
     setParamIfPossible_MACRO(mapInteger64Controls_, XPRSsetintcontrol64,
-                             std::stoll);
+                             absl::SimpleAtoi<int64_t>, int64_t);
     LOG(ERROR) << "Unknown parameter " << paramName << " : function "
                << __FUNCTION__ << std::endl;
     return false;


### PR DESCRIPTION
Using such functions as `std::stoi`, `std::stod`, etc. caused us a lot of trouble because these functions are locale dependent, as illustrated below

```cpp
#include <iostream>
#include <locale>
#include <string>

void convert(std::string locale)
{
    std::string value = "9.81";
    if (std::setlocale(LC_ALL, locale.c_str()))
    {
        double converted = std::stod(value);
        std::cout << "locale " << locale << " converted to " << converted << std::endl;
    }
    else
    {
        std::cout << "locale set failed for " << locale << std::endl;
    }
}
int main()
{
    convert("C");
    convert("fr_FR.utf8");
    // OUTPUT
    // locale C converted to 9.81
    // locale fr_FR.utf8 converted to 9
}
```

At first, we thought that using `ScopedLocale` would allow us to temporarily use the "C" locale, but this approach has multiple problems
1. It's not thread-safe. For example calling `std::stod` when the locale is being changed through `std::setlocale` is undefined behavior [source](https://en.cppreference.com/w/cpp/locale/setlocale).
2. C is hard, `const char*` pointers easily become dangling or invalid without the caller knowing

```cpp
struct ScopedLocale {
  ScopedLocale() {
    oldLocale = std::setlocale(LC_NUMERIC, nullptr);
    auto newLocale = std::setlocale(LC_NUMERIC, "C");
    CHECK_EQ(std::string(newLocale), "C");
  }
  ~ScopedLocale() { std::setlocale(LC_NUMERIC, oldLocale); }

 private:
  const char* oldLocale;
};
```

We ran into an issue where the locale wasn't properly restored after using `MPSolver::XpressInterface`. So we decided to use [absl's locale independent functions](https://abseil.io/docs/cpp/guides/strings#numericConversion) to perform that task.