### PR TITLE
generic test of pointer size in model_cache

### DIFF
--- a/ortools/constraint_solver/model_cache.h
+++ b/ortools/constraint_solver/model_cache.h
@@ -51,7 +51,8 @@ inline uint64_t Hash1(int value) { return Hash1(static_cast<uint32_t>(value)); }
 
 inline uint64_t Hash1(void* const ptr) {
 #if defined(__x86_64__) || defined(_M_X64) || defined(__powerpc64__) || \
-    defined(__aarch64__) || (defined(_MIPS_SZPTR) && (_MIPS_SZPTR == 64))
+    defined(__aarch64__) || (defined(_MIPS_SZPTR) && (_MIPS_SZPTR == 64)) || \
+    (defined(INTPTR_MAX) && defined(INT64_MAX) && (INTPTR_MAX == INT64_MAX))
   return Hash1(reinterpret_cast<uint64_t>(ptr));
 #else
   return Hash1(reinterpret_cast<uint32_t>(ptr));


### PR DESCRIPTION
I've recently started working on an OCaml interface to OR-Tools. This interface compiles OR-Tools from the source. It fails the OCaml continuous integration tests for the s390x and riscv64 architectures since the hashing pointer-cast tests explicitly for different 64-bit architectures. The proposed change is to complement these tests with C++11 constants from `<cstdint>`. The two constants used, `INTPTR_MAX` and `INT64_MAX`, are optional, but defined&& short-circuiting should prevent failures if they are not present.
