### PR TITLE
rework java_wrap_cc

### DIFF
--- a/bazel/swig_java.bzl
+++ b/bazel/swig_java.bzl
@@ -15,6 +15,7 @@
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("@rules_java//java:java_library.bzl", "java_library")
 load("@rules_java//java/common:java_common.bzl", "java_common")
 
@@ -33,7 +34,9 @@ def _create_src_jar(ctx, java_runtime_info, input_dir, output_jar):
     )
 
 def _java_wrap_cc_impl(ctx):
-    src = ctx.file.src
+    if len(ctx.files.srcs) != 1:
+        fail("There must be exactly one *.swig file", attr = "srcs")
+    swig_src = ctx.files.srcs[0]
     outfile = ctx.outputs.outfile
     outhdr = ctx.outputs.outhdr
 
@@ -65,7 +68,7 @@ def _java_wrap_cc_impl(ctx):
         swig_args.add("-module", ctx.attr.module)
     for include_path in depset(transitive = include_path_sets).to_list():
         swig_args.add("-I" + include_path)
-    swig_args.add(src.path)
+    swig_args.add(swig_src.path)
     generated_c_files = [outfile]
     if ctx.attr.use_directors:
         generated_c_files.append(outhdr)
@@ -74,7 +77,7 @@ def _java_wrap_cc_impl(ctx):
     swig_lib = {"SWIG_LIB": paths.dirname(ctx.files._swig_lib[0].path)}
     ctx.actions.run(
         outputs = generated_c_files + [java_files_dir],
-        inputs = depset([src] + ctx.files.swig_includes + ctx.files._swig_lib, transitive = header_sets),
+        inputs = depset([swig_src] + ctx.files.swig_includes + ctx.files._swig_lib, transitive = header_sets),
         env = swig_lib,
         executable = ctx.executable._swig,
         arguments = [swig_args],
@@ -92,10 +95,13 @@ It's expected that the `swig` binary exists in the host's path.
 """,
     implementation = _java_wrap_cc_impl,
     attrs = {
-        "src": attr.label(
-            doc = "Single swig source file.",
-            allow_single_file = True,
-            mandatory = True,
+        "srcs": attr.label_list(
+            allow_empty = False,
+            allow_files = [".swig", ".i"],
+            flags = ["DIRECT_COMPILE_TIME_INPUT", "ORDER_INDEPENDENT"],
+            doc = """
+A list of one <code>swig</code> source.
+            """,
         ),
         "deps": attr.label_list(
             doc = "C++ dependencies.",
@@ -141,9 +147,9 @@ It's expected that the `swig` binary exists in the host's path.
     },
 )
 
-def ortools_java_wrap_cc(
+def java_wrap_cc(
         name,
-        src,
+        srcs,
         package,
         deps = [],
         java_deps = [],
@@ -159,7 +165,7 @@ def ortools_java_wrap_cc(
 
     Args:
         name: target name.
-        src: single .i source file.
+        srcs: A list of one <code>swig</code> source.
         package: package of generated Java files.
         deps: C++ deps.
         java_deps: Java deps.
@@ -183,7 +189,7 @@ def ortools_java_wrap_cc(
 
     _java_wrap_cc(
         name = wrapper_name,
-        src = src,
+        srcs = srcs,
         package = package,
         outfile = outfile,
         outhdr = outhdr if use_directors else None,

--- a/ortools/algorithms/java/BUILD.bazel
+++ b/ortools/algorithms/java/BUILD.bazel
@@ -13,16 +13,16 @@
 
 # Description: java wrapping of the C++ code at ../
 
-load("//bazel:swig_java.bzl", "ortools_java_wrap_cc")
+load("//bazel:swig_java.bzl", "java_wrap_cc")
 
-ortools_java_wrap_cc(
+java_wrap_cc(
     name = "knapsacksolver",
-    src = "knapsack_solver.swig",
+    srcs = ["knapsack_solver.swig"],
     module = "operations_research_algorithms",
     package = "com.google.ortools.algorithms",
     swig_includes = [
         "//ortools/base:base_swig",
-        "//ortools/util/java:vector_swig",
+        "//ortools/util/java:vector.swig",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/ortools/graph/java/BUILD.bazel
+++ b/ortools/graph/java/BUILD.bazel
@@ -15,11 +15,11 @@
 
 load("@contrib_rules_jvm//java:defs.bzl", "java_junit5_test")
 load("@rules_jvm_external//:defs.bzl", "artifact")
-load("//bazel:swig_java.bzl", "ortools_java_wrap_cc")
+load("//bazel:swig_java.bzl", "java_wrap_cc")
 
-ortools_java_wrap_cc(
+java_wrap_cc(
     name = "graph",
-    src = "graph.swig",
+    srcs = ["graph.swig"],
     module = "graph",
     package = "com.google.ortools.graph",
     swig_includes = [

--- a/ortools/init/java/BUILD.bazel
+++ b/ortools/init/java/BUILD.bazel
@@ -13,16 +13,16 @@
 
 # Description: java wrapping of the C++ code at ../
 
-load("//bazel:swig_java.bzl", "ortools_java_wrap_cc")
+load("//bazel:swig_java.bzl", "java_wrap_cc")
 
-ortools_java_wrap_cc(
+java_wrap_cc(
     name = "init",
-    src = "init.i",
+    srcs = ["init.i"],
     module = "operations_research_init",
     package = "com.google.ortools.init",
     swig_includes = [
         "//ortools/base:base_swig",
-        "//ortools/util/java:absl_string_view_swig",
+        "//ortools/util/java:absl_string_view.swig",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/ortools/java/com/google/ortools/BUILD.bazel
+++ b/ortools/java/com/google/ortools/BUILD.bazel
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_java//java:java_library.bzl", "java_library")
 
 # Utilities to load native libraries in java or-tools.
 cc_binary(

--- a/ortools/java/com/google/ortools/modelbuilder/BUILD.bazel
+++ b/ortools/java/com/google/ortools/modelbuilder/BUILD.bazel
@@ -11,6 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_java//java:java_library.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 # Utilities to load native libraries in java or-tools.

--- a/ortools/java/com/google/ortools/sat/BUILD.bazel
+++ b/ortools/java/com/google/ortools/sat/BUILD.bazel
@@ -11,6 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_java//java:java_library.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 # Utilities to load native libraries in java or-tools.

--- a/ortools/linear_solver/java/BUILD.bazel
+++ b/ortools/linear_solver/java/BUILD.bazel
@@ -15,16 +15,16 @@
 
 load("@contrib_rules_jvm//java:defs.bzl", "java_junit5_test")
 load("@rules_jvm_external//:defs.bzl", "artifact")
-load("//bazel:swig_java.bzl", "ortools_java_wrap_cc")
+load("//bazel:swig_java.bzl", "java_wrap_cc")
 
-ortools_java_wrap_cc(
+java_wrap_cc(
     name = "modelbuilder",
-    src = "modelbuilder.swig",
+    srcs = ["modelbuilder.swig"],
     module = "modelbuilder",
     package = "com.google.ortools.modelbuilder",
     swig_includes = [
         "//ortools/base:base_swig",
-        "//ortools/util/java:vector_swig",
+        "//ortools/util/java:vector.swig",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/ortools/sat/java/BUILD.bazel
+++ b/ortools/sat/java/BUILD.bazel
@@ -15,23 +15,23 @@
 
 load("@contrib_rules_jvm//java:defs.bzl", "java_junit5_test")
 load("@rules_jvm_external//:defs.bzl", "artifact")
-load("//bazel:swig_java.bzl", "ortools_java_wrap_cc")
+load("//bazel:swig_java.bzl", "java_wrap_cc")
 
-ortools_java_wrap_cc(
+java_wrap_cc(
     name = "sat",
-    src = "sat.swig",
+    srcs = ["sat.swig"],
     java_deps = [
         "//ortools/sat:cp_model_java_proto",
         "//ortools/sat:sat_parameters_java_proto",
-        "//ortools/util/java:sorted_interval_list",
+        "//ortools/util/java:sorted_interval_list_swig",
         "@protobuf//java/core",
     ],
     package = "com.google.ortools.sat",
     swig_includes = [
         "//ortools/base:base_swig",
-        "//ortools/util/java:proto_swig",
-        "//ortools/util/java:sorted_interval_list_swig",
-        "//ortools/util/java:vector_swig",
+        "//ortools/util/java:proto.i",
+        "//ortools/util/java:sorted_interval_list.swig",
+        "//ortools/util/java:vector.swig",
     ],
     use_directors = True,
     visibility = ["//visibility:public"],

--- a/ortools/util/java/BUILD.bazel
+++ b/ortools/util/java/BUILD.bazel
@@ -11,48 +11,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Description: java wrapping of the code in ../
+# Description: java wrapping of (some of) the code in ../, plus
+# some generic utilities for SWIG java.
 
-load("//bazel:swig_java.bzl", "ortools_java_wrap_cc")
+load("//bazel:swig_java.bzl", "java_wrap_cc")
 
-filegroup(
-    name = "vector_swig",
-    srcs = [
+# These .swig files are currently just included in other .swig files.
+# TODO(user): Create dedicated java_wrap_cc rules and unit tests.
+exports_files(
+    [
+        "absl_string_view.swig",
+        "proto.i",
+        "sorted_interval_list.swig",
+        "tuple_set.swig",
         "vector.swig",
     ],
-    visibility = ["//visibility:public"],
 )
 
-filegroup(
-    name = "proto_swig",
-    srcs = [
-        "proto.i",
-    ],
-    visibility = ["//visibility:public"],
-)
-
-filegroup(
-    name = "absl_string_view_swig",
-    srcs = [
-        "absl_string_view.swig",
-    ],
-    visibility = ["//visibility:public"],
-)
-
-filegroup(
+java_wrap_cc(
     name = "sorted_interval_list_swig",
-    srcs = [
-        "sorted_interval_list.swig",
-    ],
-    visibility = ["//visibility:public"],
-)
-
-ortools_java_wrap_cc(
-    name = "sorted_interval_list",
-    src = "sorted_interval_list.swig",
+    srcs = ["sorted_interval_list.swig"],
     package = "com.google.ortools.util",
     swig_includes = [
-        ":vector_swig",
+        ":vector.swig",
         "//ortools/base:base_swig",
     ],
     swig_opt = select({
@@ -61,6 +42,7 @@ ortools_java_wrap_cc(
     }),
     visibility = ["//visibility:public"],
     deps = [
+        "//ortools/base",
         "//ortools/util:sorted_interval_list",
     ],
 )


### PR DESCRIPTION
This change makes the oss code closer to the internal code which helps keep the two in sync.