### PR TITLE
Fix issue #4988: CpSolver.Solve() callback breaking argument change

### DIFF
--- a/ortools/sat/python/cp_model.py
+++ b/ortools/sat/python/cp_model.py
@@ -2016,9 +2016,9 @@ class CpSolver:
 
     @deprecated("Use solve() method instead.")
     def Solve(
-        self, model: CpModel, callback: "CpSolverSolutionCallback" = None
+        self, model: CpModel, solution_callback: "CpSolverSolutionCallback" = None
     ) -> cmh.CpSolverStatus:
-        return self.solve(model, callback)
+        return self.solve(model, solution_callback)
 
     @deprecated("Use solution_info() method instead.")
     def SolutionInfo(self) -> str:

--- a/ortools/sat/python/cp_model_test.py
+++ b/ortools/sat/python/cp_model_test.py
@@ -1691,6 +1691,19 @@ class CpModelTest(absltest.TestCase):
         self.assertEqual(cp_model.OPTIMAL, status)
         self.assertEqual(6, solution_sum.sum)
 
+    def test_Solve_with_solution_callback(self) -> None:
+        model = cp_model.CpModel()
+        x = model.new_int_var(0, 5, "x")
+        y = model.new_int_var(0, 5, "y")
+        model.add_linear_constraint(x + y, 6, 6)
+
+        solver = cp_model.CpSolver()
+        solution_sum = SolutionSum([x, y])
+        self.assertRaises(RuntimeError, solution_sum.value, x)
+        status = solver.Solve(model, solution_callback=solution_sum)
+        self.assertEqual(cp_model.OPTIMAL, status)
+        self.assertEqual(6, solution_sum.sum)
+
     def test_solve_with_float_value_in_callback(self) -> None:
         model = cp_model.CpModel()
         x = model.new_int_var(0, 5, "x")


### PR DESCRIPTION
This PR fixes an issue introduced in commit 4a2de332ce318b98d4489bc6265c84e270bcb09f and raised in #4988 where a breaking change was made whilst improving the quality of the CP-SAT python codebase. The change is very minor, and introduces a small test as an additional thought. I appreciate the method is deprecated so the test may feel more like bloat in this case, I am happy to adjust either way.
