### PR TITLE
Update ORToolsBinaries to 0.1.0

### DIFF
--- a/ortools/julia/ORToolsBinaries.jl/Project.toml
+++ b/ortools/julia/ORToolsBinaries.jl/Project.toml
@@ -1,6 +1,6 @@
 name = "ORToolsBinaries"
 uuid = "594ad865-6a17-49ee-8f22-76ed020c7c08"
-version = "0.0.2"
+version = "0.1.0"
 
 [deps]
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"

--- a/ortools/julia/ORToolsBinaries.jl/Project.toml
+++ b/ortools/julia/ORToolsBinaries.jl/Project.toml
@@ -1,6 +1,6 @@
 name = "ORToolsBinaries"
 uuid = "594ad865-6a17-49ee-8f22-76ed020c7c08"
-version = "0.0.1"
+version = "0.0.2"
 
 [deps]
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"

--- a/ortools/julia/ORToolsBinaries.jl/deps/build.jl
+++ b/ortools/julia/ORToolsBinaries.jl/deps/build.jl
@@ -22,10 +22,13 @@ const TARGET_PACKAGES = Dict{String, String}(
 
 const DEPS_DIR = @__DIR__
 
-println("WARNING: if ORTools_jll provides binaries for your platform, prefer using them rather than this package.")
+println("WARNING: if ORTools_jll provides binaries for your platform, " *
+        "prefer using them rather than this package.")
 println()
 println("Downloading and installing a precompiled version of OR-Tools...")
-println("BASE_URL: $BASE_URL, ORTOOLS_MINOR_VERSION: $ORTOOLS_MINOR_VERSION, ORTOOLS_PATCH_VERSION: $ORTOOLS_PATCH_VERSION")
+println("BASE_URL: $BASE_URL, ORTOOLS_MINOR_VERSION: " *
+        "$ORTOOLS_MINOR_VERSION, ORTOOLS_PATCH_VERSION: " *
+		"$ORTOOLS_PATCH_VERSION")
 
 key = "unknown"
 if Sys.islinux()
@@ -54,16 +57,20 @@ elseif Sys.iswindows()
     end
 end
 
-println("Sys.islinux: $(Sys.islinux()), Sys.isapple: $(Sys.isapple()), Sys.iswindows: $(Sys.iswindows()), Sys.ARCH: $(Sys.ARCH)")
+println("Sys.islinux: $(Sys.islinux()), Sys.isapple: $(Sys.isapple()), " *
+        "Sys.iswindows: $(Sys.iswindows()), Sys.ARCH: $(Sys.ARCH)")
 println("Detected platform: $key")
 if !(key in keys(TARGET_PACKAGES))
-    error("No package found for $key. Known packages: $(keys(TARGET_PACKAGES)). Maybe ORTools_jll contains a package for your platform.")
+    error("No package found for $key. Known packages: " *
+	      "$(keys(TARGET_PACKAGES)). Maybe ORTools_jll contains a package " *
+		  "for your platform.")
 end
 
 println("Downloading the following binary package:")
 println(TARGET_PACKAGES[key])
 package = Downloads.download(TARGET_PACKAGES[key])
-println("Package downloaded. Size: $(filesize(package)) bytes, i.e. roughly $(round(Int, filesize(package) / 1024 / 1024)) MiB")
+println("Package downloaded. Size: $(filesize(package)) bytes, i.e. roughly " *
+        "$(round(Int, filesize(package) / 1024 / 1024)) MiB")
 println("Local path (temporary): $package")
 
 dest_dir = joinpath(DEPS_DIR, "lib")
@@ -71,19 +78,28 @@ if isdir(dest_dir)
     rm(dest_dir, recursive=true, force=true)
 end
 mkpath(dest_dir)
+println("Destination directory: $dest_dir")
 
+# Extract the archives by picking only the shared libraries.
+# There are probably too many extracted files, but it will do for now.
 count_files = 0
 if endswith(TARGET_PACKAGES[key], ".zip")
     # Only for Windows. The ZIP archive contains a folder with the same name
     # as the archive itself. We only need the DLLs in the `bin` folder.
     zr = ZipArchives.ZipReader(read(package))
     for name in ZipArchives.zip_names(zr)
-        if startswith(name, PACKAGE_FILE_NAME_WITHOUT_EXTENSION[key]) && endswith(name, ".dll")
+		should_extract = (
+			startswith(name, PACKAGE_FILE_NAME_WITHOUT_EXTENSION[key]) &&
+			endswith(name, ".dll")
+		)
+        if should_extract
             filename = basename(name)
-            println("Extracting: $filename (path in the ZIP archive: $name)")
+			dest_path = joinpath(dest_dir, filename)
+            println("Extracting: $filename (path in the ZIP archive: $name; " *
+			        "destination path: $dest_path)")
             
             ZipArchives.zip_openentry(zr, name) do io
-                open(joinpath(dest_dir, filename), "w") do f
+                open(dest_path, "w") do f
                     write(f, io)
                 end
             end
@@ -100,8 +116,8 @@ elseif endswith(TARGET_PACKAGES[key], ".tar.gz")
 
         Tar.extract(tar_stream, dest_dir) do header
             name = header.path
-            should_extract = startswith(name, PACKAGE_FILE_NAME_WITHOUT_EXTENSION[key]) && 
-                             (endswith(name, ".so") || endswith(name, ".dylib"))
+            should_extract = endswith(name, ".so") || endswith(name, ".dylib") ||
+                             contains(name, ".so.")
             if should_extract
                 println("Extracting: $(basename(name)) (path in TAR.GZ archive: $(name))")
             end
@@ -118,7 +134,14 @@ elseif endswith(TARGET_PACKAGES[key], ".tar.gz")
     end
 
     # Clean up after flattening.
-    rm(joinpath(dest_dir, PACKAGE_FILE_NAME_WITHOUT_EXTENSION[key]), recursive=true)
+	tmp_dir_extraction = joinpath(
+		dest_dir, PACKAGE_FILE_NAME_WITHOUT_EXTENSION[key])
+	if !isdir(tmp_dir_extraction)
+		tmp_dir_extraction = replace(
+				tmp_dir_extraction, "amd64" => "x86_64")
+	end
+	println("Cleaning up temporary folder: $tmp_dir_extraction")
+	rm(tmp_dir_extraction, recursive=true)
 else
     error("Assertion failed: archive type not supported. Please report the problem to the maintainers of OR-Tools.")
 end

--- a/ortools/julia/ORToolsBinaries.jl/deps/build.jl
+++ b/ortools/julia/ORToolsBinaries.jl/deps/build.jl
@@ -28,7 +28,7 @@ println()
 println("Downloading and installing a precompiled version of OR-Tools...")
 println("BASE_URL: $BASE_URL, ORTOOLS_MINOR_VERSION: " *
         "$ORTOOLS_MINOR_VERSION, ORTOOLS_PATCH_VERSION: " *
-		"$ORTOOLS_PATCH_VERSION")
+        "$ORTOOLS_PATCH_VERSION")
 
 key = "unknown"
 if Sys.islinux()
