### PR TITLE
[ENH] set_cover Python: add SetCoverLagrangian bindings

### DIFF
--- a/ortools/set_cover/python/BUILD.bazel
+++ b/ortools/set_cover/python/BUILD.bazel
@@ -27,6 +27,7 @@ pybind_extension(
         "//ortools/set_cover:base_types",
         "//ortools/set_cover:set_cover_heuristics",
         "//ortools/set_cover:set_cover_invariant",
+        "//ortools/set_cover:set_cover_lagrangian",
         "//ortools/set_cover:set_cover_model",
         "//ortools/set_cover:set_cover_reader",
         "@abseil-cpp//absl/time",

--- a/ortools/set_cover/python/set_cover.cc
+++ b/ortools/set_cover/python/set_cover.cc
@@ -17,12 +17,14 @@
 #include <cstddef>
 #include <iterator>
 #include <memory>
+#include <tuple>
 #include <vector>
 
 #include "absl/types/span.h"
 #include "ortools/set_cover/base_types.h"
 #include "ortools/set_cover/set_cover_heuristics.h"
 #include "ortools/set_cover/set_cover_invariant.h"
+#include "ortools/set_cover/set_cover_lagrangian.h"
 #include "ortools/set_cover/set_cover_model.h"
 #include "ortools/set_cover/set_cover_reader.h"
 #include "pybind11/numpy.h"
@@ -33,7 +35,9 @@
 
 using ::operations_research::BaseInt;
 using ::operations_research::ClearRandomSubsets;
+using ::operations_research::Cost;
 using ::operations_research::DualAscentOptimizer;
+using ::operations_research::ElementCostVector;
 using ::operations_research::ElementDegreeSolutionGenerator;
 using ::operations_research::ElementIndex;
 using ::operations_research::GreedySolutionOptimizer;
@@ -55,6 +59,7 @@ using ::operations_research::WriteSetCoverSolutionText;
 
 using ::operations_research::SetCoverDecision;
 using ::operations_research::SetCoverInvariant;
+using ::operations_research::SetCoverLagrangian;
 using ::operations_research::SetCoverModel;
 using ::operations_research::SparseColumn;
 using ::operations_research::SparseRow;
@@ -80,6 +85,12 @@ std::vector<SubsetIndex> VectorIntToVectorSubsetIndex(
 SubsetCostVector VectorDoubleToSubsetCostVector(
     absl::Span<const double> doubles) {
   SubsetCostVector costs(doubles.begin(), doubles.end());
+  return costs;
+}
+
+ElementCostVector VectorDoubleToElementCostVector(
+    absl::Span<const double> doubles) {
+  ElementCostVector costs(doubles.begin(), doubles.end());
   return costs;
 }
 
@@ -623,5 +634,136 @@ PYBIND11_MODULE(set_cover, m) {
   m.def("read_set_cover_solution_proto", &ReadSetCoverSolutionProto);
 
   // set_cover_lagrangian.h
-  // TODO(user): add support for SetCoverLagrangian.
+  // OptimizeImpl() is a dummy in this class, which the header says is meant to
+  // be used only through ComputeLowerBound(), so optimize() is not exposed.
+  py::class_<SetCoverLagrangian>(m, "SetCoverLagrangian")
+      .def(py::init<SetCoverInvariant*>())
+      .def("use_num_threads", &SetCoverLagrangian::UseNumThreads,
+           arg("num_threads"), py::return_value_policy::reference_internal)
+      .def("initialize_lagrange_multipliers",
+           [](const SetCoverLagrangian& lagrangian) -> std::vector<double> {
+             return lagrangian.InitializeLagrangeMultipliers().get();
+           })
+      .def(
+          "compute_reduced_costs",
+          [](const SetCoverLagrangian& lagrangian,
+             const std::vector<double>& costs,
+             const std::vector<double>& multipliers) -> std::vector<double> {
+            return lagrangian
+                .ComputeReducedCosts(
+                    VectorDoubleToSubsetCostVector(costs),
+                    VectorDoubleToElementCostVector(multipliers))
+                .get();
+          },
+          arg("costs"), arg("multipliers"))
+      .def(
+          "parallel_compute_reduced_costs",
+          [](const SetCoverLagrangian& lagrangian,
+             const std::vector<double>& costs,
+             const std::vector<double>& multipliers) -> std::vector<double> {
+            return lagrangian
+                .ParallelComputeReducedCosts(
+                    VectorDoubleToSubsetCostVector(costs),
+                    VectorDoubleToElementCostVector(multipliers))
+                .get();
+          },
+          arg("costs"), arg("multipliers"))
+      .def(
+          "compute_subgradient",
+          [](const SetCoverLagrangian& lagrangian,
+             const std::vector<double>& reduced_costs) -> std::vector<double> {
+            return lagrangian
+                .ComputeSubgradient(
+                    VectorDoubleToSubsetCostVector(reduced_costs))
+                .get();
+          },
+          arg("reduced_costs"))
+      .def(
+          "parallel_compute_subgradient",
+          [](const SetCoverLagrangian& lagrangian,
+             const std::vector<double>& reduced_costs) -> std::vector<double> {
+            return lagrangian
+                .ParallelComputeSubgradient(
+                    VectorDoubleToSubsetCostVector(reduced_costs))
+                .get();
+          },
+          arg("reduced_costs"))
+      .def(
+          "compute_lagrangian_value",
+          [](const SetCoverLagrangian& lagrangian,
+             const std::vector<double>& reduced_costs,
+             const std::vector<double>& multipliers) -> Cost {
+            return lagrangian.ComputeLagrangianValue(
+                VectorDoubleToSubsetCostVector(reduced_costs),
+                VectorDoubleToElementCostVector(multipliers));
+          },
+          arg("reduced_costs"), arg("multipliers"))
+      .def(
+          "parallel_compute_lagrangian_value",
+          [](const SetCoverLagrangian& lagrangian,
+             const std::vector<double>& reduced_costs,
+             const std::vector<double>& multipliers) -> Cost {
+            return lagrangian.ParallelComputeLagrangianValue(
+                VectorDoubleToSubsetCostVector(reduced_costs),
+                VectorDoubleToElementCostVector(multipliers));
+          },
+          arg("reduced_costs"), arg("multipliers"))
+      // UpdateMultipliers() mutates its argument through a pointer. The Python
+      // binding returns the updated multipliers instead.
+      .def(
+          "update_multipliers",
+          [](const SetCoverLagrangian& lagrangian, double step_size,
+             Cost lagrangian_value, Cost upper_bound,
+             const std::vector<double>& reduced_costs,
+             const std::vector<double>& multipliers) -> std::vector<double> {
+            ElementCostVector updated =
+                VectorDoubleToElementCostVector(multipliers);
+            lagrangian.UpdateMultipliers(
+                step_size, lagrangian_value, upper_bound,
+                VectorDoubleToSubsetCostVector(reduced_costs), &updated);
+            return updated.get();
+          },
+          arg("step_size"), arg("lagrangian_value"), arg("upper_bound"),
+          arg("reduced_costs"), arg("multipliers"))
+      .def(
+          "parallel_update_multipliers",
+          [](const SetCoverLagrangian& lagrangian, double step_size,
+             Cost lagrangian_value, Cost upper_bound,
+             const std::vector<double>& reduced_costs,
+             const std::vector<double>& multipliers) -> std::vector<double> {
+            ElementCostVector updated =
+                VectorDoubleToElementCostVector(multipliers);
+            lagrangian.ParallelUpdateMultipliers(
+                step_size, lagrangian_value, upper_bound,
+                VectorDoubleToSubsetCostVector(reduced_costs), &updated);
+            return updated.get();
+          },
+          arg("step_size"), arg("lagrangian_value"), arg("upper_bound"),
+          arg("reduced_costs"), arg("multipliers"))
+      .def(
+          "compute_gap",
+          [](const SetCoverLagrangian& lagrangian,
+             const std::vector<double>& reduced_costs,
+             const std::vector<bool>& solution,
+             const std::vector<double>& multipliers) -> Cost {
+            return lagrangian.ComputeGap(
+                VectorDoubleToSubsetCostVector(reduced_costs),
+                BoolVectorToSubsetBoolVector(solution),
+                VectorDoubleToElementCostVector(multipliers));
+          },
+          arg("reduced_costs"), arg("solution"), arg("multipliers"))
+      // ThreePhase() is declared in set_cover_lagrangian.h:135 but defined
+      // nowhere in the tree, so binding it produces an undefined symbol at
+      // module load. Left out until it has an implementation.
+      .def(
+          "compute_lower_bound",
+          [](SetCoverLagrangian& lagrangian, const std::vector<double>& costs,
+             Cost upper_bound)
+              -> std::tuple<Cost, std::vector<double>, std::vector<double>> {
+            auto [lower_bound, reduced_costs, multipliers] =
+                lagrangian.ComputeLowerBound(
+                    VectorDoubleToSubsetCostVector(costs), upper_bound);
+            return {lower_bound, reduced_costs.get(), multipliers.get()};
+          },
+          arg("costs"), arg("upper_bound"));
 }

--- a/ortools/set_cover/python/set_cover.cc
+++ b/ortools/set_cover/python/set_cover.cc
@@ -17,6 +17,7 @@
 #include <cstddef>
 #include <iterator>
 #include <memory>
+#include <string>
 #include <tuple>
 #include <vector>
 
@@ -85,6 +86,13 @@ SubsetCostVector VectorDoubleToSubsetCostVector(
     absl::Span<const double> doubles) {
   SubsetCostVector costs(doubles.begin(), doubles.end());
   return costs;
+}
+
+void CheckNumThreads(int num_threads) {
+  if (num_threads < 1) {
+    throw py::value_error("num_threads must be at least 1, got " +
+                          std::to_string(num_threads));
+  }
 }
 
 SubsetBoolVector BoolVectorToSubsetBoolVector(const std::vector<bool>& bools) {
@@ -627,28 +635,62 @@ PYBIND11_MODULE(set_cover, m) {
   m.def("read_set_cover_solution_proto", &ReadSetCoverSolutionProto);
 
   // set_cover_lagrangian.h
-  // OptimizeImpl() is a dummy in this class, which the header says is meant to
-  // be used only through ComputeLowerBound(), so optimize() is not exposed.
-  // ThreePhase() is declared in set_cover_lagrangian.h:135 but defined
-  // nowhere in the tree, so binding it produces an undefined symbol at
-  // module load. Left out until it has an implementation.
-  // Scope is the usage in set_cover_solve.cc; see PR for why the rest is left
-  // out. compute_lower_bound() runs a 1000-iteration subgradient loop on the
-  // class's own thread pool, so the GIL is released while it runs.
-  py::class_<SetCoverLagrangian>(m, "SetCoverLagrangian")
-      .def(py::init<SetCoverInvariant*>())
-      .def("use_num_threads", &SetCoverLagrangian::UseNumThreads,
-           arg("num_threads"), py::return_value_policy::reference_internal)
+  // Only the members set_cover_solve.cc uses are bound. Optimize() is a dummy
+  // in this class, and ThreePhase() is declared in set_cover_lagrangian.h but
+  // never defined, so binding it fails at import with an undefined symbol.
+  py::class_<SetCoverLagrangian>(m, "SetCoverLagrangian",
+                                 "Lagrangian relaxation lower bound for a set "
+                                 "cover model; see set_cover_lagrangian.h.")
+      .def(py::init([](SetCoverInvariant* inv, int num_threads) {
+             CheckNumThreads(num_threads);
+             auto lagrangian = std::make_unique<SetCoverLagrangian>(inv);
+             lagrangian->UseNumThreads(num_threads);
+             return lagrangian;
+           }),
+           arg("inv"), arg("num_threads") = 1,
+           "Creates the thread pool that compute_lower_bound() runs on. The "
+           "C++ class only creates it in UseNumThreads(); doing it here keeps "
+           "a fresh object usable.")
+      .def(
+          "use_num_threads",
+          [](SetCoverLagrangian& lagrangian,
+             int num_threads) -> SetCoverLagrangian& {
+            CheckNumThreads(num_threads);
+            return lagrangian.UseNumThreads(num_threads);
+          },
+          arg("num_threads"), py::return_value_policy::reference_internal,
+          "Recreates the thread pool with num_threads >= 1 threads. Returns "
+          "self.")
       .def(
           "compute_lower_bound",
           [](SetCoverLagrangian& lagrangian, const std::vector<double>& costs,
              Cost upper_bound)
               -> std::tuple<Cost, std::vector<double>, std::vector<double>> {
-            auto [lower_bound, reduced_costs, multipliers] =
-                lagrangian.ComputeLowerBound(
-                    VectorDoubleToSubsetCostVector(costs), upper_bound);
+            const BaseInt num_subsets =
+                lagrangian.inv()->model()->num_subsets();
+            if (costs.size() != static_cast<size_t>(num_subsets)) {
+              throw py::value_error("costs has " +
+                                    std::to_string(costs.size()) +
+                                    " entries, the model has " +
+                                    std::to_string(num_subsets) + " subsets");
+            }
+            // The subgradient loop runs for a fixed number of iterations on
+            // the class's own thread pool, so the GIL is released meanwhile.
+            const auto [lower_bound, reduced_costs, multipliers] = [&] {
+              py::gil_scoped_release release;
+              return lagrangian.ComputeLowerBound(
+                  VectorDoubleToSubsetCostVector(costs), upper_bound);
+            }();
             return {lower_bound, reduced_costs.get(), multipliers.get()};
           },
           arg("costs"), arg("upper_bound"),
-          py::call_guard<py::gil_scoped_release>());
+          "Runs the subgradient method on the Lagrangian relaxation and "
+          "returns (lower_bound, reduced_costs, multipliers). costs must have "
+          "one entry per subset; upper_bound is the cost of a known feasible "
+          "solution. lower_bound is the best Lagrangian value seen, while "
+          "reduced_costs and multipliers come from the final iteration, which "
+          "need not be the one that attained the bound. The bound is also "
+          "reported on the invariant with is_cost_consistent=false, replacing "
+          "any earlier bound. The GIL is released while this runs; do not "
+          "mutate the invariant or its model from another thread meanwhile.");
 }

--- a/ortools/set_cover/python/set_cover.cc
+++ b/ortools/set_cover/python/set_cover.cc
@@ -633,7 +633,8 @@ PYBIND11_MODULE(set_cover, m) {
   // nowhere in the tree, so binding it produces an undefined symbol at
   // module load. Left out until it has an implementation.
   // Scope is the usage in set_cover_solve.cc; see PR for why the rest is left
-  // out.
+  // out. compute_lower_bound() runs a 1000-iteration subgradient loop on the
+  // class's own thread pool, so the GIL is released while it runs.
   py::class_<SetCoverLagrangian>(m, "SetCoverLagrangian")
       .def(py::init<SetCoverInvariant*>())
       .def("use_num_threads", &SetCoverLagrangian::UseNumThreads,
@@ -648,5 +649,6 @@ PYBIND11_MODULE(set_cover, m) {
                     VectorDoubleToSubsetCostVector(costs), upper_bound);
             return {lower_bound, reduced_costs.get(), multipliers.get()};
           },
-          arg("costs"), arg("upper_bound"));
+          arg("costs"), arg("upper_bound"),
+          py::call_guard<py::gil_scoped_release>());
 }

