### PR TITLE
sat: disable fuzztest tests except on linux

### DIFF
--- a/ortools/sat/BUILD.bazel
+++ b/ortools/sat/BUILD.bazel
@@ -3706,6 +3706,10 @@ cc_test(
     name = "diffn_util_test",
     size = "small",
     srcs = ["diffn_util_test.cc"],
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     deps = [
         ":2d_orthogonal_packing_testing",
         ":diffn_util",


### PR DESCRIPTION
Typical trace on amd64 Macos Bazel Build:

```
[9,353 / 10,048] [Prepa] Linking ortools/sat/diffn_util_test
[9,400 / 10,048] Linking ortools/sat/diffn_util_test; 1s darwin-sandbox
ERROR: /Users/runner/work/or-tools/or-tools/ortools/sat/BUILD.bazel:3705:8: Linking ortools/sat/diffn_util_test failed: (Exit 1): cc_wrapper.sh failed: error executing CppLink command (from target //ortools/sat:diffn_util_test) external/rules_cc++cc_configure_extension+local_config_cc/cc_wrapper.sh @bazel-out/darwin_x86_64-fastbuild/bin/ortools/sat/diffn_util_test-0.params

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
ld: warning: ignoring duplicate libraries: '-lm', '-lpthread'
ld: Undefined symbols:
  highwayhash::HighwayHash<2u>::operator()(unsigned long long const (&) [4], char const*, unsigned long, unsigned long long*) const, referenced from:
      riegeli::chunk_encoding_internal::Hash(std::__1::basic_string_view<char, std::__1::char_traits<char>>) in libhash.a[2](hash.o)
      riegeli::chunk_encoding_internal::Hash(riegeli::Chain const&) in libhash.a[2](hash.o)
  highwayhash::HighwayHash<4u>::operator()(unsigned long long const (&) [4], char const*, unsigned long, unsigned long long*) const, referenced from:
      riegeli::chunk_encoding_internal::Hash(std::__1::basic_string_view<char, std::__1::char_traits<char>>) in libhash.a[2](hash.o)
      riegeli::chunk_encoding_internal::Hash(riegeli::Chain const&) in libhash.a[2](hash.o)
  highwayhash::HighwayHashCat<2u>::operator()(unsigned long long const (&) [4], highwayhash::StringView const*, unsigned long, unsigned long long*) const, referenced from:
      riegeli::chunk_encoding_internal::Hash(riegeli::Chain const&) in libhash.a[2](hash.o)
  highwayhash::HighwayHashCat<4u>::operator()(unsigned long long const (&) [4], highwayhash::StringView const*, unsigned long, unsigned long long*) const, referenced from:
      riegeli::chunk_encoding_internal::Hash(riegeli::Chain const&) in libhash.a[2](hash.o)
clang: error: linker command failed with exit code 1 (use -v to see invocation)
INFO: Build succeeded for only 1683 of 1684 top-level targets
INFO: Found 1684 targets...
INFO: Elapsed time: 97.507s, Critical Path: 37.66s
INFO: 2 processes: 10874 action cache hit, 2 internal.
ERROR: Build did NOT complete successfully
Error: Process completed with exit code 1.
```