### PR TITLE
Add constant term in DoubleLinearExpr::AddExpression

### DIFF
--- a/ortools/sat/cp_model.cc
+++ b/ortools/sat/cp_model.cc
@@ -409,13 +409,13 @@ DoubleLinearExpr& DoubleLinearExpr::AddTerm(BoolVar var, double coeff) {
 
 DoubleLinearExpr& DoubleLinearExpr::AddExpression(const LinearExpr& expr,
                                                   double coeff) {
+  constant_ += static_cast<double>(expr.constant()) * coeff;
   const std::vector<int>& indices = expr.variables();
   const std::vector<int64_t> coefficients = expr.coefficients();
   for (int i = 0; i < indices.size(); ++i) {
     variables_.push_back(indices[i]);
     coefficients_.push_back(1.0 * static_cast<double>(coefficients[i]) * coeff);
   }
-
   return *this;
 }
 


### PR DESCRIPTION
**What version of OR-Tools and what language are you using?**
Version: main
Language: C++

**Which solver are you using (e.g. CP-SAT, Routing Solver, GLOP, BOP, Gurobi)**
CP-SAT

**What operating system (Linux, Windows, ...) and version?**
Linux

**What did you do?**
Added the constant term from a `LinearExpr` to a `DoubleLinearExpr`.

**What did you expect to see**
The constant term from the `LinearExpr` correctly added to the `DoubleLinearExpr`.

**What did you see instead?**
The constant term from the `LinearExpr` was missing in the resulting `DoubleLinearExpr`.

**Anything else we should know about your project / environment**
N/A