### PR TITLE
Use a fixed order for MPSolver / XPRESS's constraint coefficients

### DIFF
--- a/ortools/linear_solver/xpress_interface.cc
+++ b/ortools/linear_solver/xpress_interface.cc
@@ -1566,8 +1566,6 @@ void XpressInterface::ExtractNewConstraints() {
           const auto& coeffs = fixedOrderCoefficientsPerConstraint[ct->index()];
           for (auto [idx, coeff] : coeffs) {
             if (variable_is_extracted(idx)) {
-              DCHECK_LT(nextNz, cols);
-              DCHECK_LT(idx, cols);
               rmatind[nextNz] = idx;
               rmatval[nextNz] = coeff;
               ++nextNz;

--- a/ortools/linear_solver/xpress_interface.cc
+++ b/ortools/linear_solver/xpress_interface.cc
@@ -1567,6 +1567,8 @@ void XpressInterface::ExtractNewConstraints() {
           const auto& coeffs = fixedOrderCoefficientsPerConstraint[ct->index()];
           for (auto [idx, coeff] : coeffs) {
             if (variable_is_extracted(idx)) {
+              DCHECK_LT(nextNz, cols);
+              DCHECK_LT(idx, cols);
               rmatind[nextNz] = idx;
               rmatval[nextNz] = coeff;
               ++nextNz;

--- a/ortools/linear_solver/xpress_interface.cc
+++ b/ortools/linear_solver/xpress_interface.cc
@@ -427,7 +427,7 @@ class XpressInterface : public MPSolverInterface {
   // Looping on MPConstraint::coefficients_ yields non-reproducible results
   // since is uses pointer addresses as keys, the value of which is
   // non-deterministic, especially their order.
-  std::map<int, std::map<int, double> >
+  absl::btree_map<int, std::map<int, double> >
       fixedOrderCoefficientsPerConstraint;
 
   // Incremental extraction.

--- a/ortools/linear_solver/xpress_interface.cc
+++ b/ortools/linear_solver/xpress_interface.cc
@@ -424,8 +424,11 @@ class XpressInterface : public MPSolverInterface {
   XPRSprob mLp;
   bool const mMip;
 
-  // Looping on MPConstraint::coefficients_ yields non-reproducible results since is uses pointer addresses as keys, the value of which is non-deterministic, especially their order.
-  std::map<int , std::vector<std::pair<int, double> > > fixedOrderCoefficientsPerConstraint;
+  // Looping on MPConstraint::coefficients_ yields non-reproducible results
+  // since is uses pointer addresses as keys, the value of which is
+  // non-deterministic, especially their order.
+  std::map<int, std::vector<std::pair<int, double> > >
+      fixedOrderCoefficientsPerConstraint;
 
   // Incremental extraction.
   // Without incremental extraction we have to re-extract the model every
@@ -1091,7 +1094,8 @@ void XpressInterface::SetCoefficient(MPConstraint* const constraint,
                                      double new_value, double) {
   InvalidateSolutionSynchronization();
 
-  fixedOrderCoefficientsPerConstraint[constraint->index()].push_back(std::make_pair(variable->index(), new_value));
+  fixedOrderCoefficientsPerConstraint[constraint->index()].emplace_back(
+      variable->index(), new_value);
 
   // Changing a single coefficient in the matrix is potentially pretty
   // slow since that coefficient has to be found in the sparse matrix

--- a/ortools/linear_solver/xpress_interface.cc
+++ b/ortools/linear_solver/xpress_interface.cc
@@ -427,7 +427,7 @@ class XpressInterface : public MPSolverInterface {
   // Looping on MPConstraint::coefficients_ yields non-reproducible results
   // since is uses pointer addresses as keys, the value of which is
   // non-deterministic, especially their order.
-  std::map<int, std::vector<std::pair<int, double> > >
+  std::map<int, std::map<int, double> >
       fixedOrderCoefficientsPerConstraint;
 
   // Incremental extraction.
@@ -1094,8 +1094,7 @@ void XpressInterface::SetCoefficient(MPConstraint* const constraint,
                                      double new_value, double) {
   InvalidateSolutionSynchronization();
 
-  fixedOrderCoefficientsPerConstraint[constraint->index()].emplace_back(
-      variable->index(), new_value);
+  fixedOrderCoefficientsPerConstraint[constraint->index()][variable->index()] = new_value;
 
   // Changing a single coefficient in the matrix is potentially pretty
   // slow since that coefficient has to be found in the sparse matrix
@@ -1128,6 +1127,8 @@ void XpressInterface::ClearConstraint(MPConstraint* const constraint) {
   if (!constraint_is_extracted(row))
     // There is nothing to do if the constraint was not even extracted.
     return;
+
+  fixedOrderCoefficientsPerConstraint.erase(constraint->index());
 
   // Clearing a constraint means setting all coefficients in the corresponding
   // row to 0 (we cannot just delete the row since that would renumber all


### PR DESCRIPTION
Using `absl::flat_hash_map<const MPVariable*, double> coefficients_` from `MPSolver::MPConstraint` yields a different order for coefficients provided the `XPRSaddrows` method. This leads to non-reproducibility in cases where problems have non-unique solutions.

Instead we use our own map with a fixed order (ie not dependent on unpredictable pointer addresses).

@lperron @Mizux If it's OK for you, can this be shipped into v9.13 ?