### PR TITLE
cmake: use OVERRIDE_FIND_PACKAGE when building ZLIB

### DIFF
--- a/cmake/dependencies/CMakeLists.txt
+++ b/cmake/dependencies/CMakeLists.txt
@@ -72,6 +72,7 @@ if(BUILD_ZLIB)
     UPDATE_COMMAND git reset --hard
     PATCH_COMMAND git apply --ignore-whitespace
     "${CMAKE_CURRENT_LIST_DIR}/../../patches/ZLIB-v1.3.1.patch"
+    OVERRIDE_FIND_PACKAGE
     SYSTEM
   )
   set(ZLIB_BUILD_EXAMPLES OFF)


### PR DESCRIPTION
should mitigate some spurious CI bugs

Typical trace:
```
CMake Error at cmake/check_deps.cmake:16 (message):
  Target ZLIB::ZLIB not available.
Call Stack (most recent call first):
  CMakeLists.txt:430 (include)
```