### PR TITLE
linear_solver: implement logcallback for HiGHS

### DIFF
--- a/ortools/linear_solver/java/ModelBuilderTest.java
+++ b/ortools/linear_solver/java/ModelBuilderTest.java
@@ -152,4 +152,25 @@ public final class ModelBuilderTest {
     assertThat(model.varFromIndex(0).getUpperBound()).isEqualTo(42.0);
     assertThat(model.varFromIndex(0).getName()).isEqualTo("x");
   }
+
+  @Test
+  public void highsLogCallback_receivesLogsWhenEnabled() {
+    ModelBuilder model = new ModelBuilder();
+    double infinity = Double.POSITIVE_INFINITY;
+    Variable x = model.newNumVar(0.0, infinity, "x");
+    Variable y = model.newNumVar(0.0, infinity, "y");
+    model.addLessOrEqual(LinearExpr.sum(new Variable[] {x, y}), 10.0);
+    model.maximize(LinearExpr.newBuilder().addTerm(x, 1.0).addTerm(y, 2.0));
+
+    ModelSolver solver = new ModelSolver("highs");
+    if (!solver.solverIsSupported()) {
+      return;
+    }
+    StringBuilder log = new StringBuilder();
+    solver.setLogCallback(msg -> log.append(msg));
+    solver.enableOutput(true);
+    assertThat(solver.solve(model)).isEqualTo(SolveStatus.OPTIMAL);
+    assertThat(log.length()).isGreaterThan(0);
+    assertThat(log.toString()).contains("Model");
+  }
 }

--- a/ortools/linear_solver/proto_solver/highs_proto_solver.h
+++ b/ortools/linear_solver/proto_solver/highs_proto_solver.h
@@ -15,6 +15,8 @@
 #define ORTOOLS_LINEAR_SOLVER_PROTO_SOLVER_HIGHS_PROTO_SOLVER_H_
 
 #include <cstdint>
+#include <functional>
+#include <string>
 
 #include "absl/status/statusor.h"
 #include "ortools/linear_solver/linear_solver.pb.h"
@@ -28,10 +30,12 @@ struct HighsSolveInfo {
 };
 
 // Solve the input MIP model with the HIGHS solver and fills `solve_info` if
-// provided.
+// provided. When `logging_callback` is non-null and points to a callable
+// function, solver log messages are sent to it instead of the console.
 absl::StatusOr<MPSolutionResponse> HighsSolveProto(
     LazyMutableCopy<MPModelRequest> request,
-    HighsSolveInfo* solve_info = nullptr);
+    HighsSolveInfo* solve_info = nullptr,
+    const std::function<void(const std::string&)>* logging_callback = nullptr);
 
 }  // namespace operations_research
 

--- a/ortools/linear_solver/python/model_builder_helper.cc
+++ b/ortools/linear_solver/python/model_builder_helper.cc
@@ -47,6 +47,7 @@
 #include "ortools/linear_solver/model_exporter.h"
 #include "pybind11/cast.h"
 #include "pybind11/eigen.h"
+#include "pybind11/functional.h"
 #include "pybind11/numpy.h"
 #include "pybind11/pybind11.h"
 #include "pybind11/pytypes.h"

--- a/ortools/linear_solver/python/model_builder_test.py
+++ b/ortools/linear_solver/python/model_builder_test.py
@@ -205,6 +205,23 @@ ENDATA
         self.assertEqual(42, model.var_from_index(0).upper_bound)
         self.assertEqual("x", model.var_from_index(0).name)
 
+    def test_highs_log_callback_receives_logs_when_enabled(self):
+        model = mb.Model()
+        x = model.new_num_var(0.0, math.inf, "x")
+        y = model.new_num_var(0.0, math.inf, "y")
+        model.add(x + y <= 10.0)
+        model.maximize(1.0 * x + 2.0 * y)
+
+        solver = mb.Solver("highs")
+        if not solver.solver_is_supported():
+            return
+        log_lines = []
+        solver.log_callback = log_lines.append
+        solver.enable_output(True)
+        self.assertEqual(solver.solve(model), mb.SolveStatus.OPTIMAL)
+        self.assertGreater(len(log_lines), 0, "Log callback should receive output")
+        self.assertIn("Model", "".join(log_lines))
+
     def test_class_api(self):
         model = mb.Model()
         x = model.new_int_var(0, 10, "x")

--- a/ortools/linear_solver/wrappers/model_builder_helper.cc
+++ b/ortools/linear_solver/wrappers/model_builder_helper.cc
@@ -619,9 +619,8 @@ void ModelSolverHelper::Solve(const ModelBuilderHelper& model) {
 #if defined(USE_HIGHS)
     case MPModelRequest::HIGHS_LINEAR_PROGRAMMING:  // ABSL_FALLTHROUGH_INTENDED
     case MPModelRequest::HIGHS_MIXED_INTEGER_PROGRAMMING: {
-      // TODO(user): Enable log_callback support.
       // TODO(user): Enable interrupt_solve.
-      const auto temp = HighsSolveProto(std::move(request));
+      const auto temp = HighsSolveProto(std::move(request), nullptr, &log_callback_);
       if (temp.ok()) {
         response_ = std::move(temp.value());
       }


### PR DESCRIPTION
implement logcallback for HiGHS solver by calling `setLogCalllback` in Java/Python