### PR TITLE
cmake: fix scip tinycthread.c build

### DIFF
--- a/patches/scip-v10.0.0.patch
+++ b/patches/scip-v10.0.0.patch
@@ -107,3 +107,33 @@ index c6ce7283..6b6b1fc8 100644
  install(FILES "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/scip-config.cmake"
                ${PROJECT_BINARY_DIR}/scip-config-version.cmake
          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/scip)
+diff --git a/src/tinycthread/tinycthread.h b/src/tinycthread/tinycthread.h
+index e0f4823c..29ca4f1e 100644
+--- a/src/tinycthread/tinycthread.h
++++ b/src/tinycthread/tinycthread.h
+@@ -450,8 +450,12 @@ int tss_set(tss_t key, void *val);
+   } once_flag;
+   #define ONCE_FLAG_INIT {0,}
+ #else
+-  #define once_flag pthread_once_t
+-  #define ONCE_FLAG_INIT PTHREAD_ONCE_INIT
++  /* Check if the system already provides C11 threads or once_flag */
++  #if !defined(__once_flag_defined)
++    typedef pthread_once_t once_flag;
++    #define ONCE_FLAG_INIT PTHREAD_ONCE_INIT
++    #define __once_flag_defined
++  #endif
+ #endif
+ 
+ /** Invoke a callback exactly once
+@@ -462,7 +466,9 @@ int tss_set(tss_t key, void *val);
+ #if defined(_TTHREAD_WIN32_)
+   void call_once(once_flag *flag, void (*func)(void));
+ #else
+-  #define call_once(flag,func) pthread_once(flag,func)
++  inline void call_once(once_flag *flag, void (*func)(void)) {
++    pthread_once(flag, func);
++  }
+ #endif
+ 
+ #ifdef __cplusplus


### PR DESCRIPTION
code was not compatible with c11 and core/glibc 2.43 (archlinux pkg)

typical error:
```
#10 753.2 /home/project/build/_deps/scip-src/src/tinycthread/tinycthread.h:453:21: error: conflicting types for ‘pthread_once_t’; have ‘__once_flag’
#10 753.2   453 |   #define once_flag pthread_once_t
#10 753.2       |                     ^~~~~~~~~~~~~~
#10 753.2 In file included from /usr/include/pthread.h:26,
#10 753.2                  from /home/project/build/_deps/scip-src/src/tinycthread/tinycthread.h:87:
#10 753.2 /usr/include/bits/pthreadtypes.h:53:30: note: previous declaration of ‘pthread_once_t’ with type ‘pthread_once_t’ {aka ‘int’}
#10 753.2    53 | typedef int __ONCE_ALIGNMENT pthread_once_t;
#10 753.2       |                              ^~~~~~~~~~~~~~
#10 753.2 /home/project/build/_deps/scip-src/src/tinycthread/tinycthread.h:465:32: error: conflicting types for ‘pthread_once’; have ‘void(int *, void (*)(void))’
#10 753.2   465 |   #define call_once(flag,func) pthread_once(flag,func)
#10 753.2       |                                ^~~~~~~~~~~~
#10 753.2 /usr/include/pthread.h:509:12: note: previous declaration of ‘pthread_once’ with type ‘int(pthread_once_t *, void (*)(void))’ {aka ‘int(int *, void (*)(void))’}
#10 753.2   509 | extern int pthread_once (pthread_once_t *__once_control,
#10 753.2       |            ^~~~~~~~~~~~
#10 753.3 make[2]: *** [_deps/scip-build/src/CMakeFiles/libscip.dir/build.make:5931: _deps/scip-build/src/CMakeFiles/libscip.dir/tinycthread/tinycthread.c.o] Error 1
```