### PR TITLE
Allow XPRESS usage through mathopt in python

### DIFF
--- a/ortools/math_opt/python/parameters.py
+++ b/ortools/math_opt/python/parameters.py
@@ -76,6 +76,8 @@ class SolverType(enum.Enum):
         QPs are unimplemented).
       SANTORINI: The Santorini Solver (first party). Supports MIP. Experimental,
         do not use in production.
+      XPRESS: Xpress solver (third party). Supports LP, MIP, and nonconvex integer
+        quadratic problems. Generally a fast option, but has special licensing.
     """
 
     GSCIP = math_opt_parameters_pb2.SOLVER_TYPE_GSCIP
@@ -89,6 +91,7 @@ class SolverType(enum.Enum):
     SCS = math_opt_parameters_pb2.SOLVER_TYPE_SCS
     HIGHS = math_opt_parameters_pb2.SOLVER_TYPE_HIGHS
     SANTORINI = math_opt_parameters_pb2.SOLVER_TYPE_SANTORINI
+    XPRESS = math_opt_parameters_pb2.SOLVER_TYPE_XPRESS
 
 
 def solver_type_from_proto(


### PR DESCRIPTION
<!--
Thank you for submitting a PR!

Please make sure you are targeting the main branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->

We need to manually add an enum value in python code in order to be able to use xpress through python in mathopt
