### PR TITLE
Fix segfault due to nullptr

### DIFF
--- a/ortools/sat/cp_model_solver.cc
+++ b/ortools/sat/cp_model_solver.cc
@@ -1370,9 +1370,11 @@ class LnsSolver : public SubSolver {
             !neighborhood.variables_that_can_be_fixed_to_local_optimum
                  .empty()) {
           display_lns_info = true;
-          shared_->bounds->FixVariablesFromPartialSolution(
-              solution_values,
-              neighborhood.variables_that_can_be_fixed_to_local_optimum);
+          if (shared_->bounds != nullptr) {
+            shared_->bounds->FixVariablesFromPartialSolution(
+                solution_values,
+                neighborhood.variables_that_can_be_fixed_to_local_optimum);
+          }
         }
 
         // Finish to fill the SolveData now that the local solve is done.


### PR DESCRIPTION
Fix segfault due to nullptr

There's a segfault when running the `fzn-cp-sat` on particular
instances, using:
- `-p1` one thread
- `-f` free-search (interleaved?)

The segfault appears to be more easy to reprodue using
`--params:use_lns_only=true`

It seems to happen because the `shared_->bounds` is `nullptr`.

The issue can be "fixed" by
```cpp
          if (shared_->bounds != nullptr) {
            shared_->bounds->FixVariablesFromPartialSolution(
                solution_values,
                neighborhood.variables_that_can_be_fixed_to_local_optimum);
          }
```
but I suspect there is a better solution the bounds should either be initialized

I think this is happening because bounds sharing is disabled here
https://github.com/google/or-tools/blob/ed94162b910fa58896db99191378d3b71a5313af/ortools/sat/cp_model_solver_helpers.cc#L1762C1-L1767C4
so I suspect the `SharedBoundsManager` is not initialized here
https://github.com/google/or-tools/blob/ed94162b910fa58896db99191378d3b71a5313af/ortools/sat/cp_model_solver_helpers.cc#L1780C1-L1784C4