### PR TITLE
cmake: do not install absl testing only lib

### DIFF
--- a/patches/abseil-cpp-20250814.0.patch
+++ b/patches/abseil-cpp-20250814.0.patch
@@ -1,3 +1,16 @@
+diff --git a/CMake/AbseilHelpers.cmake b/CMake/AbseilHelpers.cmake
+index 624a3c7..8d0493d 100644
+--- a/CMake/AbseilHelpers.cmake
++++ b/CMake/AbseilHelpers.cmake
+@@ -345,7 +345,7 @@ Cflags: -I\${includedir}${PC_CFLAGS}\n")
+     endif()
+   endif()
+ 
+-  if(ABSL_ENABLE_INSTALL)
++  if(ABSL_ENABLE_INSTALL AND NOT ABSL_CC_LIB_TESTONLY)
+     install(TARGETS ${_NAME} EXPORT ${PROJECT_NAME}Targets
+           RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+           LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 1e7c856..a3c3dae 100644
 --- a/CMakeLists.txt


### PR DESCRIPTION
this should break the dependency cycle of abseil-cpp depending on GTest
which depends on abseil-cpp ...

<!--
Thank you for submitting a PR!

Please make sure you are targeting the main branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->
