### PR TITLE
cmake: system_deps build googletest

### DIFF
--- a/cmake/docker/system_deps/Dockerfile
+++ b/cmake/docker/system_deps/Dockerfile
@@ -12,7 +12,7 @@ RUN pacman -Syu --noconfirm \
  coin-or-cbc coin-or-clp \
  glpk \
  scip \
- gtest benchmark
+ benchmark
 
 ENTRYPOINT ["/bin/bash", "-c"]
 CMD [ "/bin/bash" ]

--- a/cmake/docker/system_deps/cpp.Dockerfile
+++ b/cmake/docker/system_deps/cpp.Dockerfile
@@ -11,7 +11,8 @@ RUN cmake -S. -Bbuild -DBUILD_DEPS=OFF \
  -DUSE_COINOR=ON \
  -DUSE_GLPK=ON \
  -DUSE_HIGHS=OFF \
- -DUSE_SCIP=ON
+ -DUSE_SCIP=ON \
+ -DBUILD_googletest=ON
 RUN cmake --build build --target all -v
 RUN cmake --build build --target install
 

--- a/cmake/docker/system_deps/dotnet.Dockerfile
+++ b/cmake/docker/system_deps/dotnet.Dockerfile
@@ -15,7 +15,8 @@ RUN cmake -S. -Bbuild -DBUILD_DEPS=OFF \
  -DUSE_HIGHS=OFF \
  -DUSE_SCIP=ON \
  -DBUILD_DOTNET=ON \
- -DBUILD_CXX_SAMPLES=OFF -DBUILD_CXX_EXAMPLES=OFF
+ -DBUILD_CXX_SAMPLES=OFF -DBUILD_CXX_EXAMPLES=OFF \
+ -DBUILD_googletest=ON
 RUN cmake --build build --target all -v
 RUN cmake --build build --target install
 

--- a/cmake/docker/system_deps/java.Dockerfile
+++ b/cmake/docker/system_deps/java.Dockerfile
@@ -14,7 +14,8 @@ RUN cmake -S. -Bbuild -DBUILD_DEPS=OFF \
  -DUSE_HIGHS=OFF \
  -DUSE_SCIP=ON \
  -DBUILD_JAVA=ON -DSKIP_GPG=ON \
- -DBUILD_CXX_SAMPLES=OFF -DBUILD_CXX_EXAMPLES=OFF
+ -DBUILD_CXX_SAMPLES=OFF -DBUILD_CXX_EXAMPLES=OFF \
+ -DBUILD_googletest=ON
 RUN cmake --build build --target all -v
 RUN cmake --build build --target install
 

--- a/cmake/docker/system_deps/python.Dockerfile
+++ b/cmake/docker/system_deps/python.Dockerfile
@@ -23,7 +23,8 @@ RUN cmake -S. -Bbuild -DBUILD_DEPS=OFF \
  -DUSE_HIGHS=OFF \
  -DUSE_SCIP=ON \
  -DBUILD_PYTHON=ON \
- -DBUILD_CXX_SAMPLES=OFF -DBUILD_CXX_EXAMPLES=OFF
+ -DBUILD_CXX_SAMPLES=OFF -DBUILD_CXX_EXAMPLES=OFF \
+ -DBUILD_googletest=ON
 RUN cmake --build build --target all -v
 RUN cmake --build build --target install
 


### PR DESCRIPTION
TLDR: have to built it to have string_view support

long story: currently you can built googletest with or without abseil-cpp, BUT if you built it without (like most distro do) then you won't have `std::string_view` (using `absl::string_view` alias) support in all googletest API...

in google3 we do use use absl::string_view with googletest so it is mandatory to have absl support in googletest when exporting or-tools tests...
