### PR TITLE
[CP-SAT] Exclude lrat_checker_main.cc from libortools

### DIFF
--- a/ortools/sat/CMakeLists.txt
+++ b/ortools/sat/CMakeLists.txt
@@ -18,6 +18,7 @@ list(REMOVE_ITEM _SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/opb_reader.h
   ${CMAKE_CURRENT_SOURCE_DIR}/sat_cnf_reader.h
   ${CMAKE_CURRENT_SOURCE_DIR}/sat_runner.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/lrat_checker_main.cc
 )
 set(NAME ${PROJECT_NAME}_sat)
 


### PR DESCRIPTION
<!--
Thank you for submitting a PR!

Please make sure you are targeting the main branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->

### Background

Currently, the OR-Tools dynamic library contains a `main` symbol, which is generally undesired in a dynamic library. This comes from the recently added `lrat_checker_main.cc` file.

### Changes

`sat/CMakeLists.txt` already utilizes a pattern to filter out binary source files such as `sat_runner.cc`. This fix adds the new source file, `lrat_checker_main.cc`, to that filter. 

### Testing

On the`main` branch as of today:

```
nm -g -C --defined-only build/lib/libortools.dylib | grep "main$"
0000000000c5ee6b S operations_research::ModelVisitor::kMapDomain
0000000000d1c4b8 S typeinfo for operations_research::MapDomain
0000000000c6003c S typeinfo name for operations_research::MapDomain
0000000000d1c460 S vtable for operations_research::MapDomain
00000000006e92d4 T _main
```

After the fix:

```
nm -g -C --defined-only build/lib/libortools.dylib | grep "main$"
0000000000caaafb S operations_research::ModelVisitor::kMapDomain
0000000000d60530 S typeinfo for operations_research::MapDomain
0000000000cabccc S typeinfo name for operations_research::MapDomain
0000000000d604d8 S vtable for operations_research::MapDomain
```