--- a/ortools/set_cover/python/set_cover.cc
+++ b/ortools/set_cover/python/set_cover.cc
@@ -37,7 +37,6 @@ using ::operations_research::BaseInt;
 using ::operations_research::ClearRandomSubsets;
 using ::operations_research::Cost;
 using ::operations_research::DualAscentOptimizer;
-using ::operations_research::ElementCostVector;
 using ::operations_research::ElementDegreeSolutionGenerator;
 using ::operations_research::ElementIndex;
 using ::operations_research::GreedySolutionOptimizer;
@@ -85,12 +84,6 @@ std::vector<SubsetIndex> VectorIntToVectorSubsetIndex(
 SubsetCostVector VectorDoubleToSubsetCostVector(
     absl::Span<const double> doubles) {
   SubsetCostVector costs(doubles.begin(), doubles.end());
-  return costs;
-}
-
-ElementCostVector VectorDoubleToElementCostVector(
-    absl::Span<const double> doubles) {
-  ElementCostVector costs(doubles.begin(), doubles.end());
   return costs;
 }
 
@@ -636,125 +629,15 @@ PYBIND11_MODULE(set_cover, m) {
   // set_cover_lagrangian.h
   // OptimizeImpl() is a dummy in this class, which the header says is meant to
   // be used only through ComputeLowerBound(), so optimize() is not exposed.
+  // ThreePhase() is declared in set_cover_lagrangian.h:135 but defined
+  // nowhere in the tree, so binding it produces an undefined symbol at
+  // module load. Left out until it has an implementation.
+  // Scope is the usage in set_cover_solve.cc; see PR for why the rest is left
+  // out.
   py::class_<SetCoverLagrangian>(m, "SetCoverLagrangian")
       .def(py::init<SetCoverInvariant*>())
       .def("use_num_threads", &SetCoverLagrangian::UseNumThreads,
            arg("num_threads"), py::return_value_policy::reference_internal)
-      .def("initialize_lagrange_multipliers",
-           [](const SetCoverLagrangian& lagrangian) -> std::vector<double> {
-             return lagrangian.InitializeLagrangeMultipliers().get();
-           })
-      .def(
-          "compute_reduced_costs",
-          [](const SetCoverLagrangian& lagrangian,
-             const std::vector<double>& costs,
-             const std::vector<double>& multipliers) -> std::vector<double> {
-            return lagrangian
-                .ComputeReducedCosts(
-                    VectorDoubleToSubsetCostVector(costs),
-                    VectorDoubleToElementCostVector(multipliers))
-                .get();
-          },
-          arg("costs"), arg("multipliers"))
-      .def(
-          "parallel_compute_reduced_costs",
-          [](const SetCoverLagrangian& lagrangian,
-             const std::vector<double>& costs,
-             const std::vector<double>& multipliers) -> std::vector<double> {
-            return lagrangian
-                .ParallelComputeReducedCosts(
-                    VectorDoubleToSubsetCostVector(costs),
-                    VectorDoubleToElementCostVector(multipliers))
-                .get();
-          },
-          arg("costs"), arg("multipliers"))
-      .def(
-          "compute_subgradient",
-          [](const SetCoverLagrangian& lagrangian,
-             const std::vector<double>& reduced_costs) -> std::vector<double> {
-            return lagrangian
-                .ComputeSubgradient(
-                    VectorDoubleToSubsetCostVector(reduced_costs))
-                .get();
-          },
-          arg("reduced_costs"))
-      .def(
-          "parallel_compute_subgradient",
-          [](const SetCoverLagrangian& lagrangian,
-             const std::vector<double>& reduced_costs) -> std::vector<double> {
-            return lagrangian
-                .ParallelComputeSubgradient(
-                    VectorDoubleToSubsetCostVector(reduced_costs))
-                .get();
-          },
-          arg("reduced_costs"))
-      .def(
-          "compute_lagrangian_value",
-          [](const SetCoverLagrangian& lagrangian,
-             const std::vector<double>& reduced_costs,
-             const std::vector<double>& multipliers) -> Cost {
-            return lagrangian.ComputeLagrangianValue(
-                VectorDoubleToSubsetCostVector(reduced_costs),
-                VectorDoubleToElementCostVector(multipliers));
-          },
-          arg("reduced_costs"), arg("multipliers"))
-      .def(
-          "parallel_compute_lagrangian_value",
-          [](const SetCoverLagrangian& lagrangian,
-             const std::vector<double>& reduced_costs,
-             const std::vector<double>& multipliers) -> Cost {
-            return lagrangian.ParallelComputeLagrangianValue(
-                VectorDoubleToSubsetCostVector(reduced_costs),
-                VectorDoubleToElementCostVector(multipliers));
-          },
-          arg("reduced_costs"), arg("multipliers"))
-      // UpdateMultipliers() mutates its argument through a pointer. The Python
-      // binding returns the updated multipliers instead.
-      .def(
-          "update_multipliers",
-          [](const SetCoverLagrangian& lagrangian, double step_size,
-             Cost lagrangian_value, Cost upper_bound,
-             const std::vector<double>& reduced_costs,
-             const std::vector<double>& multipliers) -> std::vector<double> {
-            ElementCostVector updated =
-                VectorDoubleToElementCostVector(multipliers);
-            lagrangian.UpdateMultipliers(
-                step_size, lagrangian_value, upper_bound,
-                VectorDoubleToSubsetCostVector(reduced_costs), &updated);
-            return updated.get();
-          },
-          arg("step_size"), arg("lagrangian_value"), arg("upper_bound"),
-          arg("reduced_costs"), arg("multipliers"))
-      .def(
-          "parallel_update_multipliers",
-          [](const SetCoverLagrangian& lagrangian, double step_size,
-             Cost lagrangian_value, Cost upper_bound,
-             const std::vector<double>& reduced_costs,
-             const std::vector<double>& multipliers) -> std::vector<double> {
-            ElementCostVector updated =
-                VectorDoubleToElementCostVector(multipliers);
-            lagrangian.ParallelUpdateMultipliers(
-                step_size, lagrangian_value, upper_bound,
-                VectorDoubleToSubsetCostVector(reduced_costs), &updated);
-            return updated.get();
-          },
-          arg("step_size"), arg("lagrangian_value"), arg("upper_bound"),
-          arg("reduced_costs"), arg("multipliers"))
-      .def(
-          "compute_gap",
-          [](const SetCoverLagrangian& lagrangian,
-             const std::vector<double>& reduced_costs,
-             const std::vector<bool>& solution,
-             const std::vector<double>& multipliers) -> Cost {
-            return lagrangian.ComputeGap(
-                VectorDoubleToSubsetCostVector(reduced_costs),
-                BoolVectorToSubsetBoolVector(solution),
-                VectorDoubleToElementCostVector(multipliers));
-          },
-          arg("reduced_costs"), arg("solution"), arg("multipliers"))
-      // ThreePhase() is declared in set_cover_lagrangian.h:135 but defined
-      // nowhere in the tree, so binding it produces an undefined symbol at
-      // module load. Left out until it has an implementation.
       .def(
           "compute_lower_bound",
           [](SetCoverLagrangian& lagrangian, const std::vector<double>& costs,

--- a/ortools/set_cover/python/set_cover_test.py
+++ b/ortools/set_cover/python/set_cover_test.py
@@ -222,6 +222,95 @@ class SetCoverTest(absltest.TestCase):
             inv.check_consistency(set_cover.consistency_level.FREE_AND_UNCOVERED)
         )
 
+    def test_lagrangian_initialize_multipliers(self):
+        model = create_knights_cover_model(8, 8)
+        inv = set_cover.SetCoverInvariant(model)
+
+        lagrangian = set_cover.SetCoverLagrangian(inv)
+        multipliers = lagrangian.initialize_lagrange_multipliers()
+        self.assertLen(multipliers, model.num_elements)
+        for multiplier in multipliers:
+            self.assertGreaterEqual(multiplier, 0.0)
+
+    def test_lagrangian_reduced_costs(self):
+        model = create_knights_cover_model(4, 4)
+        inv = set_cover.SetCoverInvariant(model)
+
+        lagrangian = set_cover.SetCoverLagrangian(inv)
+        multipliers = lagrangian.initialize_lagrange_multipliers()
+        costs = list(model.subset_costs)
+        reduced_costs = lagrangian.compute_reduced_costs(costs, multipliers)
+        self.assertLen(reduced_costs, model.num_subsets)
+
+    def test_lagrangian_subgradient_and_value(self):
+        model = create_knights_cover_model(4, 4)
+        inv = set_cover.SetCoverInvariant(model)
+
+        lagrangian = set_cover.SetCoverLagrangian(inv)
+        multipliers = lagrangian.initialize_lagrange_multipliers()
+        costs = list(model.subset_costs)
+        reduced_costs = lagrangian.compute_reduced_costs(costs, multipliers)
+
+        subgradient = lagrangian.compute_subgradient(reduced_costs)
+        self.assertLen(subgradient, model.num_elements)
+
+        value = lagrangian.compute_lagrangian_value(reduced_costs, multipliers)
+        self.assertIsInstance(value, float)
+
+    def test_lagrangian_update_multipliers(self):
+        model = create_knights_cover_model(4, 4)
+        inv = set_cover.SetCoverInvariant(model)
+
+        lagrangian = set_cover.SetCoverLagrangian(inv)
+        multipliers = lagrangian.initialize_lagrange_multipliers()
+        costs = list(model.subset_costs)
+        reduced_costs = lagrangian.compute_reduced_costs(costs, multipliers)
+        value = lagrangian.compute_lagrangian_value(reduced_costs, multipliers)
+
+        updated = lagrangian.update_multipliers(
+            1.0, value, 100.0, reduced_costs, multipliers
+        )
+        self.assertLen(updated, model.num_elements)
+        for multiplier in updated:
+            self.assertGreaterEqual(multiplier, 0.0)
+
+    def test_lagrangian_lower_bound(self):
+        model = create_knights_cover_model(8, 8)
+        self.assertTrue(model.compute_feasibility())
+        inv = set_cover.SetCoverInvariant(model)
+
+        greedy = set_cover.GreedySolutionOptimizer(inv)
+        self.assertTrue(greedy.optimize())
+        upper_bound = inv.cost()
+
+        lagrangian = set_cover.SetCoverLagrangian(inv)
+        # compute_lower_bound() runs the parallel code paths unconditionally,
+        # and the thread pool only exists once use_num_threads() has been
+        # called. Without this line the C++ dereferences a null thread pool.
+        lagrangian.use_num_threads(4)
+        costs = list(model.subset_costs)
+        lower_bound, reduced_costs, multipliers = lagrangian.compute_lower_bound(
+            costs, upper_bound
+        )
+        self.assertLen(reduced_costs, model.num_subsets)
+        self.assertLen(multipliers, model.num_elements)
+        self.assertLessEqual(lower_bound, upper_bound)
+
+    def test_lagrangian_parallel_matches_serial(self):
+        model = create_knights_cover_model(4, 4)
+        inv = set_cover.SetCoverInvariant(model)
+
+        lagrangian = set_cover.SetCoverLagrangian(inv)
+        self.assertIs(lagrangian.use_num_threads(2), lagrangian)
+
+        multipliers = lagrangian.initialize_lagrange_multipliers()
+        costs = list(model.subset_costs)
+        serial = lagrangian.compute_reduced_costs(costs, multipliers)
+        parallel = lagrangian.parallel_compute_reduced_costs(costs, multipliers)
+        self.assertLen(parallel, len(serial))
+        for serial_cost, parallel_cost in zip(serial, parallel):
+            self.assertAlmostEqual(serial_cost, parallel_cost)
+
     # TODO(user): KnightsCoverGreedyAndTabu, KnightsCoverGreedyRandomClear,
     # KnightsCoverElementDegreeRandomClear, KnightsCoverRandomClearMip,
     # KnightsCoverMip

--- a/ortools/set_cover/python/set_cover_test.py
+++ b/ortools/set_cover/python/set_cover_test.py
@@ -235,14 +235,11 @@ class SetCoverTest(absltest.TestCase):
         self.assertTrue(greedy.optimize())
         upper_bound = inv.cost()
 
-        lagrangian = set_cover.SetCoverLagrangian(inv)
-        # compute_lower_bound() runs the parallel code paths unconditionally,
-        # and the thread pool only exists once use_num_threads() has been
-        # called. Without this line the C++ dereferences a null thread pool.
-        lagrangian.use_num_threads(4)
-        costs = list(model.subset_costs)
+        # The constructor creates the thread pool, so compute_lower_bound()
+        # is usable without a prior use_num_threads() call.
+        lagrangian = set_cover.SetCoverLagrangian(inv, num_threads=4)
         lower_bound, reduced_costs, multipliers = lagrangian.compute_lower_bound(
-            costs, upper_bound
+            model.subset_costs, upper_bound
         )
         self.assertLen(reduced_costs, model.num_subsets)
         self.assertLen(multipliers, model.num_elements)
@@ -261,13 +258,25 @@ class SetCoverTest(absltest.TestCase):
         inv = set_cover.SetCoverInvariant(model)
         self.assertTrue(set_cover.GreedySolutionOptimizer(inv).optimize())
 
+        lagrangian = set_cover.SetCoverLagrangian(inv)
         # use_num_threads() returns the object itself, so it can be chained.
-        lagrangian = set_cover.SetCoverLagrangian(inv).use_num_threads(1)
+        self.assertIs(lagrangian.use_num_threads(2), lagrangian)
         lower_bound, _, _ = lagrangian.compute_lower_bound(
-            list(model.subset_costs), inv.cost()
+            model.subset_costs, inv.cost()
         )
         self.assertGreater(lower_bound, 0.0)
         self.assertLessEqual(lower_bound, 3.0)
+
+    def test_lagrangian_rejects_invalid_arguments(self):
+        model = create_knights_cover_model(4, 4)
+        inv = set_cover.SetCoverInvariant(model)
+        with self.assertRaises(ValueError):
+            set_cover.SetCoverLagrangian(inv, num_threads=0)
+        lagrangian = set_cover.SetCoverLagrangian(inv)
+        with self.assertRaises(ValueError):
+            lagrangian.use_num_threads(-1)
+        with self.assertRaises(ValueError):
+            lagrangian.compute_lower_bound([1.0, 2.0], 10.0)
 
 
 if __name__ == "__main__":

--- a/ortools/set_cover/python/set_cover_test.py
+++ b/ortools/set_cover/python/set_cover_test.py
@@ -222,58 +222,6 @@ class SetCoverTest(absltest.TestCase):
             inv.check_consistency(set_cover.consistency_level.FREE_AND_UNCOVERED)
         )
 
-    def test_lagrangian_initialize_multipliers(self):
-        model = create_knights_cover_model(8, 8)
-        inv = set_cover.SetCoverInvariant(model)
-
-        lagrangian = set_cover.SetCoverLagrangian(inv)
-        multipliers = lagrangian.initialize_lagrange_multipliers()
-        self.assertLen(multipliers, model.num_elements)
-        for multiplier in multipliers:
-            self.assertGreaterEqual(multiplier, 0.0)
-
-    def test_lagrangian_reduced_costs(self):
-        model = create_knights_cover_model(4, 4)
-        inv = set_cover.SetCoverInvariant(model)
-
-        lagrangian = set_cover.SetCoverLagrangian(inv)
-        multipliers = lagrangian.initialize_lagrange_multipliers()
-        costs = list(model.subset_costs)
-        reduced_costs = lagrangian.compute_reduced_costs(costs, multipliers)
-        self.assertLen(reduced_costs, model.num_subsets)
-
-    def test_lagrangian_subgradient_and_value(self):
-        model = create_knights_cover_model(4, 4)
-        inv = set_cover.SetCoverInvariant(model)
-
-        lagrangian = set_cover.SetCoverLagrangian(inv)
-        multipliers = lagrangian.initialize_lagrange_multipliers()
-        costs = list(model.subset_costs)
-        reduced_costs = lagrangian.compute_reduced_costs(costs, multipliers)
-
-        subgradient = lagrangian.compute_subgradient(reduced_costs)
-        self.assertLen(subgradient, model.num_elements)
-
-        value = lagrangian.compute_lagrangian_value(reduced_costs, multipliers)
-        self.assertIsInstance(value, float)
-
-    def test_lagrangian_update_multipliers(self):
-        model = create_knights_cover_model(4, 4)
-        inv = set_cover.SetCoverInvariant(model)
-
-        lagrangian = set_cover.SetCoverLagrangian(inv)
-        multipliers = lagrangian.initialize_lagrange_multipliers()
-        costs = list(model.subset_costs)
-        reduced_costs = lagrangian.compute_reduced_costs(costs, multipliers)
-        value = lagrangian.compute_lagrangian_value(reduced_costs, multipliers)
-
-        updated = lagrangian.update_multipliers(
-            1.0, value, 100.0, reduced_costs, multipliers
-        )
-        self.assertLen(updated, model.num_elements)
-        for multiplier in updated:
-            self.assertGreaterEqual(multiplier, 0.0)
-
     def test_lagrangian_lower_bound(self):
         model = create_knights_cover_model(8, 8)
         self.assertTrue(model.compute_feasibility())
@@ -296,20 +244,23 @@ class SetCoverTest(absltest.TestCase):
         self.assertLen(multipliers, model.num_elements)
         self.assertLessEqual(lower_bound, upper_bound)
 
-    def test_lagrangian_parallel_matches_serial(self):
+    def test_lagrangian_use_num_threads_comes_first(self):
         model = create_knights_cover_model(4, 4)
         inv = set_cover.SetCoverInvariant(model)
 
+        greedy = set_cover.GreedySolutionOptimizer(inv)
+        self.assertTrue(greedy.optimize())
+        upper_bound = inv.cost()
+
+        # use_num_threads() creates the thread pool that compute_lower_bound()
+        # dereferences, so it has to run first. It returns the object itself,
+        # so the two calls can be chained.
         lagrangian = set_cover.SetCoverLagrangian(inv)
         self.assertIs(lagrangian.use_num_threads(2), lagrangian)
-
-        multipliers = lagrangian.initialize_lagrange_multipliers()
-        costs = list(model.subset_costs)
-        serial = lagrangian.compute_reduced_costs(costs, multipliers)
-        parallel = lagrangian.parallel_compute_reduced_costs(costs, multipliers)
-        self.assertLen(parallel, len(serial))
-        for serial_cost, parallel_cost in zip(serial, parallel):
-            self.assertAlmostEqual(serial_cost, parallel_cost)
+        lower_bound, _, _ = lagrangian.compute_lower_bound(
+            list(model.subset_costs), upper_bound
+        )
+        self.assertLessEqual(lower_bound, upper_bound)
 
     # TODO(user): KnightsCoverGreedyAndTabu, KnightsCoverGreedyRandomClear,
     # KnightsCoverElementDegreeRandomClear, KnightsCoverRandomClearMip,

--- a/ortools/set_cover/python/set_cover_test.py
+++ b/ortools/set_cover/python/set_cover_test.py
@@ -222,6 +222,10 @@ class SetCoverTest(absltest.TestCase):
             inv.check_consistency(set_cover.consistency_level.FREE_AND_UNCOVERED)
         )
 
+    # TODO(user): KnightsCoverGreedyAndTabu, KnightsCoverGreedyRandomClear,
+    # KnightsCoverElementDegreeRandomClear, KnightsCoverRandomClearMip,
+    # KnightsCoverMip
+
     def test_lagrangian_lower_bound(self):
         model = create_knights_cover_model(8, 8)
         self.assertTrue(model.compute_feasibility())
@@ -243,28 +247,27 @@ class SetCoverTest(absltest.TestCase):
         self.assertLen(reduced_costs, model.num_subsets)
         self.assertLen(multipliers, model.num_elements)
         self.assertLessEqual(lower_bound, upper_bound)
+        # The bound is also reported on the invariant, as DualAscentOptimizer
+        # does with its bound.
+        self.assertEqual(inv.export_solution_as_proto().cost_lower_bound, lower_bound)
 
-    def test_lagrangian_use_num_threads_comes_first(self):
-        model = create_knights_cover_model(4, 4)
+    def test_lagrangian_lower_bound_never_exceeds_optimum(self):
+        # Six elements on a cycle, subset i covers {i, i + 1}: the optimum is 3.
+        model = set_cover.SetCoverModel()
+        for i in range(6):
+            model.add_empty_subset(1.0)
+            model.add_element_to_last_subset(i)
+            model.add_element_to_last_subset((i + 1) % 6)
         inv = set_cover.SetCoverInvariant(model)
+        self.assertTrue(set_cover.GreedySolutionOptimizer(inv).optimize())
 
-        greedy = set_cover.GreedySolutionOptimizer(inv)
-        self.assertTrue(greedy.optimize())
-        upper_bound = inv.cost()
-
-        # use_num_threads() creates the thread pool that compute_lower_bound()
-        # dereferences, so it has to run first. It returns the object itself,
-        # so the two calls can be chained.
-        lagrangian = set_cover.SetCoverLagrangian(inv)
-        self.assertIs(lagrangian.use_num_threads(2), lagrangian)
+        # use_num_threads() returns the object itself, so it can be chained.
+        lagrangian = set_cover.SetCoverLagrangian(inv).use_num_threads(1)
         lower_bound, _, _ = lagrangian.compute_lower_bound(
-            list(model.subset_costs), upper_bound
+            list(model.subset_costs), inv.cost()
         )
-        self.assertLessEqual(lower_bound, upper_bound)
-
-    # TODO(user): KnightsCoverGreedyAndTabu, KnightsCoverGreedyRandomClear,
-    # KnightsCoverElementDegreeRandomClear, KnightsCoverRandomClearMip,
-    # KnightsCoverMip
+        self.assertGreater(lower_bound, 0.0)
+        self.assertLessEqual(lower_bound, 3.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Disclosure:** drafted with AI assistance (Claude). I reviewed every line, and built and ran it myself; see Verification for what that covered.

*Edited 2026-09-05: narrowed from twelve bound methods to the two the solver binary itself uses, the binding made safe to call, and the benchmark redone on 50 OR-Library instances against verified optima. The earlier description is in the edit history. Merges cleanly into `main` @ `5a1b660`.*

### What

Binds `SetCoverLagrangian::ComputeLowerBound()` and `UseNumThreads()` to Python, the same two calls `set_cover_solve.cc` makes to compute `LagrangianRelaxationLB`. This clears `// TODO(user): add support for SetCoverLagrangian.` at the end of `ortools/set_cover/python/set_cover.cc`. No change in the algorithm.

The Python module has greedy, steepest, GLS, tabu and dual ascent, but no way to get a Lagrangian bound. `SetCoverLagrangian(inv, num_threads=1)`, `use_num_threads(n)` and `compute_lower_bound(costs, upper_bound)`, which returns `(bound, reduced_costs, multipliers)` as `(float, list[float], list[float])`; the last two are not reachable from Python by any other route. The bound is also written to the invariant through `ReportLowerBound()`, as `DualAscentOptimizer` does with its bound. Docstrings state what the triple is (the bound is the best value seen, the vectors come from the final iteration) and that the GIL is released while the loop runs.

### Why: a much tighter bound than the one Python already has

All 50 OR-Library instances of sets 4, 5, 6 and A to E, read with the already-bound `read_orlib_scp`. Optimum from CP-SAT (every instance `OPTIMAL`, all within 9 s), LP relaxation from GLOP. Primal is `GreedySolutionOptimizer` then `SteepestSearch`. Dual ascent is `DualAscentOptimizer` with `set_num_random_passes(50)`, best of three runs; it is randomized and moves by a few units between runs, and 200 passes did not improve it. Lagrangian is `compute_lower_bound(costs, primal)` with 4 threads; every result is bit-identical with 1 thread, and every bound is at most the LP bound. Gaps are relative to the optimum, mean over the set with the range in brackets.

| set | instances | subsets | elements | dual ascent gap to optimum | Lagrangian gap to optimum | Lagrangian / LP bound | dual ascent time | Lagrangian time |
|---|---|---|---|---|---|---|---|---|
| scp4x | 10 | 1000 | 200 | 9.4% (7.3 to 10.5) | 0.9% (0.1 to 1.9) | 99.3% | 3 ms | 0.32 s |
| scp5x | 10 | 2000 | 200 | 9.9% (7.9 to 11.6) | 0.8% (0.2 to 1.3) | 99.5% | 5 ms | 0.38 s |
| scp6x | 5 | 1000 | 200 | 20.5% (17.6 to 23.3) | 6.1% (5.5 to 6.8) | 97.2% | 6 ms | 0.33 s |
| scpax | 5 | 3000 | 300 | 16.6% (14.8 to 18.3) | 3.0% (2.1 to 3.7) | 98.5% | 10 ms | 0.45 s |
| scpbx | 5 | 3000 | 300 | 28.4% (25.0 to 31.6) | 10.7% (9.1 to 12.6) | 96.8% | 22 ms | 0.58 s |
| scpcx | 5 | 4000 | 400 | 20.7% (19.4 to 22.6) | 4.4% (3.4 to 6.0) | 97.8% | 16 ms | 0.56 s |
| scpdx | 5 | 4000 | 400 | 32.0% (27.9 to 34.8) | 11.8% (7.2 to 13.5) | 96.2% | 34 ms | 0.74 s |
| scpex | 5 | 500 | 50 | 80.0% (80.0 to 80.0) | 32.7% (31.0 to 34.5) | 99.0% | 2 ms | 0.28 s |
| all | 50 | | | 23.7% | 7.2% | 98.3% | 11 ms | 0.43 s |

The Lagrangian bound reaches 96 to 99.5% of the LP bound, and closes about two thirds of the gap dual ascent leaves. It costs 30 to 150 times more wall clock, because `ComputeLowerBound()` runs a fixed 1000-iteration subgradient loop.

<details>
<summary>Per-instance results</summary>

| instance | optimum | LP | primal | dual ascent LB | gap | Lagrangian LB | gap | dual ascent | Lagrangian |
|---|---|---|---|---|---|---|---|---|---|
| scp41 | 429 | 429.00 | 438 | 385 | 10.3% | 420.96 | 1.9% | 3 ms | 0.32 s |
| scp42 | 512 | 512.00 | 547 | 465 | 9.2% | 511.10 | 0.2% | 3 ms | 0.32 s |
| scp43 | 516 | 516.00 | 546 | 466 | 9.7% | 515.39 | 0.1% | 3 ms | 0.30 s |
| scp44 | 494 | 494.00 | 510 | 458 | 7.3% | 489.01 | 1.0% | 3 ms | 0.32 s |
| scp45 | 512 | 512.00 | 519 | 465 | 9.2% | 507.79 | 0.8% | 3 ms | 0.32 s |
| scp46 | 560 | 557.25 | 594 | 501 | 10.5% | 556.52 | 0.6% | 3 ms | 0.32 s |
| scp47 | 430 | 430.00 | 449 | 390 | 9.3% | 426.19 | 0.9% | 3 ms | 0.33 s |
| scp48 | 492 | 488.67 | 502 | 441 | 10.4% | 485.48 | 1.3% | 4 ms | 0.28 s |
| scp49 | 641 | 638.54 | 672 | 579 | 9.7% | 636.19 | 0.8% | 3 ms | 0.32 s |
| scp410 | 514 | 513.50 | 521 | 470 | 8.6% | 509.07 | 1.0% | 3 ms | 0.33 s |
| scp51 | 253 | 251.22 | 271 | 225 | 11.1% | 250.33 | 1.1% | 6 ms | 0.37 s |
| scp52 | 302 | 299.76 | 329 | 272 | 9.9% | 298.78 | 1.1% | 5 ms | 0.42 s |
| scp53 | 226 | 226.00 | 232 | 208 | 8.0% | 224.87 | 0.5% | 5 ms | 0.40 s |
| scp54 | 242 | 240.50 | 253 | 214 | 11.6% | 240.22 | 0.7% | 5 ms | 0.39 s |
| scp55 | 211 | 211.00 | 220 | 192 | 9.0% | 210.15 | 0.4% | 5 ms | 0.40 s |
| scp56 | 213 | 212.50 | 234 | 194 | 8.9% | 212.50 | 0.2% | 5 ms | 0.38 s |
| scp57 | 293 | 291.78 | 311 | 263 | 10.2% | 290.75 | 0.8% | 5 ms | 0.37 s |
| scp58 | 288 | 287.00 | 308 | 256 | 11.1% | 285.20 | 1.0% | 5 ms | 0.35 s |
| scp59 | 279 | 279.00 | 290 | 247 | 11.5% | 275.39 | 1.3% | 5 ms | 0.36 s |
| scp510 | 265 | 265.00 | 274 | 244 | 7.9% | 263.14 | 0.7% | 5 ms | 0.37 s |
| scp61 | 138 | 133.14 | 147 | 107 | 22.5% | 128.64 | 6.8% | 5 ms | 0.35 s |
| scp62 | 146 | 140.46 | 160 | 112 | 23.3% | 137.91 | 5.5% | 6 ms | 0.36 s |
| scp63 | 145 | 140.13 | 152 | 118 | 18.6% | 136.70 | 5.7% | 8 ms | 0.31 s |
| scp64 | 131 | 129.00 | 137 | 108 | 17.6% | 122.81 | 6.2% | 5 ms | 0.32 s |
| scp65 | 161 | 153.35 | 178 | 128 | 20.5% | 151.07 | 6.2% | 6 ms | 0.31 s |
| scpa1 | 253 | 246.84 | 271 | 210 | 17.0% | 243.94 | 3.6% | 10 ms | 0.44 s |
| scpa2 | 252 | 247.50 | 267 | 206 | 18.3% | 242.76 | 3.7% | 12 ms | 0.48 s |
| scpa3 | 232 | 228.00 | 244 | 192 | 17.2% | 224.78 | 3.1% | 10 ms | 0.47 s |
| scpa4 | 234 | 231.40 | 246 | 197 | 15.8% | 227.90 | 2.6% | 10 ms | 0.42 s |
| scpa5 | 236 | 234.89 | 247 | 201 | 14.8% | 231.09 | 2.1% | 9 ms | 0.44 s |
| scpb1 | 69 | 64.54 | 73 | 49 | 29.0% | 62.65 | 9.2% | 21 ms | 0.61 s |
| scpb2 | 76 | 69.30 | 78 | 54 | 28.9% | 66.44 | 12.6% | 21 ms | 0.58 s |
| scpb3 | 80 | 74.16 | 85 | 58 | 27.5% | 71.52 | 10.6% | 20 ms | 0.57 s |
| scpb4 | 79 | 71.22 | 85 | 54 | 31.6% | 69.60 | 11.9% | 20 ms | 0.57 s |
| scpb5 | 72 | 67.67 | 76 | 54 | 25.0% | 65.42 | 9.1% | 26 ms | 0.57 s |
| scpc1 | 227 | 223.80 | 246 | 183 | 19.4% | 218.04 | 3.9% | 16 ms | 0.59 s |
| scpc2 | 219 | 212.85 | 231 | 176 | 19.6% | 208.50 | 4.8% | 16 ms | 0.56 s |
| scpc3 | 243 | 234.58 | 256 | 188 | 22.6% | 228.44 | 6.0% | 16 ms | 0.57 s |
| scpc4 | 219 | 213.85 | 239 | 171 | 21.9% | 210.14 | 4.0% | 17 ms | 0.54 s |
| scpc5 | 215 | 211.64 | 228 | 172 | 20.0% | 207.70 | 3.4% | 16 ms | 0.55 s |
| scpd1 | 60 | 55.31 | 68 | 40 | 33.3% | 52.93 | 11.8% | 34 ms | 0.77 s |
| scpd2 | 66 | 59.35 | 70 | 43 | 34.8% | 57.28 | 13.2% | 34 ms | 0.72 s |
| scpd3 | 72 | 65.07 | 78 | 47 | 34.7% | 62.26 | 13.5% | 34 ms | 0.72 s |
| scpd4 | 62 | 55.84 | 65 | 44 | 29.0% | 53.90 | 13.1% | 34 ms | 0.74 s |
| scpd5 | 61 | 58.62 | 71 | 44 | 27.9% | 56.58 | 7.2% | 34 ms | 0.73 s |
| scpe1 | 5 | 3.48 | 5 | 1 | 80.0% | 3.45 | 31.0% | 2 ms | 0.26 s |
| scpe2 | 5 | 3.38 | 6 | 1 | 80.0% | 3.34 | 33.2% | 2 ms | 0.31 s |
| scpe3 | 5 | 3.30 | 5 | 1 | 80.0% | 3.27 | 34.5% | 2 ms | 0.27 s |
| scpe4 | 5 | 3.45 | 6 | 1 | 80.0% | 3.41 | 31.8% | 2 ms | 0.29 s |
| scpe5 | 5 | 3.39 | 5 | 1 | 80.0% | 3.36 | 32.8% | 2 ms | 0.29 s |
</details>

<details>
<summary>Reproduce (this build, the OR-Library `scp*.txt` files in the working directory)</summary>

```python
import glob, os, time
from ortools.set_cover.python import set_cover

for path in sorted(glob.glob("scp*.txt")):
    model = set_cover.read_orlib_scp(path)
    inv = set_cover.SetCoverInvariant(model)
    set_cover.GreedySolutionOptimizer(inv).optimize()
    steepest = set_cover.SteepestSearch(inv)
    steepest.set_max_iterations(2000)
    steepest.optimize()
    primal = inv.cost()

    dual_lb, t0 = 0.0, time.perf_counter()
    for _ in range(3):
        inv_d = set_cover.SetCoverInvariant(model)
        dual = set_cover.DualAscentOptimizer(inv_d)
        dual.set_num_random_passes(50)
        dual.optimize()
        dual_lb = max(dual_lb, inv_d.export_solution_as_proto().cost_lower_bound)
    dual_s = (time.perf_counter() - t0) / 3

    lagrangian = set_cover.SetCoverLagrangian(set_cover.SetCoverInvariant(model), num_threads=4)
    t0 = time.perf_counter()
    lag_lb, _, _ = lagrangian.compute_lower_bound(model.subset_costs, primal)
    lag_s = time.perf_counter() - t0
    print(f"{os.path.basename(path)}: primal {primal:.0f} dual {dual_lb:.0f} ({dual_s:.3f}s) lagrangian {lag_lb:.2f} ({lag_s:.2f}s)")
```

Optima: CP-SAT on the same files (`AddBoolOr` per row, minimize the cost sum), all `OPTIMAL`; they match the published values.
</details>

### Scope

The rest of the class's public surface is deliberately left unbound. The header marks the class as interim (_"intended to be used only for ComputeLowerBound(). FOR THE TIME BEING"_) and `set_cover_solve.cc:331` carries a TODO to make its API uniform. Binding more would fix in Python an API you plan to change. 
An earlier revision of this PR did bind all twelve methods; I could go back to that if wanted..

Also, one question: 
- would you rather see `SetCoverCftOptimizer` bound instead? 

It fits the `SetCoverOptimizer` pattern the existing bindings already wrap. If so, I will close this and open that.

### Two things in the C++ class, filed as #5341

Neither comes from this PR, and both were reproduced on this build. `ThreePhase()` is declared but has no definition (the three-phase procedure lives in `set_cover_cft.cc`); binding it makes the module fail at import with `undefined symbol`, so it is left unbound with a comment. `ComputeLowerBound()` dereferences a null `thread_pool_` unless `UseNumThreads()` ran first (SIGSEGV, 5 of 5 runs); `set_cover_solve.cc` does call it first, the header does not say so. The Python constructor therefore takes `num_threads` (default 1) and creates the pool itself, so a fresh object cannot hit that path. For the same reason the binding rejects `num_threads < 1` (division by zero in `BlockSize()`) and a `costs` list whose length differs from the model's subset count (out-of-bounds read in `FillReducedCostsSlice()`) with `ValueError`.

### Changes

- `ortools/set_cover/python/set_cover.cc`: include, `using` for `Cost` and `SetCoverLagrangian`, a `CheckNumThreads()` helper, `py::class_<SetCoverLagrangian>` with constructor, `use_num_threads`, `compute_lower_bound`, docstrings.
- `ortools/set_cover/python/set_cover_test.py`: 3 tests: the bound on the knights-cover model (sizes, bound at most the primal cost, bound reported on the invariant), the bound on a 6-cycle with known optimum 3, and the three `ValueError` cases.
- `ortools/set_cover/python/BUILD.bazel`: adds the `//ortools/set_cover:set_cover_lagrangian` dep.
- `ortools/set_cover/python/CMakeLists.txt`: no change needed, the pybind target already links `::ortools`.

`costs` is typed `const std::vector<double>&`, not `absl::Span<const double>`: this module registers no `absl::Span` caster, so a Span-typed parameter cannot be called from Python at all (see #5278 for the existing cases).

### Verification

`bazel test //ortools/set_cover/python:set_cover_test` passes on Linux (Bazel 8.7.0, x86_64) against `main` @ `5a1b660`: 13 tests, the 10 existing plus the 3 added. `clang-format` clean against the repo `.clang-format`; `black` clean at the file's existing line width. The benchmark above ran on that same build.

No longer depends on #5121. CLA signed.

### Checklist

- [x] Read CONTRIBUTING.md and the PR template, targeting `main`
- [x] CLA signed
- [x] Minimal diff: bindings, tests, and one build dep
- [x] No unrelated formatting or refactoring changes
- [x] AI-assisted: disclosed above
