### PR TITLE
algorithms: disable knapsack_solver_test.py if SCIP no unavailable

### DIFF
--- a/ortools/algorithms/python/CMakeLists.txt
+++ b/ortools/algorithms/python/CMakeLists.txt
@@ -33,6 +33,9 @@ add_library(${PROJECT_NAMESPACE}::knapsack_solver_pybind11 ALIAS knapsack_solver
 
 if(BUILD_TESTING)
   file(GLOB PYTHON_SRCS "*_test.py")
+  if(NOT USE_SCIP)
+    list(FILTER PYTHON_SRCS EXCLUDE REGEX "knapsack_solver_test.py$")
+  endif()
   foreach(FILE_NAME IN LISTS PYTHON_SRCS)
     add_python_test(FILE_NAME ${FILE_NAME})
   endforeach()


### PR DESCRIPTION
some knapsack solver tests rely on scip, so to mitigate we currently disable this test when SCIP support is off.

Currently:
1) we can't probe from the KnapsackSolver API if the underlying solver is available
2) Recent change in linear solver (solver registration) make the test crash when the solver is unavailable. (internal CHECK make the code crash instead of returning an exception ?)

here the exception is never throw
https://github.com/google/or-tools/blob/7a4d9960cf2fd3025c8e1dba9ac961e2dfb7b43c/ortools/algorithms/python/knapsack_solver_test.py#L77-L86
instead this call make the program exit
https://github.com/google/or-tools/blob/7a4d9960cf2fd3025c8e1dba9ac961e2dfb7b43c/ortools/algorithms/python/knapsack_solver_test.py#L27
