### PR TITLE
Add XPRESS to Python MathOpt SolverType enum

### DIFF
--- a/ortools/math_opt/python/parameters.py
+++ b/ortools/math_opt/python/parameters.py
@@ -77,6 +77,8 @@ class SolverType(enum.Enum):
         QPs are unimplemented).
       SANTORINI: The Santorini Solver (first party). Supports MIP. Experimental,
         do not use in production.
+      XPRESS: FICO Xpress solver (third party). Supports LP, MIP, and QP/MIQP
+        problems. Requires a local Xpress installation with XPRESSDIR set.
     """
 
     GSCIP = math_opt_parameters_pb2.SOLVER_TYPE_GSCIP
@@ -90,6 +92,7 @@ class SolverType(enum.Enum):
     SCS = math_opt_parameters_pb2.SOLVER_TYPE_SCS
     HIGHS = math_opt_parameters_pb2.SOLVER_TYPE_HIGHS
     SANTORINI = math_opt_parameters_pb2.SOLVER_TYPE_SANTORINI
+    XPRESS = math_opt_parameters_pb2.SOLVER_TYPE_XPRESS
 
 
 def solver_type_from_proto(


### PR DESCRIPTION
## Summary
Expose the Xpress solver in the Python MathOpt API by adding `XPRESS` to the `SolverType` enum.

## Changes
- Add `XPRESS` enum value mapping to `SOLVER_TYPE_XPRESS` protobuf
- Add docstring entry describing Xpress capabilities (LP, MIP, QP/MIQP)

## Context
The underlying C++ MathOpt implementation and protobuf definition already support Xpress. This small change makes it accessible from Python/MathOpt.

## Testing
This is a minimal change exposing an existing protobuf enum value. The Xpress MathOpt solver implementation (C++) already has test coverage. No new tests are required as this simply wires up the existing `SOLVER_TYPE_XPRESS` to the Python enum.

## CLA
Signed.