### PR TITLE
Integrate HiGHS and few minor fixes from Augmenta

### DIFF
--- a/examples/cpp/uncapacitated_facility_location.cc
+++ b/examples/cpp/uncapacitated_facility_location.cc
@@ -211,6 +211,11 @@ void RunAllExamples(int32_t facilities, int32_t clients, double fix_cost) {
   UncapacitatedFacilityLocation(facilities, clients, fix_cost,
                                 MPSolver::GLPK_MIXED_INTEGER_PROGRAMMING);
 #endif
+#if defined(USE_HIGHS)
+  LOG(INFO) << "---- Integer programming example with HiGHS ----";
+  UncapacitatedFacilityLocation(facilities, clients, fix_cost,
+                                MPSolver::HIGHS_MIXED_INTEGER_PROGRAMMING);
+#endif
 #if defined(USE_SCIP)
   LOG(INFO) << "---- Integer programming example with SCIP ----";
   UncapacitatedFacilityLocation(facilities, clients, fix_cost,

--- a/makefiles/Makefile.cpp.mk
+++ b/makefiles/Makefile.cpp.mk
@@ -603,6 +603,7 @@ detect_cpp:
 	@echo USE_COINOR = $(USE_COINOR)
 	@echo USE_SCIP = $(USE_SCIP)
 	@echo USE_GLPK = $(USE_GLPK)
+	@echo USE_HIGHS = $(USE_HIGHS)
 	@echo USE_CPLEX = $(USE_CPLEX)
 ifdef GLPK_ROOT
 	@echo GLPK_ROOT = $(GLPK_ROOT)

--- a/ortools/graph/christofides.h
+++ b/ortools/graph/christofides.h
@@ -57,9 +57,9 @@ class ChristofidesPathSolver {
  public:
   enum class MatchingAlgorithm {
     MINIMUM_WEIGHT_MATCHING,
-#if defined(USE_CBC) || defined(USE_SCIP)
+#if defined(USE_CBC) || defined(USE_SCIP) || defined(USE_HIGHS)
     MINIMUM_WEIGHT_MATCHING_WITH_MIP,
-#endif  // defined(USE_CBC) || defined(USE_SCIP)
+#endif  // defined(USE_CBC) || defined(USE_SCIP) || defined(USE_HIGHS)
     MINIMAL_WEIGHT_MATCHING,
   };
   ChristofidesPathSolver(NodeIndex num_nodes, CostFunction costs);
@@ -155,7 +155,7 @@ ComputeMinimumWeightMatching(const GraphType& graph,
   return match;
 }
 
-#if defined(USE_CBC) || defined(USE_SCIP)
+#if defined(USE_CBC) || defined(USE_SCIP) || defined(USE_HIGHS)
 // Computes a minimum weight perfect matching on an undirected graph using a
 // Mixed Integer Programming model.
 // TODO(user): Handle infeasible cases if this algorithm is used outside of
@@ -211,6 +211,9 @@ ComputeMinimumWeightMatchingWithMIP(const GraphType& graph,
 #if defined(USE_SCIP)
   MPSolver mp_solver("MatchingWithSCIP",
                      MPSolver::SCIP_MIXED_INTEGER_PROGRAMMING);
+#elif defined(USE_HIGHS)
+  MPSolver mp_solver("MatchingWithHiGHS",
+                     MPSolver::HIGHS_MIXED_INTEGER_PROGRAMMING);
 #elif defined(USE_CBC)
   MPSolver mp_solver("MatchingWithCBC",
                      MPSolver::CBC_MIXED_INTEGER_PROGRAMMING);
@@ -330,7 +333,7 @@ ChristofidesPathSolver<CostType, ArcIndex, NodeIndex, CostFunction>::Solve() {
       result->swap(closure_arcs);
       break;
     }
-#endif  // defined(USE_CBC) || defined(USE_SCIP)
+#endif  // defined(USE_CBC) || defined(USE_SCIP) || defined(USE_HIGHS)
     case MatchingAlgorithm::MINIMAL_WEIGHT_MATCHING: {
       // TODO(user): Cost caching was added and can gain up to 20% but
       // increases memory usage; see if we can avoid caching.


### PR DESCRIPTION
This pull request introduces support for the HiGHS solver throughout the codebase, updates some dependency versions, and adds a patch for SCIP to fix assertion issues. The changes ensure that HiGHS can be used as a backend for various algorithms and examples, and that the build system and workspace configuration are updated accordingly.

**HiGHS Solver Integration:**

* Added support for HiGHS in the Christofides algorithm, enabling minimum weight matching with MIP using HiGHS (`ortools/graph/christofides.h`). [[1]](diffhunk://#diff-d011f3396431247663758fd0ac7ea1c117370f3bfb728ad987962898e1e17702L60-R62) [[2]](diffhunk://#diff-d011f3396431247663758fd0ac7ea1c117370f3bfb728ad987962898e1e17702L158-R158) [[3]](diffhunk://#diff-d011f3396431247663758fd0ac7ea1c117370f3bfb728ad987962898e1e17702R214-R216) [[4]](diffhunk://#diff-d011f3396431247663758fd0ac7ea1c117370f3bfb728ad987962898e1e17702L333-R336)
* Enabled HiGHS for the uncapacitated facility location example (`examples/cpp/uncapacitated_facility_location.cc`).
* Updated the Makefile to display the `USE_HIGHS` flag (`makefiles/Makefile.cpp.mk`).
* Added the `USE_HIGHS` define to the workspace configuration (`or-tools.code-workspace`).
* Added comments and TODOs in the HiGHS interface implementation for future improvements (`ortools/linear_solver/highs_interface.cc`). [[1]](diffhunk://#diff-dea83aad64ba00c0e1e6e7e97145f63eeaf227291ddd6e21fa138022f02c802aR227-R240) [[2]](diffhunk://#diff-dea83aad64ba00c0e1e6e7e97145f63eeaf227291ddd6e21fa138022f02c802aR252-R256)

**Dependency and Build System Updates:**

* Updated `google_benchmark` and `googletest` Bazel dependencies to newer versions and resolved merge conflicts in `MODULE.bazel`.
* Added a `git_override` for SCIP with a patch to fix debug-build assertion issues (`MODULE.bazel`, `patches/scip-v10.0.2.patch`). [[1]](diffhunk://#diff-6136fc12446089c3db7360e923203dd114b6a1466252e71667c6791c20fe6bdcR78-R86) [[2]](diffhunk://#diff-46f4620badf16439c5c3ae998d867d31a70188f72396b43ace1e6a01141f8ce4R110-R150)

These changes collectively improve solver flexibility, maintainability, and build reliability.<!--
Thank you for submitting a PR!

Please make sure you are targeting the main branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->
