### PR TITLE
Refactor MPSolver interface registration to include runtime readiness checks.

### DIFF
--- a/ortools/linear_solver/gurobi_interface.cc
+++ b/ortools/linear_solver/gurobi_interface.cc
@@ -1417,7 +1417,8 @@ namespace {
 const void* const kRegisterGurobiLp ABSL_ATTRIBUTE_UNUSED = [] {
   MPSolverInterfaceFactoryRepository::GetInstance()->Register(
       [](MPSolver* solver) { return new GurobiInterface(solver, false); },
-      MPSolver::GUROBI_LINEAR_PROGRAMMING);
+      MPSolver::GUROBI_LINEAR_PROGRAMMING,
+      []() { return GurobiIsCorrectlyInstalled(); });
   return nullptr;
 }();
 
@@ -1425,7 +1426,8 @@ const void* const kRegisterGurobiLp ABSL_ATTRIBUTE_UNUSED = [] {
 const void* const kRegisterGurobiMip ABSL_ATTRIBUTE_UNUSED = [] {
   MPSolverInterfaceFactoryRepository::GetInstance()->Register(
       [](MPSolver* solver) { return new GurobiInterface(solver, true); },
-      MPSolver::GUROBI_MIXED_INTEGER_PROGRAMMING);
+      MPSolver::GUROBI_MIXED_INTEGER_PROGRAMMING,
+      []() { return GurobiIsCorrectlyInstalled(); });
   return nullptr;
 }();
 

--- a/ortools/linear_solver/xpress_interface.cc
+++ b/ortools/linear_solver/xpress_interface.cc
@@ -2289,7 +2289,8 @@ namespace {
 const void* const kRegisterXpress ABSL_ATTRIBUTE_UNUSED = [] {
   MPSolverInterfaceFactoryRepository::GetInstance()->Register(
       [](MPSolver* const solver) { return new XpressInterface(solver, false); },
-      MPSolver::XPRESS_LINEAR_PROGRAMMING);
+      MPSolver::XPRESS_LINEAR_PROGRAMMING,
+      []() { return XpressIsCorrectlyInstalled(); });
   return nullptr;
 }();
 
@@ -2297,7 +2298,8 @@ const void* const kRegisterXpress ABSL_ATTRIBUTE_UNUSED = [] {
 const void* const kRegisterXpressMip ABSL_ATTRIBUTE_UNUSED = [] {
   MPSolverInterfaceFactoryRepository::GetInstance()->Register(
       [](MPSolver* const solver) { return new XpressInterface(solver, true); },
-      MPSolver::XPRESS_MIXED_INTEGER_PROGRAMMING);
+      MPSolver::XPRESS_MIXED_INTEGER_PROGRAMMING,
+      []() { return XpressIsCorrectlyInstalled(); });
   return nullptr;
 }();
 


### PR DESCRIPTION
This PR is removing the need for `linear_solver` to depend on `GurobiIsCorrectlyInstalled` and `XpressIsCorrectlyInstalled`.
