### PR TITLE
Fix illegal pybind11 keep_alive in def_property_readonly (#5140)

### DIFF
--- a/ortools/sat/python/wrappers.cc
+++ b/ortools/sat/python/wrappers.cc
@@ -344,7 +344,7 @@ class Generator {
     .def_property_readonly(
         "$0",
         []($1 self) { return self->mutable_$2(); },
-        py::return_value_policy::reference, py::keep_alive<0, 1>()))",
+        py::return_value_policy::reference_internal))",
           field.name(), current_context_.self_mutable_name, field.name());
       // We'll need to generate the wrapping for
       // `google::protobuf::RepeatedPtrField<$3>`.
@@ -357,7 +357,7 @@ class Generator {
     .def_property_readonly(
         "$0",
         []($1 self) { return self->mutable_$0(); },
-        py::return_value_policy::reference, py::keep_alive<0, 1>()))",
+        py::return_value_policy::reference_internal))",
                                 field.name(),
                                 current_context_.self_mutable_name);
       // We'll need to generate the wrapping for


### PR DESCRIPTION
## Problem

Modern pybind11 rejects `keep_alive` inside `def_property_readonly`:

```cpp
.def_property_readonly(
    "...",
    getter,
    py::return_value_policy::reference,
    py::keep_alive<0, 1>())
```

This now triggers:

> `static assertion failed: def_property family does not currently support keep_alive`

The root cause is in `ortools/util/python/wrappers.cc`, where autogenerated bindings emit this pattern for repeated protobuf fields.

## Fix

Replace:

```cpp
py::return_value_policy::reference,
py::keep_alive<0,1>()
```

with:

```cpp
py::return_value_policy::reference_internal
```

`reference_internal` preserves non-owning reference semantics while correctly tying returned field lifetime to the owning protobuf object.

## Impact

This fixes generated bindings for repeated proto fields such as:

* `CircuitConstraintProto.tails`
* `CircuitConstraintProto.heads`
* `CircuitConstraintProto.literals`

and other repeated protobuf fields generated through `GenerateRepeatedField()`.

## Testing

* Replaces unsupported call policy usage with supported `reference_internal` lifetime semantics compatible with modern pybind11.
* Preserves lifetime semantics correctly
* No behavioral change beyond fixing invalid annotation usage

Fixes #5140
