### PR TITLE
cmake: Add support for custom protoc executable via OR_TOOLS_PROTOC_EXECUTABLE

### DIFF
--- a/cmake/host.cmake
+++ b/cmake/host.cmake
@@ -11,6 +11,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if (OR_TOOLS_PROTOC_EXECUTABLE)
+  set(PROTOC_PRG ${OR_TOOLS_PROTOC_EXECUTABLE})
+  return()
+endif()
+
 if(NOT CMAKE_CROSSCOMPILING)
   set(PROTOC_PRG protobuf::protoc)
   return()


### PR DESCRIPTION
Allow users to specify a custom protoc executable by setting the OR_TOOLS_PROTOC_EXECUTABLE variable, which takes precedence over the default cross-compilation and system protoc detection logic.


