### PR TITLE
Use _WIN32 instead of _MSC_VER for _USE_MATH_DEFINES

### DIFF
--- a/ortools/base/mathutil.cc
+++ b/ortools/base/mathutil.cc
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 #include "absl/log/check.h"
-#if defined(_MSC_VER)
+#if defined(_WIN32)
 #define _USE_MATH_DEFINES
 #include <cmath>
 #endif


### PR DESCRIPTION
In hopes of propelling the Julia integration of OR Tools, I expanded the availability via Julia's cross-compilation; see [#12900](https://github.com/JuliaPackaging/Yggdrasil/pull/12900) and [#12999](https://github.com/JuliaPackaging/Yggdrasil/pull/12999)

We encountered one small issue where only MSVC is supported but no other Windows compilers. I would appreciate it if this could be done for windows in general.
