### PR TITLE
cmake: fix absl::status_matchers support

### DIFF
--- a/cmake/dependencies/CMakeLists.txt
+++ b/cmake/dependencies/CMakeLists.txt
@@ -110,6 +110,9 @@ if(BUILD_absl)
   set(ABSL_USE_SYSTEM_INCLUDES ON)
   # We want Abseil to declare what C++ standard it was compiled with.
   set(ABSL_PROPAGATE_CXX_STD ON)
+  set(ABSL_BUILD_TEST_HELPERS ON)
+  set(ABSL_USE_EXTERNAL_GOOGLETEST ON)
+  set(ABSL_FIND_GOOGLETEST OFF)
   # We want Abseil to keep the INSTALL rules enabled, even though it is a
   # subproject. Otherwise the install rules in this project break.
   set(ABSL_ENABLE_INSTALL ON)
@@ -527,8 +530,8 @@ if(BUILD_googletest)
     "${CMAKE_CURRENT_LIST_DIR}/../../patches/googletest-v1.17.0.patch"
   )
   set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-  set(INSTALL_GTEST OFF)
   set(GTEST_HAS_ABSL ON)
+  set(INSTALL_GTEST ON)
   FetchContent_MakeAvailable(googletest)
   list(POP_BACK CMAKE_MESSAGE_INDENT)
   message(CHECK_PASS "fetched")

