### PR TITLE
cmake: fix java build

### DIFF
--- a/cmake/java.cmake
+++ b/cmake/java.cmake
@@ -113,6 +113,7 @@ if(USE_PDLP)
   list(APPEND proto_java_files ${pdlp_proto_java_files})
 endif()
 list(REMOVE_ITEM proto_java_files "ortools/constraint_solver/assignment.proto")
+list(REMOVE_ITEM proto_java_files "ortools/util/testdata/wrappers_test_message.proto")
 foreach(PROTO_FILE IN LISTS proto_java_files)
   #message(STATUS "protoc proto(java): ${PROTO_FILE}")
   get_filename_component(PROTO_DIR ${PROTO_FILE} DIRECTORY)
@@ -261,18 +262,20 @@ list(APPEND CMAKE_SWIG_FLAGS "-I${PROJECT_SOURCE_DIR}")
 
 # Swig wrap all libraries
 foreach(SUBPROJECT IN ITEMS
- util
  algorithms
  graph
  init
  linear_solver
  constraint_solver
  routing
- sat)
+ sat
+ util)
   add_subdirectory(ortools/${SUBPROJECT}/java)
   target_link_libraries(jni${JAVA_ARTIFACT} PRIVATE jni${SUBPROJECT})
 endforeach()
 target_link_libraries(jni${JAVA_ARTIFACT} PRIVATE jnimodelbuilder)
+target_link_libraries(jni${JAVA_ARTIFACT} PRIVATE ortools::util_java_jni_helper)
+target_link_libraries(jni${JAVA_ARTIFACT} PRIVATE jni_cp_model_proto)
 
 #################################
 ##  Java Native Maven Package  ##

--- a/ortools/bop/boolean_problem.proto
+++ b/ortools/bop/boolean_problem.proto
@@ -17,6 +17,12 @@ syntax = "proto2";
 
 package operations_research.bop;
 
+// clang-format off
+option csharp_namespace = "Google.OrTools.Bop";
+option java_package = "com.google.ortools.bop";
+option java_multiple_files = true;
+// clang-format on
+
 // A linear Boolean constraint which is a bounded sum of linear terms. Each term
 // beeing a literal times an integer coefficient. If we assume that a literal
 // takes the value 1 if it is true and 0 otherwise, the constraint is:

--- a/ortools/bop/bop_parameters.proto
+++ b/ortools/bop/bop_parameters.proto
@@ -15,9 +15,12 @@ syntax = "proto2";
 
 package operations_research.bop;
 
+// clang-format off
+option csharp_namespace = "Google.OrTools.Bop";
 option java_package = "com.google.ortools.bop";
 option java_multiple_files = true;
-option csharp_namespace = "Google.OrTools.Bop";
+// clang-format on
+
 // Method used to optimize a solution in Bop.
 //
 // NEXT TAG: 16

--- a/ortools/sat/java/CMakeLists.txt
+++ b/ortools/sat/java/CMakeLists.txt
@@ -79,8 +79,6 @@ set_target_properties(jni_cp_model_proto PROPERTIES
   SWIG_USE_TARGET_INCLUDE_DIRECTORIES ON
   POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(jni_cp_model_proto PRIVATE ortools::ortools)
-target_link_libraries(jni_cp_model_proto PRIVATE ortools::util_java_jni_helper)
-target_link_libraries(jni${JAVA_ARTIFACT} PRIVATE jni_cp_model_proto)
 
 # sat
 set(SWIG_MODULE_jnisat_EXTRA_DEPS java_cp_model_proto)

--- a/ortools/util/java/CMakeLists.txt
+++ b/ortools/util/java/CMakeLists.txt
@@ -48,7 +48,7 @@ set_target_properties(util_java_jni_helper PROPERTIES
 target_include_directories(util_java_jni_helper PUBLIC
   ${PROJECT_SOURCE_DIR}
   ${PROJECT_BINARY_DIR})
-target_include_directories (util_java_jni_helper PRIVATE ${JNI_INCLUDE_DIRS})
-target_link_libraries (util_java_jni_helper PRIVATE ${JNI_LIBRARIES})
+target_include_directories(util_java_jni_helper PRIVATE ${JNI_INCLUDE_DIRS})
+target_link_libraries(util_java_jni_helper PRIVATE ${JNI_LIBRARIES})
 add_library(${PROJECT_NAMESPACE}::util_java_jni_helper ALIAS util_java_jni_helper)
 

--- a/ortools/util/testdata/wrappers_test_message.proto
+++ b/ortools/util/testdata/wrappers_test_message.proto
@@ -15,6 +15,12 @@ syntax = "proto2";
 
 package operations_research.util;
 
+// clang-format off
+option csharp_namespace = "Google.OrTools.Util";
+option java_package = "com.google.ortools.util";
+option java_multiple_files = true;
+// clang-format on
+
 message WrappersTestMessage {
   optional int32 int32_field = 1;
   optional int64 int64_field = 2;


### PR DESCRIPTION
TESTED using
```sh
cmake -S. -Bbuild_java -DBUILD_JAVA=ON
cmake --build build_java --target java_package
comm -23 <(nm -u -C build_java/lib/libjniortools.so | awk '{print $NF}' | sort -u) \
         <(nm -C -D --defined-only build_java/lib/libortools.so | awk '{print $NF}' | sort -u) \
| grep operations_research
```