### PR TITLE
Misleading method name fix in SetCoverModel

### DIFF
--- a/ortools/algorithms/python/set_cover.cc
+++ b/ortools/algorithms/python/set_cover.cc
@@ -221,9 +221,9 @@ PYBIND11_MODULE(set_cover, m) {
       .def("sort_elements_in_subsets", &SetCoverModel::SortElementsInSubsets)
       .def("compute_feasibility", &SetCoverModel::ComputeFeasibility)
       .def(
-          "reserve_num_subsets",
+          "resize_num_subsets",
           [](SetCoverModel& model, BaseInt num_subsets) {
-            model.ReserveNumSubsets(num_subsets);
+            model.ResizeNumSubsets(num_subsets);
           },
           arg("num_subsets"))
       .def(

--- a/ortools/algorithms/set_cover_model.cc
+++ b/ortools/algorithms/set_cover_model.cc
@@ -92,7 +92,7 @@ SetCoverModel SetCoverModel::GenerateRandomModelFrom(
   DCHECK_GT(cost_scale, 0.0);
   model.num_elements_ = num_elements;
   model.num_nonzeros_ = 0;
-  model.ReserveNumSubsets(num_subsets);
+  model.ResizeNumSubsets(num_subsets);
   model.UpdateAllSubsetsList();
   absl::BitGen bitgen;
 
@@ -298,22 +298,22 @@ void SetCoverModel::AddElementToSubset(ElementIndex element,
   AddElementToSubset(element.value(), subset.value());
 }
 
-// Reserves num_subsets columns in the model.
-void SetCoverModel::ReserveNumSubsets(BaseInt num_subsets) {
+// Reserves num_subsets columns in the model creating empty subsets if needed.
+void SetCoverModel::ResizeNumSubsets(BaseInt num_subsets) {
   num_subsets_ = std::max(num_subsets_, num_subsets);
   columns_.resize(num_subsets_, SparseColumn());
   subset_costs_.resize(num_subsets_, 0.0);
   UpdateAllSubsetsList();
 }
 
-void SetCoverModel::ReserveNumSubsets(SubsetIndex num_subsets) {
-  ReserveNumSubsets(num_subsets.value());
+void SetCoverModel::ResizeNumSubsets(SubsetIndex num_subsets) {
+  ResizeNumSubsets(num_subsets.value());
 }
 
 // Reserves num_elements rows in the column indexed by subset.
 void SetCoverModel::ReserveNumElementsInSubset(BaseInt num_elements,
                                                BaseInt subset) {
-  ReserveNumSubsets(subset);
+  ResizeNumSubsets(subset);
   columns_[SubsetIndex(subset)].reserve(ColumnEntryIndex(num_elements));
 }
 
@@ -416,7 +416,7 @@ SetCoverProto SetCoverModel::ExportModelAsProto() const {
 void SetCoverModel::ImportModelFromProto(const SetCoverProto& message) {
   columns_.clear();
   subset_costs_.clear();
-  ReserveNumSubsets(message.subset_size());
+  ResizeNumSubsets(message.subset_size());
   SubsetIndex subset_index(0);
   for (const SetCoverProto::Subset& subset_proto : message.subset()) {
     subset_costs_[subset_index] = subset_proto.cost();

--- a/ortools/algorithms/set_cover_model.cc
+++ b/ortools/algorithms/set_cover_model.cc
@@ -317,7 +317,7 @@ void SetCoverModel::ReserveNumElementsInSubset(BaseInt num_elements,
   columns_[SubsetIndex(subset)].reserve(ColumnEntryIndex(num_elements));
 }
 
-void SetCoverModel::ReserveNumElementsInSubset(ElementIndex num_elements,
+void SetCoverModel::ReserveNumElementsInSubset(RowEntryIndex num_elements,
                                                SubsetIndex subset) {
   ReserveNumElementsInSubset(num_elements.value(), subset.value());
 }

--- a/ortools/algorithms/set_cover_model.h
+++ b/ortools/algorithms/set_cover_model.h
@@ -217,9 +217,9 @@ class SetCoverModel {
   // the elements.
   bool ComputeFeasibility() const;
 
-  // Reserves num_subsets columns in the model.
-  void ReserveNumSubsets(BaseInt num_subsets);
-  void ReserveNumSubsets(SubsetIndex num_subsets);
+  // Reserves num_subsets columns in the model creating empty subsets if needed.
+  void ResizeNumSubsets(BaseInt num_subsets);
+  void ResizeNumSubsets(SubsetIndex num_subsets);
 
   // Reserves num_elements rows in the column indexed by subset.
   void ReserveNumElementsInSubset(BaseInt num_elements, BaseInt subset);

--- a/ortools/algorithms/set_cover_model.h
+++ b/ortools/algorithms/set_cover_model.h
@@ -223,7 +223,7 @@ class SetCoverModel {
 
   // Reserves num_elements rows in the column indexed by subset.
   void ReserveNumElementsInSubset(BaseInt num_elements, BaseInt subset);
-  void ReserveNumElementsInSubset(ElementIndex num_elements,
+  void ReserveNumElementsInSubset(RowEntryIndex num_elements,
                                   SubsetIndex subset);
 
   // Returns the model as a SetCoverProto. Note that the elements of each subset

--- a/ortools/algorithms/set_cover_reader.cc
+++ b/ortools/algorithms/set_cover_reader.cc
@@ -112,7 +112,7 @@ SetCoverModel ReadOrlibScp(absl::string_view filename) {
   SetCoverReader reader(file);
   const ElementIndex num_rows(reader.ParseNextInteger());
   const SubsetIndex num_cols(reader.ParseNextInteger());
-  model.ReserveNumSubsets(num_cols.value());
+  model.ResizeNumSubsets(num_cols.value());
   for (SubsetIndex subset : SubsetRange(num_cols)) {
     const double cost(reader.ParseNextDouble());
     model.SetSubsetCost(subset.value(), cost);
@@ -141,7 +141,7 @@ SetCoverModel ReadOrlibRail(absl::string_view filename) {
   SetCoverReader reader(file);
   const ElementIndex num_rows(reader.ParseNextInteger());
   const BaseInt num_cols(reader.ParseNextInteger());
-  model.ReserveNumSubsets(num_cols);
+  model.ResizeNumSubsets(num_cols);
   for (BaseInt subset(0); subset < num_cols; ++subset) {
     LOG_EVERY_N_SEC(INFO, 5)
         << absl::StrFormat("Reading subset %d (%.1f%%)", subset,


### PR DESCRIPTION
Hello!  

I'm currently working on a larger PR to (hopefully) introduce a subgradient-based heuristic for the Set Covering problem. In the process, I noticed a couple of minor issues that might be worth addressing:  

### Rename `ReserveNumSubsets` --> `ResizeNumSubsets`  
The name `ReserveNumSubsets` suggests (by analogy with `std::vector::reserve`) that it only allocates memory without creating new subsets. However, it actually resizes the model, introducing the necessary empty subsets.

Moreover, since the current interface allows models to be built subset by subset (with `AddElementToLastSubset` behaving similarly to `std::vector::push_back`), this further increases the risk of misusing the function.

Additionally, `ReserveNumElementsInSubset` (defined right after it) does follow the expected behavior of `std::vector::reserve`, meaning it allocates memory but does not create new elements. 

To remove this inconsistency, this PR renames `ReserveNumSubsets` to `ResizeNumSubsets`, aligning it with `std::vector::resize` to better reflect its behavior.

### Nit: `ElementIndex`  -->  `RowEntryIndex`  
Since the codebase defines `RowEntryIndex` as the custom type for row entry indices, this PR also replaces `ElementIndex` with `RowEntryIndex`  on the `ReserveNumElementsInSubset` overload.  

Let me know if you have any feedback!  
