### PR TITLE
Update change of C API function name PyEval to PyObject

### DIFF
--- a/bazel/notebook_requirements.txt
+++ b/bazel/notebook_requirements.txt
@@ -85,7 +85,7 @@ isoduration==20.11.0
     # via jsonschema
 jedi==0.19.0
     # via ipython
-jinja2==3.1.3
+jinja2==3.1.5
     # via
     #   jupyter-server
     #   jupyterlab

--- a/ortools/constraint_solver/python/constraint_solver.i
+++ b/ortools/constraint_solver/python/constraint_solver.i
@@ -140,7 +140,7 @@ static void PyFunctionSolverToVoid(PyObject* pyfunc,
   PyObject* const pysolver =
       SWIG_NewPointerObj(s, SWIGTYPE_p_operations_research__Solver,
                          SWIG_POINTER_EXCEPTION);
-  PyObject* const pyresult = PyEval_CallFunction(pyfunc, "(O)", pysolver);
+  PyObject* const pyresult = PyObject_CallFunction(pyfunc, "(O)", pysolver);
   if (!pyresult) {
     PyErr_SetString(PyExc_RuntimeError,
                     "std::function<void(Solver*)> invocation failed.");

--- a/ortools/julia/ORToolsGenerated.jl/Project.toml
+++ b/ortools/julia/ORToolsGenerated.jl/Project.toml
@@ -4,9 +4,11 @@ version = "0.0.1"
 
 [deps]
 ORTools_jll = "717719f8-c30c-5086-8f3c-70cd6a1e3a46"
+ProtoBuf = "3349acd9-ac6a-5e09-bcdb-63829b23a429"
 
 [compat]
 ORTools_jll = "9.11.0"
+ProtoBuf = "1.0.15"
 julia = "1.9"
 
 [extras]

--- a/ortools/julia/ORToolsGenerated.jl/Project.toml
+++ b/ortools/julia/ORToolsGenerated.jl/Project.toml
@@ -1,4 +1,4 @@
-name = "ORTools"
+name = "ORToolsGenerated"
 uuid = "6b269722-41d3-11ee-be56-0242ac120002"
 version = "0.0.1"
 
@@ -7,6 +7,7 @@ ORTools_jll = "717719f8-c30c-5086-8f3c-70cd6a1e3a46"
 
 [compat]
 ORTools_jll = "9.11.0"
+julia = "1.9"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/ortools/julia/ORToolsGenerated.jl/Project.toml
+++ b/ortools/julia/ORToolsGenerated.jl/Project.toml
@@ -6,7 +6,7 @@ version = "0.0.1"
 ORTools_jll = "717719f8-c30c-5086-8f3c-70cd6a1e3a46"
 
 [compat]
-ORTools_jll = "9.7.0+2"
+ORTools_jll = "9.11.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/ortools/julia/ORToolsGenerated.jl/src/genproto/google/google.jl
+++ b/ortools/julia/ORToolsGenerated.jl/src/genproto/google/google.jl
@@ -1,5 +1,5 @@
 module google
 
-include("google/protobuf/protobuf.jl")
+include("protobuf/protobuf.jl")
 
 end # module google

--- a/ortools/julia/ORToolsGenerated.jl/src/genproto/operations_research/operations_research.jl
+++ b/ortools/julia/ORToolsGenerated.jl/src/genproto/operations_research/operations_research.jl
@@ -19,7 +19,7 @@ include("scheduling/scheduling.jl")
 include("glop/glop.jl")
 include("bop/bop.jl")
 include("packing/packing.jl")
-include("ortools/pdlp/pdlp.jl")
+include("pdlp/pdlp.jl")
 include("math_opt/math_opt.jl")
 
 end # module operations_research


### PR DESCRIPTION
Compilation of the or-tools fails, because the PyEval_CallFunction was replaced with PyObject_CallFunction.