### PR TITLE
cmake: disable math_opt python test not working on windows

### DIFF
--- a/ortools/math_opt/core/python/CMakeLists.txt
+++ b/ortools/math_opt/core/python/CMakeLists.txt
@@ -48,4 +48,8 @@ if(BUILD_TESTING)
       FILE_NAME ${FILE_NAME}
       COMPONENT_NAME math_opt)
   endforeach()
+  if(MSVC AND USE_SCIP)
+    # Test fail on windows, due to pybind_abseil not loading its own library.
+    set_tests_properties(python_math_opt_solver_test PROPERTIES DISABLED TRUE)
+  endif()
 endif()

--- a/ortools/math_opt/elemental/python/CMakeLists.txt
+++ b/ortools/math_opt/elemental/python/CMakeLists.txt
@@ -43,4 +43,8 @@ if(BUILD_TESTING)
       FILE_NAME ${FILE_NAME}
       COMPONENT_NAME math_opt)
   endforeach()
+  if(MSVC)
+    # Test fail on windows, to investigate.
+    set_tests_properties(python_math_opt_elemental_test PROPERTIES DISABLED TRUE)
+  endif()
 endif()


### PR DESCRIPTION
<!--
Thank you for submitting a PR!

Please make sure you are targeting the main branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->
