### PR TITLE
Handle GLPK library naming on windows

### DIFF
--- a/cmake/bundle-install.cmake.in
+++ b/cmake/bundle-install.cmake.in
@@ -34,7 +34,7 @@ if (@BUILD_SCIP@)
   set(DEPS ${DEPS} libscip.lib)
 endif()
 if (@BUILD_GLPK@)
-  set(DEPS ${DEPS} libglpk.lib)
+  set(DEPS ${DEPS} *glpk.lib)
 endif()
 
 # Bundle all .lib into @PROJECT_NAME@_full.lib


### PR DESCRIPTION
libglpk.a on linux, GLPK.lib on windows.