@@ -62,8 +62,8 @@ println("Sys.islinux: $(Sys.islinux()), Sys.isapple: $(Sys.isapple()), " *
 println("Detected platform: $key")
 if !(key in keys(TARGET_PACKAGES))
     error("No package found for $key. Known packages: " *
-	      "$(keys(TARGET_PACKAGES)). Maybe ORTools_jll contains a package " *
-		  "for your platform.")
+          "$(keys(TARGET_PACKAGES)). Maybe ORTools_jll contains a package " *
+          "for your platform.")
 end
 
 println("Downloading the following binary package:")
@@ -88,16 +88,16 @@ if endswith(TARGET_PACKAGES[key], ".zip")
     # as the archive itself. We only need the DLLs in the `bin` folder.
     zr = ZipArchives.ZipReader(read(package))
     for name in ZipArchives.zip_names(zr)
-		should_extract = (
-			startswith(name, PACKAGE_FILE_NAME_WITHOUT_EXTENSION[key]) &&
-			endswith(name, ".dll")
-		)
+        should_extract = (
+            startswith(name, PACKAGE_FILE_NAME_WITHOUT_EXTENSION[key]) &&
+            endswith(name, ".dll")
+        )
         if should_extract
             filename = basename(name)
-			dest_path = joinpath(dest_dir, filename)
+            dest_path = joinpath(dest_dir, filename)
             println("Extracting: $filename (path in the ZIP archive: $name; " *
-			        "destination path: $dest_path)")
-            
+                    "destination path: $dest_path)")
+
             ZipArchives.zip_openentry(zr, name) do io
                 open(dest_path, "w") do f
                     write(f, io)
@@ -134,14 +134,14 @@ elseif endswith(TARGET_PACKAGES[key], ".tar.gz")
     end
 
     # Clean up after flattening.
-	tmp_dir_extraction = joinpath(
-		dest_dir, PACKAGE_FILE_NAME_WITHOUT_EXTENSION[key])
-	if !isdir(tmp_dir_extraction)
-		tmp_dir_extraction = replace(
-				tmp_dir_extraction, "amd64" => "x86_64")
-	end
-	println("Cleaning up temporary folder: $tmp_dir_extraction")
-	rm(tmp_dir_extraction, recursive=true)
+    tmp_dir_extraction = joinpath(
+            dest_dir, PACKAGE_FILE_NAME_WITHOUT_EXTENSION[key])
+    if !isdir(tmp_dir_extraction)
+        tmp_dir_extraction = replace(
+            tmp_dir_extraction, "amd64" => "x86_64")
+    end
+    println("Cleaning up temporary folder: $tmp_dir_extraction")
+    rm(tmp_dir_extraction, recursive=true)
 else
     error("Assertion failed: archive type not supported. Please report the problem to the maintainers of OR-Tools.")
 end


### PR DESCRIPTION
The main addition is fixing installation on Linux (but, if you are using this package as a Linux user, please first have a look at ORTools_jll).

Already merged upstream: https://github.com/JuliaRegistries/General/pull/151691