### PR TITLE
Fix compat with protobuf < 5.26

### DIFF
--- a/ortools/util/file_util.cc
+++ b/ortools/util/file_util.cc
@@ -166,7 +166,11 @@ absl::Status WriteProtoToFile(absl::string_view filename,
     case ProtoWriteFormat::kJson: {
       google::protobuf::util::JsonPrintOptions options;
       options.add_whitespace = true;
+#if PROTOBUF_VERSION >= 5026000  // Version 26.0.0
       options.always_print_fields_with_no_presence = true;
+#else
+      options.always_print_primitive_fields = true;
+#endif
       options.preserve_proto_field_names = true;
       if (!google::protobuf::util::MessageToJsonString(proto, &output_string,
                                                        options)


### PR DESCRIPTION
In my case I run with protobuf 4.25.4 the only issue building or-tools is this field.

Maybe it could be nice to keep a very light compatibility even if untested. 