### PR TITLE
bazel: fix gLinux gcc based build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,12 @@
 # Enable logging rc options.
 common --announce_rc
 
+# Mitigate gLinux gcc-15.2.0-3 defaults to -Wa,-gsframe, causing:
+# "relocation refers to a discarded section: " linker error
+# see: https://github.com/llvm/llvm-project/issues/156667
+common:linux --copt=-Wa,--gsframe=no
+common:linux --host_copt=-Wa,--gsframe=no
+
 ###############################################################################
 # Global options for building OR-Tools.
 ###############################################################################


### PR DESCRIPTION
related to: https://github.com/llvm/llvm-project/issues/156667#issuecomment-3252227547

gcc-15 version:
* GLinux is using `15.2.0`**-3**,
* Ubuntu 26.04 is using `gcc (Ubuntu 15.2.0-12ubuntu1) `,
* Ubuntu 25.10 is using `gcc (Ubuntu 15.2.0-4ubuntu4)`

ref: https://yaqs.corp.google.com/eng/q/3916204231928840192#a2

## GCC official image
```sh
$ docker run --rm --init -it gcc:15 bash -c "as --help | grep gsframe"
  --gsframe               generate SFrame stack trace information
  ```
  
## Ubuntu 26.04 LTS official image
  ```sh
$   docker run --rm --init -it ubuntu:26.04 bash -c "apt update -qq && apt install -yq gcc && as --help | grep gsframe"
...
  --gsframe[={no|yes}]    whether to generate SFrame stack trace information
  --gsframe-<N>           generate SFrame version <N> information. 3 == <N>
  ```
  
## gLinux
  ```sh
$ as --help | grep gsframe
--gsframe[={no|yes}]    whether to generate SFrame stack trace information
  ```
  
Thus, `gsframe=[yes/no]` seems not to be available for all gcc version and can't be added to `.bazelrc`, 

