### PR TITLE
math_opt: only run SCIP tests if enabled

### DIFF
--- a/ortools/math_opt/solver_tests/test_models_test.cc
+++ b/ortools/math_opt/solver_tests/test_models_test.cc
@@ -24,21 +24,25 @@ namespace operations_research::math_opt {
 
 using ::testing::status::IsOkAndHolds;
 
+#if defined(USE_SCIP)
 TEST(SmallModelTest, Integer) {
   const std::unique_ptr<const Model> model = SmallModel(/*integer=*/true);
   EXPECT_THAT(Solve(*model, SolverType::kGscip), IsOkAndHolds(IsOptimal(9.0)));
 }
+#endif  // USE_SCIP
 
 TEST(SmallModelTest, Continuous) {
   const std::unique_ptr<const Model> model = SmallModel(/*integer=*/false);
   EXPECT_THAT(Solve(*model, SolverType::kGlop), IsOkAndHolds(IsOptimal(12.0)));
 }
 
+#if defined(USE_SCIP)
 TEST(DenseIndependentSetTest, Integer) {
   const std::unique_ptr<const Model> model =
       DenseIndependentSet(/*integer=*/true);
   EXPECT_THAT(Solve(*model, SolverType::kGscip), IsOkAndHolds(IsOptimal(7.0)));
 }
+#endif  // USE_SCIP
 
 TEST(DenseIndependentSetTest, Continuous) {
   const std::unique_ptr<const Model> model =
@@ -47,6 +51,7 @@ TEST(DenseIndependentSetTest, Continuous) {
               IsOkAndHolds(IsOptimal(10.0 * (5 + 4 + 3) / 2.0)));
 }
 
+#if defined(USE_SCIP)
 TEST(DenseIndependentSetHint5Test, HintIsFeasibleWithObjective5) {
   const std::unique_ptr<Model> model = DenseIndependentSet(/*integer=*/true, 5);
   ModelSolveParameters model_params;
@@ -58,12 +63,15 @@ TEST(DenseIndependentSetHint5Test, HintIsFeasibleWithObjective5) {
   }
   EXPECT_THAT(Solve(*model, SolverType::kGscip), IsOkAndHolds(IsOptimal(5.0)));
 }
+#endif  // USE_SCIP
 
+#if defined(USE_SCIP)
 TEST(IndependentSetCompleteGraphTest, Integer) {
   const std::unique_ptr<const Model> model =
       IndependentSetCompleteGraph(/*integer=*/true);
   EXPECT_THAT(Solve(*model, SolverType::kGscip), IsOkAndHolds(IsOptimal(1.0)));
 }
+#endif  // USE_SCIP
 
 TEST(IndependentSetCompleteGraphTest, Continuous) {
   const std::unique_ptr<const Model> model =


### PR DESCRIPTION
Usage of SCIP library can be disabled in CMake build by setting -DUSE_SCIP=OFF.

However, the tests were still run unconditionally, showing test failures like this:

```
/build/source/ortools/math_opt/solver_tests/test_models_test.cc:29: Failure
Value of: Solve(*model, SolverType::kGscip)
Expected: is OK and has a value that (is an object whose field `termination` (is an object whose field `reason` is equal to optimal) and (is an object whose field `problem_status` (is an object whose field `primal_status` is equal to feasible) and (is an object whose field `dual_status` is equal to feasible) and (is an object whose field `primal_or_dual_infeasible` is equal to false))) and (is an object whose property `has_primal_feasible_solution` is equal to true) and (is an object whose property `objective_value` is approximately 9 (absolute error <= 1.0000000000000001e-05))
  Actual: [INVALID_ARGUMENT: solver type SOLVER_TYPE_GSCIP is not registered, support for this solver has not been compiled], which has status INVALID_ARGUMENT: solver type SOLVER_TYPE_GSCIP is not registered, support for this solver has not been compiled

[  FAILED  ] SmallModelTest.Integer (2 ms)
[ RUN      ] SmallModelTest.Continuous
[       OK ] SmallModelTest.Continuous (1 ms)
[----------] 2 tests from SmallModelTest (3 ms total)

[----------] 2 tests from DenseIndependentSetTest
[ RUN      ] DenseIndependentSetTest.Integer
/build/source/ortools/math_opt/solver_tests/test_models_test.cc:40: Failure
Value of: Solve(*model, SolverType::kGscip)
Expected: is OK and has a value that (is an object whose field `termination` (is an object whose field `reason` is equal to optimal) and (is an object whose field `problem_status` (is an object whose field `primal_status` is equal to feasible) and (is an object whose field `dual_status` is equal to feasible) and (is an object whose field `primal_or_dual_infeasible` is equal to false))) and (is an object whose property `has_primal_feasible_solution` is equal to true) and (is an object whose property `objective_value` is approximately 7 (absolute error <= 1.0000000000000001e-05))
  Actual: [INVALID_ARGUMENT: solver type SOLVER_TYPE_GSCIP is not registered, support for this solver has not been compiled], which has status INVALID_ARGUMENT: solver type SOLVER_TYPE_GSCIP is not registered, support for this solver has not been compiled

[  FAILED  ] DenseIndependentSetTest.Integer (0 ms)
[ RUN      ] DenseIndependentSetTest.Continuous
[       OK ] DenseIndependentSetTest.Continuous (1 ms)
[----------] 2 tests from DenseIndependentSetTest (2 ms total)

[----------] 1 test from DenseIndependentSetHint5Test
[ RUN      ] DenseIndependentSetHint5Test.HintIsFeasibleWithObjective5
/build/source/ortools/math_opt/solver_tests/test_models_test.cc:59: Failure
Value of: Solve(*model, SolverType::kGscip)
Expected: is OK and has a value that (is an object whose field `termination` (is an object whose field `reason` is equal to optimal) and (is an object whose field `problem_status` (is an object whose field `primal_status` is equal to feasible) and (is an object whose field `dual_status` is equal to feasible) and (is an object whose field `primal_or_dual_infeasible` is equal to false))) and (is an object whose property `has_primal_feasible_solution` is equal to true) and (is an object whose property `objective_value` is approximately 5 (absolute error <= 1.0000000000000001e-05))
  Actual: [INVALID_ARGUMENT: solver type SOLVER_TYPE_GSCIP is not registered, support for this solver has not been compiled], which has status INVALID_ARGUMENT: solver type SOLVER_TYPE_GSCIP is not registered, support for this solver has not been compiled

[  FAILED  ] DenseIndependentSetHint5Test.HintIsFeasibleWithObjective5 (0 ms)
[----------] 1 test from DenseIndependentSetHint5Test (0 ms total)

[----------] 2 tests from IndependentSetCompleteGraphTest
[ RUN      ] IndependentSetCompleteGraphTest.Integer
/build/source/ortools/math_opt/solver_tests/test_models_test.cc:65: Failure
Value of: Solve(*model, SolverType::kGscip)
Expected: is OK and has a value that (is an object whose field `termination` (is an object whose field `reason` is equal to optimal) and (is an object whose field `problem_status` (is an object whose field `primal_status` is equal to feasible) and (is an object whose field `dual_status` is equal to feasible) and (is an object whose field `primal_or_dual_infeasible` is equal to false))) and (is an object whose property `has_primal_feasible_solution` is equal to true) and (is an object whose property `objective_value` is approximately 1 (absolute error <= 1.0000000000000001e-05))
  Actual: [INVALID_ARGUMENT: solver type SOLVER_TYPE_GSCIP is not registered, support for this solver has not been compiled], which has status INVALID_ARGUMENT: solver type SOLVER_TYPE_GSCIP is not registered, support for this solver has not been compiled

[  FAILED  ] IndependentSetCompleteGraphTest.Integer (0 ms)
```

Fix this, by conditionalizing these tests on USE_SCIP.