### PR TITLE
cmake(ci): split amd64 cmake dotnet workflows to avoid space limit

### DIFF
--- a/.github/workflows/amd64_linux_cmake_dotnet.yml
+++ b/.github/workflows/amd64_linux_cmake_dotnet.yml
@@ -20,7 +20,14 @@ env:
 
 jobs:
   native:
-    name: amd64•Linux•CMake•.Net
+    strategy:
+      matrix:
+        config: [
+          {name: "examples", flags: "-DBUILD_DOTNET_EXAMPLES=ON -DBUILD_DOTNET_SAMPLES=OFF"},
+          {name: "samples", flags: "-DBUILD_DOTNET_EXAMPLES=OFF -DBUILD_DOTNET_SAMPLES=ON"},
+        ]
+      fail-fast: false
+    name: amd64•Linux•CMake•.Net(${{matrix.config.name}})
     runs-on: ubuntu-latest
     env:
       deps_src_key: amd64_linux_dotnet_deps_src
@@ -71,6 +78,7 @@ jobs:
           -G "Ninja"
           -DCMAKE_BUILD_TYPE=Release
           -DBUILD_CXX_SAMPLES=OFF -DBUILD_CXX_EXAMPLES=OFF
+          ${{matrix.config.flags}}
           -DBUILD_DOTNET=ON
           -DCMAKE_INSTALL_PREFIX=install
       - name: Build


### PR DESCRIPTION
<!--
Thank you for submitting a PR!

Please make sure you are targeting the main branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->
