### PR TITLE
Dropped orders should not come with dropped reload stations in cvrp_r…

### DIFF
--- a/ortools/constraint_solver/samples/cvrp_reload.py
+++ b/ortools/constraint_solver/samples/cvrp_reload.py
@@ -298,6 +298,7 @@ def print_solution(data, manager, routing, assignment):  # pylint:disable=too-ma
         if assignment.Value(routing.NextVar(index)) == index:
             dropped.append(order)
     print(f'dropped orders: {dropped}')
+    dropped = []
     for reload in range(1, 6):
         index = manager.NodeToIndex(reload)
         if assignment.Value(routing.NextVar(index)) == index:


### PR DESCRIPTION
…eload.py example output

<!--
Thank you for submitting a PR!

Please make sure you are targeting the main branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->
