### PR TITLE
Allow creating HiGHS MPSolver interface with empty model name

### DIFF
--- a/ortools/linear_solver/proto_solver/highs_proto_solver.cc
+++ b/ortools/linear_solver/proto_solver/highs_proto_solver.cc
@@ -55,7 +55,7 @@ absl::StatusOr<MPSolutionResponse> HighsSolveProto(
 
   Highs highs;
   // Set model name.
-  if (model.has_name()) {
+  if (model.has_name() && !model.name().empty()) {
     const std::string model_name = model.name();
     highs.passModelName(model_name);
   }


### PR DESCRIPTION
When calling MPSolver::CreateSolver("highs"), the model name is an empty string.  
HiGHS raises the following error: `Cannot define empty model names`.  
This fixes it.