### PR TITLE
ci: migrate rockylinux base image

### DIFF
--- a/bazel/docker/rockylinux/Dockerfile
+++ b/bazel/docker/rockylinux/Dockerfile
@@ -1,6 +1,6 @@
 # Create a virtual environment with all tools installed
-# ref: https://hub.docker.com/_/rockylinux
-FROM rockylinux:9 AS env
+# ref: https://hub.docker.com/rockylinux/rockylinux
+FROM rockylinux/rockylinux:9 AS env
 
 # Install system build dependencies
 ENV PATH=/usr/local/bin:$PATH

--- a/cmake/docker/rockylinux/Dockerfile
+++ b/cmake/docker/rockylinux/Dockerfile
@@ -1,6 +1,6 @@
 # Create a virtual environment with all tools installed
-# ref: https://hub.docker.com/_/rockylinux
-FROM rockylinux:9 AS base
+# ref: https://hub.docker.com/rockylinux/rockylinux
+FROM rockylinux/rockylinux:9 AS base
 
 # Install system build dependencies
 ENV PATH=/usr/local/bin:$PATH

--- a/tools/docker/images/rockylinux-9.Dockerfile
+++ b/tools/docker/images/rockylinux-9.Dockerfile
@@ -1,5 +1,5 @@
-# ref: https://hub.docker.com/_/rockylinux
-FROM rockylinux:9 AS env
+# ref: https://hub.docker.com/rockylinux/rockylinux
+FROM rockylinux/rockylinux:9 AS env
 
 #############
 ##  SETUP  ##

--- a/tools/docker/test/rockylinux-9/cpp.Dockerfile
+++ b/tools/docker/test/rockylinux-9/cpp.Dockerfile
@@ -1,5 +1,5 @@
-# ref: https://hub.docker.com/_/rockylinux
-FROM rockylinux:9
+# ref: https://hub.docker.com/rockylinux/rockylinux
+FROM rockylinux/rockylinux:9
 
 #############
 ##  SETUP  ##

--- a/tools/docker/test/rockylinux-9/dotnet.Dockerfile
+++ b/tools/docker/test/rockylinux-9/dotnet.Dockerfile
@@ -1,5 +1,5 @@
-# ref: https://hub.docker.com/_/rockylinux
-FROM rockylinux:9
+# ref: https://hub.docker.com/rockylinux/rockylinux
+FROM rockylinux/rockylinux:9
 
 #############
 ##  SETUP  ##

--- a/tools/docker/test/rockylinux-9/java.Dockerfile
+++ b/tools/docker/test/rockylinux-9/java.Dockerfile
@@ -1,5 +1,5 @@
-# ref: https://hub.docker.com/_/rockylinux
-FROM rockylinux:9
+# ref: https://hub.docker.com/rockylinux/rockylinux
+FROM rockylinux/rockylinux:9
 
 #############
 ##  SETUP  ##

--- a/tools/docker/test/rockylinux-9/python.Dockerfile
+++ b/tools/docker/test/rockylinux-9/python.Dockerfile
@@ -1,5 +1,5 @@
-# ref: https://hub.docker.com/_/rockylinux
-FROM rockylinux:9
+# ref: https://hub.docker.com/rockylinux/rockylinux
+FROM rockylinux/rockylinux:9
 
 #############
 ##  SETUP  ##


### PR DESCRIPTION
> The Docker team curates the Official Images program,
and there are currently some technical constraints preventing
Rocky Linux from publishing updates here. For the most
up-to-date container images, please refer to the Rocky Linux
Docker Hub repository for now.

ref: https://hub.docker.com/_/rockylinux

<!--
Thank you for submitting a PR!

Please make sure you are targeting the main branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->
