### PR TITLE
remove unused closeVisitTypes renaming and documentation

### DIFF
--- a/ortools/routing/java/routing.swig
+++ b/ortools/routing/java/routing.swig
@@ -165,7 +165,6 @@ import java.util.function.LongUnaryOperator;
 %rename (checkLimit) RoutingModel::CheckLimit;
 %rename (closeModel) RoutingModel::CloseModel;
 %rename (closeModelWithParameters) RoutingModel::CloseModelWithParameters;
-%rename (closeVisitTypes) RoutingModel::CloseVisitTypes;
 %rename (compactAndCheckAssignment) RoutingModel::CompactAndCheckAssignment;
 %rename (compactAssignment) RoutingModel::CompactAssignment;
 %rename (computeLowerBound) RoutingModel::ComputeLowerBound;

--- a/ortools/routing/python/doc.h
+++ b/ortools/routing/python/doc.h
@@ -1379,9 +1379,6 @@ static const char*
         R"doc(Same as above taking search parameters (as of 10/2015 some the
 parameters have to be set when closing the model).)doc";
 
-static const char* __doc_operations_research_RoutingModel_CloseVisitTypes =
-    R"doc("close" types.)doc";
-
 static const char*
     __doc_operations_research_RoutingModel_CompactAndCheckAssignment =
         R"doc(Same as CompactAssignment() but also checks the validity of the final

--- a/ortools/routing/routing.h
+++ b/ortools/routing/routing.h
@@ -1092,10 +1092,8 @@ class OR_DLL RoutingModel {
   /// Set the node visit types and incompatibilities/requirements between the
   /// types (see below).
   ///
-  /// NOTE: Before adding any incompatibilities and/or requirements on types:
-  ///       1) All corresponding node types must have been set.
-  ///       2) CloseVisitTypes() must be called so all containers are resized
-  ///          accordingly.
+  /// NOTE: Before adding any incompatibilities and/or requirements on types
+  /// all corresponding node types must have been set.
   ///
   /// The following enum is used to describe how a node with a given type 'T'
   /// impacts the number of types 'T' on the route when visited, and thus


### PR DESCRIPTION
closeVisitTypes function has been removed with https://github.com/google/or-tools/commit/6de3f59af23f83125a83868bff28810cdeb46bde#diff-5d04ac9cf933c2ab8529983dd9fb2e24f583631042dab6f01364d8a908e83660 .
But there were a few dangling references in comments, docs and bindings. 
They are removed with this PR. 