--- a/ortools/base/CMakeLists.txt
+++ b/ortools/base/CMakeLists.txt
@@ -58,6 +58,7 @@ ortools_cxx_library(
   LINK_LIBRARIES
     absl::log
     absl::strings
+    absl::status_matchers
     GTest::gtest
     GTest::gmock
     protobuf::libprotobuf

--- a/patches/abseil-cpp-20250814.0.patch
+++ b/patches/abseil-cpp-20250814.0.patch
@@ -1,5 +1,18 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1e7c856..a3c3dae 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -145,7 +145,7 @@ if((BUILD_TESTING AND ABSL_BUILD_TESTING) OR ABSL_BUILD_TEST_HELPERS)
+         add_library(GTest::gmock ALIAS gmock)
+         add_library(GTest::gmock_main ALIAS gmock_main)
+       else()
+-        message(FATAL_ERROR "ABSL_USE_EXTERNAL_GOOGLETEST is ON and ABSL_FIND_GOOGLETEST is OFF, which means that the top-level project must build the Google Test project. However, the target gtest was not found.")
++        message(WARNING "ABSL_USE_EXTERNAL_GOOGLETEST is ON and ABSL_FIND_GOOGLETEST is OFF, which means that the top-level project must build the Google Test project. However, the target gtest was not found.")
+       endif()
+     endif()
+   else()
 diff --git a/absl/flags/declare.h b/absl/flags/declare.h
-index 8d2a856e..a1540467 100644
+index 8d2a856..a154046 100644
 --- a/absl/flags/declare.h
 +++ b/absl/flags/declare.h
 @@ -59,10 +59,15 @@ ABSL_NAMESPACE_END
@@ -19,7 +32,7 @@ index 8d2a856e..a1540467 100644
  
  #endif  // ABSL_FLAGS_DECLARE_H_
 diff --git a/absl/log/CMakeLists.txt b/absl/log/CMakeLists.txt
-index eb19bec0..13b2d240 100644
+index eb19bec..13b2d24 100644
 --- a/absl/log/CMakeLists.txt
 +++ b/absl/log/CMakeLists.txt
 @@ -47,6 +47,7 @@ absl_cc_library(
@@ -31,7 +44,7 @@ index eb19bec0..13b2d240 100644
      absl::log_internal_nullguard
      absl::log_internal_nullstream
 diff --git a/absl/log/check_test_impl.inc b/absl/log/check_test_impl.inc
-index 5a7caf47..7bcedd40 100644
+index 5a7caf4..7bcedd4 100644
 --- a/absl/log/check_test_impl.inc
 +++ b/absl/log/check_test_impl.inc
 @@ -13,6 +13,8 @@
@@ -63,7 +76,7 @@ index 5a7caf47..7bcedd40 100644
  enum { CASE_A, CASE_B };
  
 diff --git a/absl/log/internal/BUILD.bazel b/absl/log/internal/BUILD.bazel
-index 1ba9d766..005861f9 100644
+index 1ba9d76..005861f 100644
 --- a/absl/log/internal/BUILD.bazel
 +++ b/absl/log/internal/BUILD.bazel
 @@ -82,6 +82,7 @@ cc_library(
@@ -75,7 +88,7 @@ index 1ba9d766..005861f9 100644
  )
  
 diff --git a/absl/log/internal/check_op.h b/absl/log/internal/check_op.h
-index 4554475d..c6078640 100644
+index 4554475..c607864 100644
 --- a/absl/log/internal/check_op.h
 +++ b/absl/log/internal/check_op.h
 @@ -40,6 +40,7 @@


### PR DESCRIPTION
This should fix the trace:
```
cmake -S. -Bbuild -DBUILD_DEPS=ON
cmake --build build --config Release --target algorithms_n_choose_k_test
...
#10 4350.3 /usr/bin/ld: CMakeFiles/algorithms_n_choose_k_test.dir/n_choose_k_test.cc.o: in function `absl_testing::lts_20250814::status_internal::MonoStatusIsMatcherImpl<absl::lts_20250814::StatusOr<long> const&>::DescribeTo(std::ostream*) const':
#10 4350.3 n_choose_k_test.cc:(.text._ZNK12absl_testing12lts_2025081415status_internal23MonoStatusIsMatcherImplIRKN4absl12lts_202508148StatusOrIlEEE10DescribeToEPSo[_ZNK12absl_testing12lts_2025081415status_internal23MonoStatusIsMatcherImplIRKN4absl12lts_202508148StatusOrIlEEE10DescribeToEPSo]+0x5): undefined reference to `absl_testing::lts_20250814::status_internal::StatusIsMatcherCommonImpl::DescribeTo(std::ostream*) const'
#10 4350.3 /usr/bin/ld: CMakeFiles/algorithms_n_choose_k_test.dir/n_choose_k_test.cc.o: in function `absl_testing::lts_20250814::status_internal::MonoStatusIsMatcherImpl<absl::lts_20250814::StatusOr<long> const&>::DescribeNegationTo(std::ostream*) const':
#10 4350.3 n_choose_k_test.cc:(.text._ZNK12absl_testing12lts_2025081415status_internal23MonoStatusIsMatcherImplIRKN4absl12lts_202508148StatusOrIlEEE18DescribeNegationToEPSo[_ZNK12absl_testing12lts_2025081415status_internal23MonoStatusIsMatcherImplIRKN4absl12lts_202508148StatusOrIlEEE18DescribeNegationToEPSo]+0x5): undefined reference to `absl_testing::lts_20250814::status_internal::StatusIsMatcherCommonImpl::DescribeNegationTo(std::ostream*) const'
#10 4350.3 /usr/bin/ld: CMakeFiles/algorithms_n_choose_k_test.dir/n_choose_k_test.cc.o: in function `absl_testing::lts_20250814::status_internal::MonoStatusIsMatcherImpl<absl::lts_20250814::StatusOr<long> const&>::MatchAndExplain(absl::lts_20250814::StatusOr<long> const&, testing::MatchResultListener*) const':
#10 4350.3 n_choose_k_test.cc:(.text._ZNK12absl_testing12lts_2025081415status_internal23MonoStatusIsMatcherImplIRKN4absl12lts_202508148StatusOrIlEEE15MatchAndExplainES8_PN7testing19MatchResultListenerE[_ZNK12absl_testing12lts_2025081415status_internal23MonoStatusIsMatcherImplIRKN4absl12lts_202508148StatusOrIlEEE15MatchAndExplainES8_PN7testing19MatchResultListenerE]+0x5): undefined reference to `absl_testing::lts_20250814::status_internal::StatusIsMatcherCommonImpl::MatchAndExplain(absl::lts_20250814::Status const&, testing::MatchResultListener*) const'
#10 4350.4 collect2: error: ld returned 1 exit status
```

ref: <https://github.com/google/or-tools/actions/runs/17850066421/job/50756770399#step:6:9013>