### PR TITLE
cmake(ci): Fix dotnet setup in debian docker

### DIFF
--- a/cmake/docker/debian/dotnet.Dockerfile
+++ b/cmake/docker/debian/dotnet.Dockerfile
@@ -3,7 +3,7 @@ FROM ortools/cmake:debian_swig AS env
 # see: https://docs.microsoft.com/en-us/dotnet/core/install/linux-debian
 RUN apt-get update -qq \
 && apt-get install -yq wget gpg apt-transport-https \
-&& wget -q "https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb" -O packages-microsoft-prod.deb \
+&& wget -q "https://packages.microsoft.com/config/debian/13/packages-microsoft-prod.deb" -O packages-microsoft-prod.deb \
 && dpkg -i packages-microsoft-prod.deb \
 && rm packages-microsoft-prod.deb \
 && apt-get update -qq \


### PR DESCRIPTION
note: now debian:latest target debian 13 (Trixies) so we have to update the microsoft feed