### PR TITLE
[BUG] set_cover Python: fix UB in the all_subsets property

### DIFF
--- a/ortools/set_cover/python/set_cover.cc
+++ b/ortools/set_cover/python/set_cover.cc
@@ -72,7 +72,8 @@ using ::py::make_iterator;
 std::vector<SubsetIndex> VectorIntToVectorSubsetIndex(
     absl::Span<const BaseInt> ints) {
   std::vector<SubsetIndex> subs;
-  std::transform(ints.begin(), ints.end(), subs.begin(),
+  subs.reserve(ints.size());
+  std::transform(ints.begin(), ints.end(), std::back_inserter(subs),
                  [](int subset) -> SubsetIndex { return SubsetIndex(subset); });
   return subs;
 }
@@ -197,17 +198,21 @@ PYBIND11_MODULE(set_cover, m) {
              return make_iterator<>(IntIterator::begin(model.num_elements()),
                                     IntIterator::end(model.num_elements()));
            })
-      .def_property_readonly("all_subsets",
-                             [](SetCoverModel& model) -> std::vector<BaseInt> {
-                               std::vector<BaseInt> subsets;
-                               std::transform(
-                                   model.all_subsets().begin(),
-                                   model.all_subsets().end(), subsets.begin(),
-                                   [](const SubsetIndex element) -> BaseInt {
-                                     return element.value();
-                                   });
-                               return subsets;
-                             })
+      .def_property_readonly(
+          "all_subsets",
+          [](SetCoverModel& model) -> std::vector<BaseInt> {
+            // all_subsets() returns by value, so it must be
+            // bound to a local: calling it twice would give
+            // begin() and end() of two distinct temporaries.
+            const std::vector<SubsetIndex> all = model.all_subsets();
+            std::vector<BaseInt> subsets;
+            subsets.reserve(all.size());
+            std::transform(all.begin(), all.end(), std::back_inserter(subsets),
+                           [](const SubsetIndex element) -> BaseInt {
+                             return element.value();
+                           });
+            return subsets;
+          })
       .def("set_name", &SetCoverModel::SetName)
       .def("add_empty_subset", &SetCoverModel::AddEmptySubset, arg("cost"))
       .def(

--- a/ortools/set_cover/python/set_cover_test.py
+++ b/ortools/set_cover/python/set_cover_test.py
@@ -222,6 +222,12 @@ class SetCoverTest(absltest.TestCase):
             inv.check_consistency(set_cover.consistency_level.FREE_AND_UNCOVERED)
         )
 
+    def test_all_subsets_property(self):
+        model = create_knights_cover_model(4, 4)
+        all_subsets = model.all_subsets
+        self.assertLen(all_subsets, model.num_subsets)
+        self.assertEqual(all_subsets, list(range(model.num_subsets)))
+
     # TODO(user): KnightsCoverGreedyAndTabu, KnightsCoverGreedyRandomClear,
     # KnightsCoverElementDegreeRandomClear, KnightsCoverRandomClearMip,
     # KnightsCoverMip


### PR DESCRIPTION
*Edited 2026-09-05: still applies cleanly to `main` @ `5a1b660`, both UB sites are still there, and the crash was re-verified on that tree and on the 9.15.6755 wheel (details under Verification). Code unchanged.*

### What

Fixes undefined behaviour in the `set_cover` Python wrapper (`ortools/set_cover/python/set_cover.cc`) and adds a regression test.

**Disclosure:** drafted with AI assistance (Claude). See the verification section for exactly what was built and run.

### The bug

`SetCoverModel.all_subsets` terminates the interpreter when read from Python. The property is [`set_cover.cc:201-213`](https://github.com/google/or-tools/blob/main/ortools/set_cover/python/set_cover.cc#L201), and it has two independent defects in one statement:

1. **`begin()` and `end()` come from different objects.** `SetCoverModel::all_subsets()` returns **by value** (`set_cover_model.h:211`):

   ```cpp
   std::vector<SubsetIndex> all_subsets() const { return all_subsets_; }
   ```

   The property calls it twice, so `model.all_subsets().begin()` and `model.all_subsets().end()` are iterators into two distinct temporaries. That pair does not delimit a valid range, and the transform runs off the end of the first temporary's buffer. This is the dominant defect, and it is why the property has never worked.

2. **The output iterator is also invalid.** `subsets.begin()` on a default-constructed, zero-capacity vector: a write through an iterator that was never valid.

The neighbouring `columns` and `rows` properties are fine: `columns()` and `rows()` return **const references** (`:189`, `:192`), so calling them twice is harmless. Their pre-size-and-write-through-`begin()` pattern is correct for a reference-returning accessor. `all_subsets()` is the only by-value accessor in the file, and it is the only one that crashes.

### Reproduction

```python
from ortools.set_cover.python import set_cover

model = set_cover.SetCoverModel()
model.add_empty_subset(1.0)
model.add_element_to_last_subset(0)
model.add_empty_subset(1.0)
model.add_element_to_last_subset(1)

print(model.all_subsets)  # process dies here
```

Segmentation fault, exit 139, on the released `ortools` 9.15.6755 wheel (macOS arm64, CPython 3.13.11). The `std::transform` statement at the v9.15 tag is identical to the one on `main`.

### The fix

Bind the returned vector to a local, then append through `back_inserter`. Binding the local also removes a third full copy that `reserve(model.all_subsets().size())` would otherwise make.

`VectorIntToVectorSubsetIndex` has the second defect too, and is fixed here for consistency, though it is not currently reachable from Python: all of its callers take `absl::Span`, and this module registers no `absl::Span` type caster. That is a separate, unrelated defect, reported independently rather than folded into this PR.

### Verification

Built and tested on Linux (Bazel 8.7.0, x86_64) against `main` @ `5a1b660` on 2026-09-05 (first run: `d9c0910`, 2026-08-01):

```
new test applied WITHOUT the fix:  FAIL (Segmentation fault in test_all_subsets_property)
new test applied WITH the fix:     PASSED
```

Reading `model.all_subsets` on the reproduction above terminates the process with SIGSEGV in 5 of 5 runs on `main` @ `5a1b660` and in 5 of 5 runs on the 9.15.6755 wheel. This is a crash fix, not a feature; it does not need to wait for v10.0.

`clang-format` clean against the repo `.clang-format`.

### Checklist

- [x] Read CONTRIBUTING.md and the PR template, targeting `main`
- [x] CLA signed
- [x] Minimal diff: the `all_subsets` fix and its test
- [x] No unrelated formatting or refactoring
- [x] AI-assisted: disclosed above

