### PR TITLE
bazel: improve windows support

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -60,6 +60,8 @@ build:macos --cxxopt=-mmacos-version-min=10.15 --host_cxxopt=-mmacos-version-min
 ###############################################################################
 
 build:windows --cxxopt=/std:c++20 --host_cxxopt=/std:c++20
+# Enable preprocessor conformance mode needed to correctly support __VA_OPT__
+build:windows --cxxopt=/Zc:preprocessor --host_cxxopt=/Zc:preprocessor
 
 # Enable the runfiles symlink tree on Windows. This makes it possible to build
 # the pip package on Windows without an intermediate data-file archive, as the

--- a/.github/workflows/amd64_windows_bazel.yml
+++ b/.github/workflows/amd64_windows_bazel.yml
@@ -47,8 +47,7 @@ jobs:
           python-version: ${{matrix.python.version}}
       - name: Check Python
         run: python --version
-      - name: Install Bazel
-        run: choco install bazel
+      - uses: bazel-contrib/setup-bazel@0.15.0
       - name: Check Bazel
         run: bazel version
       - name: Restore bazel cache


### PR DESCRIPTION

typical trace:
```
ortools/linear_solver/proto_solver/sat_solver_utils.cc(72): error C2146: syntax error: missing ')' before identifier '__VA_OPT__'
ortools/linear_solver/proto_solver/sat_solver_utils.cc(72): error C2146: syntax error: missing ';' before identifier '__VA_OPT__'
ortools/linear_solver/proto_solver/sat_solver_utils.cc(72): error C2143: syntax error: missing ')' before ','
ortools/linear_solver/proto_solver/sat_solver_utils.cc(72): error C3861: '__VA_OPT__': identifier not found
ortools/linear_solver/proto_solver/sat_solver_utils.cc(72): error C2059: syntax error: ')'
ortools/linear_solver/proto_solver/sat_solver_utils.cc(72): error C2059: syntax error: ';'
```