### PR TITLE
graph: Extract `Build()` from the `BaseGraph` class.

### DIFF
--- a/ortools/algorithms/find_graph_symmetries_test.cc
+++ b/ortools/algorithms/find_graph_symmetries_test.cc
@@ -696,22 +696,20 @@ TEST_F(FindSymmetriesTest, InwardGrid) {
   }
 }
 
-void AddReverseArcs(Graph* graph) {
+void AddReverseArcs(Graph::Builder& builder) {
+  const auto graph = Graph::Builder(builder).Build(nullptr);
   const int num_arcs = graph->num_arcs();
   for (int a = 0; a < num_arcs; ++a) {
-    graph->AddArc(graph->Head(a), graph->Tail(a));
+    builder.AddArc(graph->Head(a), graph->Tail(a));
   }
 }
 
-void AddReverseArcsAndFinalize(Graph* graph) {
-  AddReverseArcs(graph);
-  graph->Build();
-}
-
-void SetGraphEdges(absl::Span<const std::pair<int, int>> edges, Graph* graph) {
-  DCHECK_EQ(graph->num_arcs(), 0);
-  for (const auto [from, to] : edges) graph->AddArc(from, to);
-  AddReverseArcsAndFinalize(graph);
+std::unique_ptr<Graph> MakeGraphFromEdges(
+    absl::Span<const std::pair<int, int>> edges) {
+  Graph::Builder builder;
+  for (const auto [from, to] : edges) builder.AddArc(from, to);
+  AddReverseArcs(builder);
+  return std::move(builder).Build(nullptr);
 }
 
 TEST(CountTrianglesTest, EmptyGraph) {
@@ -723,19 +721,18 @@ TEST(CountTrianglesTest, SimpleUndirectedExample) {
   // 0--1--2
   //  `.|`.|
   //    3--4--5
-  Graph g;
-  SetGraphEdges(
-      {{0, 1}, {1, 2}, {0, 3}, {1, 4}, {1, 3}, {2, 4}, {3, 4}, {4, 5}}, &g);
+  const auto g = MakeGraphFromEdges(
+      {{0, 1}, {1, 2}, {0, 3}, {1, 4}, {1, 3}, {2, 4}, {3, 4}, {4, 5}});
   // Reminder: every undirected triangle counts as two directed triangles.
-  EXPECT_THAT(CountTriangles(g, /*max_degree=*/999),
+  EXPECT_THAT(CountTriangles(*g, /*max_degree=*/999),
               ElementsAre(2, 6, 2, 4, 4, 0));
-  EXPECT_THAT(CountTriangles(g, /*max_degree=*/3),
+  EXPECT_THAT(CountTriangles(*g, /*max_degree=*/3),
               ElementsAre(2, 0, 2, 4, 0, 0));
-  EXPECT_THAT(CountTriangles(g, /*max_degree=*/2),
+  EXPECT_THAT(CountTriangles(*g, /*max_degree=*/2),
               ElementsAre(2, 0, 2, 0, 0, 0));
-  EXPECT_THAT(CountTriangles(g, /*max_degree=*/1),
+  EXPECT_THAT(CountTriangles(*g, /*max_degree=*/1),
               ElementsAre(0, 0, 0, 0, 0, 0));
-  EXPECT_THAT(CountTriangles(g, /*max_degree=*/0),
+  EXPECT_THAT(CountTriangles(*g, /*max_degree=*/0),
               ElementsAre(0, 0, 0, 0, 0, 0));
 }
 
@@ -745,7 +742,7 @@ TEST(CountTrianglesTest, SimpleDirectedExample) {
   // 0     |    |     5
   //  \    |    v    /
   //   `-> 3 <- 4 <-'
-  Graph g;
+  Graph::Builder builder;
   for (auto [from, to] : std::vector<std::pair<int, int>>{
            {0, 1},
            {1, 2},
@@ -757,12 +754,12 @@ TEST(CountTrianglesTest, SimpleDirectedExample) {
            {2, 4},
            {4, 2},
        }) {
-    g.AddArc(from, to);
+    builder.AddArc(from, to);
   }
-  g.Build();
-  EXPECT_THAT(CountTriangles(g, /*max_degree=*/999),
+  const auto g = std::move(builder).Build(nullptr);
+  EXPECT_THAT(CountTriangles(*g, /*max_degree=*/999),
               ElementsAre(1, 0, 0, 0, 0, 2));
-  EXPECT_THAT(CountTriangles(g, /*max_degree=*/1),
+  EXPECT_THAT(CountTriangles(*g, /*max_degree=*/1),
               ElementsAre(0, 0, 0, 0, 0, 0));
 }
 
@@ -770,15 +767,14 @@ TEST(LocalBfsTest, SimpleExample) {
   // 0--1--2
   //  `.|`.|
   //    3--4--5
-  Graph g;
-  SetGraphEdges(
-      {{0, 1}, {1, 2}, {0, 3}, {1, 4}, {1, 3}, {2, 4}, {3, 4}, {4, 5}}, &g);
-  std::vector<bool> tmp_mask(g.num_nodes(), false);
+  const auto g = MakeGraphFromEdges(
+      {{0, 1}, {1, 2}, {0, 3}, {1, 4}, {1, 3}, {2, 4}, {3, 4}, {4, 5}});
+  std::vector<bool> tmp_mask(g->num_nodes(), false);
   std::vector<int> visited;
   std::vector<int> num_within_radius;
 
   // Run a first unlimited BFS from 0.
-  LocalBfs(g, /*source=*/0, /*stop_after_num_nodes=*/99, &visited,
+  LocalBfs(*g, /*source=*/0, /*stop_after_num_nodes=*/99, &visited,
            &num_within_radius, &tmp_mask);
   EXPECT_THAT(
       visited,
@@ -791,7 +787,7 @@ TEST(LocalBfsTest, SimpleExample) {
 
   // Then a BFS that stops after visiting 4 nodes: we should finish exploring
   // that distance, i.e. explore 2 and 4, but not 5. Still, 5 is "visited".
-  LocalBfs(g, /*source=*/0, /*stop_after_num_nodes=*/4, &visited,
+  LocalBfs(*g, /*source=*/0, /*stop_after_num_nodes=*/4, &visited,
            &num_within_radius, &tmp_mask);
   EXPECT_THAT(visited, AnyOf(ElementsAre(0, 1, 3, 2, 4, 5),
                              ElementsAre(0, 1, 3, 4, 2, 5),
@@ -799,7 +795,7 @@ TEST(LocalBfsTest, SimpleExample) {
   EXPECT_THAT(num_within_radius, ElementsAre(1, 3, 5, 6));
 
   // Then a BFS that stops after visiting 2 nodes.
-  LocalBfs(g, /*source=*/0, /*stop_after_num_nodes=*/2, &visited,
+  LocalBfs(*g, /*source=*/0, /*stop_after_num_nodes=*/2, &visited,
            &num_within_radius, &tmp_mask);
   EXPECT_THAT(visited,
               AnyOf(ElementsAre(0, 1, 3, 2, 4), ElementsAre(0, 1, 3, 4, 2),
@@ -807,12 +803,12 @@ TEST(LocalBfsTest, SimpleExample) {
   EXPECT_THAT(num_within_radius, ElementsAre(1, 3, 5));
 
   // Now run a BFS from node 3, stop exploring after 1 node.
-  LocalBfs(g, /*source=*/3, /*stop_after_num_nodes=*/1, &visited,
+  LocalBfs(*g, /*source=*/3, /*stop_after_num_nodes=*/1, &visited,
            &num_within_radius, &tmp_mask);
   EXPECT_THAT(visited, UnorderedElementsAre(3, 0, 1, 4));
   EXPECT_THAT(num_within_radius, ElementsAre(1, 4));
   // Now after 2 nodes.
-  LocalBfs(g, /*source=*/3, /*stop_after_num_nodes=*/2, &visited,
+  LocalBfs(*g, /*source=*/3, /*stop_after_num_nodes=*/2, &visited,
            &num_within_radius, &tmp_mask);
   EXPECT_THAT(visited, UnorderedElementsAre(3, 0, 1, 4, 2, 5));
   EXPECT_THAT(num_within_radius, ElementsAre(1, 4, 6));

--- a/ortools/bop/boolean_problem.cc
+++ b/ortools/bop/boolean_problem.cc
@@ -561,7 +561,7 @@ class IdGenerator {
 // in [0, num_classes) and any symmetry will only map nodes with the same class
 // between each other.
 template <typename Graph>
-Graph* GenerateGraphForSymmetryDetection(
+std::unique_ptr<const Graph> GenerateGraphForSymmetryDetection(
     const LinearBooleanProblem& problem,
     std::vector<int>* initial_equivalence_classes) {
   // First, we convert the problem to its canonical representation.
@@ -578,7 +578,7 @@ Graph* GenerateGraphForSymmetryDetection(
 
   // TODO(user): reserve the memory for the graph? not sure it is worthwhile
   // since it would require some linear scan of the problem though.
-  Graph* graph = new Graph();
+  typename Graph::Builder builder;
   initial_equivalence_classes->clear();
 
   // We will construct a graph with 3 different types of node that must be
@@ -593,8 +593,8 @@ Graph* GenerateGraphForSymmetryDetection(
     // Note that the indices are in [0, 2 * num_variables) and in one to one
     // correspondence with the index representation of a literal.
     const Literal literal = Literal(BooleanVariable(i), true);
-    graph->AddArc(literal.Index().value(), literal.NegatedIndex().value());
-    graph->AddArc(literal.NegatedIndex().value(), literal.Index().value());
+    builder.AddArc(literal.Index().value(), literal.NegatedIndex().value());
+    builder.AddArc(literal.NegatedIndex().value(), literal.Index().value());
   }
 
   // We use 0 for their initial equivalence class, but that may be modified
@@ -648,18 +648,18 @@ Graph* GenerateGraphForSymmetryDetection(
         // Connect this node to the constraint node. Note that we don't
         // technically need the arcs in both directions, but that may help a bit
         // the algorithm to find symmetries.
-        graph->AddArc(constraint_node_index, current_node_index);
-        graph->AddArc(current_node_index, constraint_node_index);
+        builder.AddArc(constraint_node_index, current_node_index);
+        builder.AddArc(current_node_index, constraint_node_index);
       }
 
       // Connect this node to the associated term.literal node. Note that we
       // don't technically need the arcs in both directions, but that may help a
       // bit the algorithm to find symmetries.
-      graph->AddArc(current_node_index, term.literal.Index().value());
-      graph->AddArc(term.literal.Index().value(), current_node_index);
+      builder.AddArc(current_node_index, term.literal.Index().value());
+      builder.AddArc(term.literal.Index().value(), current_node_index);
     }
   }
-  graph->Build();
+  auto graph = std::move(builder).Build(nullptr);
   DCHECK_EQ(graph->num_nodes(), initial_equivalence_classes->size());
   return graph;
 }
@@ -704,8 +704,8 @@ void FindLinearBooleanProblemSymmetries(
     std::vector<std::unique_ptr<SparsePermutation>>* generators) {
   typedef GraphSymmetryFinder::Graph Graph;
   std::vector<int> equivalence_classes;
-  std::unique_ptr<Graph> graph(
-      GenerateGraphForSymmetryDetection<Graph>(problem, &equivalence_classes));
+  std::unique_ptr<const Graph> graph =
+      GenerateGraphForSymmetryDetection<Graph>(problem, &equivalence_classes);
   LOG(INFO) << "Graph has " << graph->num_nodes() << " nodes and "
             << graph->num_arcs() / 2 << " edges.";
 #if defined(ORTOOLS_TARGET_OS_SUPPORTS_FILE)

--- a/ortools/graph/BUILD.bazel
+++ b/ortools/graph/BUILD.bazel
@@ -48,12 +48,9 @@ cc_test(
         "//ortools/base:types",
         "//ortools/graph_base:graph",
         "//ortools/graph_base:io",
-        "//ortools/graph_base:test_util",
         "//ortools/util:flat_matrix",
-        "@abseil-cpp//absl/log:check",
         "@abseil-cpp//absl/random",
         "@abseil-cpp//absl/random:distributions",
-        "@google_benchmark//:benchmark",
     ],
 )
 
@@ -150,7 +147,6 @@ cc_test(
         "@abseil-cpp//absl/random:distributions",
         "@abseil-cpp//absl/strings",
         "@abseil-cpp//absl/types:span",
-        "@google_benchmark//:benchmark",
     ],
 )
 
@@ -215,7 +211,6 @@ cc_test(
         "@abseil-cpp//absl/status",
         "@abseil-cpp//absl/strings:str_format",
         "@abseil-cpp//absl/types:span",
-        "@google_benchmark//:benchmark",
     ],
 )
 
@@ -234,7 +229,6 @@ cc_test(
         "//ortools/base:gmock_main",
         "//ortools/graph_base:graph",
         "@abseil-cpp//absl/base:core_headers",
-        "@google_benchmark//:benchmark",
     ],
 )
 
@@ -258,7 +252,6 @@ cc_test(
         "//ortools/base:types",
         "//ortools/graph_base:graph",
         "@abseil-cpp//absl/base:core_headers",
-        "@abseil-cpp//absl/random:distributions",
         "@abseil-cpp//absl/types:span",
         "@google_benchmark//:benchmark",
     ],
@@ -473,7 +466,6 @@ cc_test(
         "@abseil-cpp//absl/random:distributions",
         "@abseil-cpp//absl/strings:str_format",
         "@abseil-cpp//absl/types:span",
-        "@google_benchmark//:benchmark",
     ],
 )
 
@@ -558,7 +550,6 @@ cc_test(
         "//ortools/graph_base:graph",
         "@abseil-cpp//absl/flags:flag",
         "@abseil-cpp//absl/log:check",
-        "@abseil-cpp//absl/random:distributions",
         "@abseil-cpp//absl/types:span",
         "@google_benchmark//:benchmark",
     ],
@@ -690,10 +681,7 @@ cc_test(
         "//ortools/base:gmock_main",
         "//ortools/graph_base:graph",
         "@abseil-cpp//absl/algorithm:container",
-        "@abseil-cpp//absl/log:check",
-        "@abseil-cpp//absl/random",
         "@abseil-cpp//absl/status",
-        "@google_benchmark//:benchmark",
     ],
 )
 
@@ -715,7 +703,6 @@ cc_test(
         ":minimum_vertex_cover",
         "//ortools/base:gmock_main",
         "@abseil-cpp//absl/algorithm:container",
-        "@google_benchmark//:benchmark",
     ],
 )
 
@@ -754,6 +741,5 @@ cc_test(
         "@abseil-cpp//absl/random",
         "@abseil-cpp//absl/status",
         "@abseil-cpp//absl/types:span",
-        "@google_benchmark//:benchmark",
     ],
 )

--- a/ortools/graph/README.md
+++ b/ortools/graph/README.md
@@ -158,8 +158,8 @@ node.
     memory loads.
 
 -   `StaticGraph<>`: More memory and speed efficient than `ListGraph<>`, but
-    requires calling `Build()` once after adding all nodes and arcs. Iterating
-    outgoing arcs requires only `2` memory loads.
+    requires building after adding all nodes and arcs. Iterating outgoing arcs
+    requires only `2` memory loads.
 
 -   `ReverseArcListGraph<>` adds reverse arcs to `ListGraph<>`. Iterating
     neighboring arcs for a node requires `O(degree)` memory loads.
@@ -202,18 +202,18 @@ You can find some canonical examples in [`samples`][samples].
 
 <!-- Links used throughout the document. -->
 [graph_h]: ../graph/graph.h
-[bounded_dijkstra_h]: http://google3/third_party/ortools/ortools/graph/bounded_dijkstra.h
-[bidirectional_dijkstra_h]: http://google3/third_party/ortools/ortools/graph/bidirectional_dijkstra.h
-[shortest_paths_h]: http://google3/third_party/ortools/ortools/graph/shortest_paths.h
-[dag_shortest_path_h]: http://google3/third_party/ortools/ortools/graph/dag_shortest_path.h
-[dag_constrained_shortest_path_h]: http://google3/third_party/ortools/ortools/graph/dag_constrained_shortest_path.h
-[hamiltonian_path_h]: http://google3/third_party/ortools/ortools/graph/hamiltonian_path.h
-[eulerian_path_h]: http://google3/third_party/ortools/ortools/graph/eulerian_path.h
-[connected_components_h]: http://google3/third_party/ortools/ortools/graph/connected_components.h
-[strongly_connected_components_h]: http://google3/third_party/ortools/ortools/graph/strongly_connected_components.h
-[cliques_h]: http://google3/third_party/ortools/ortools/graph/cliques.h
-[linear_assignment_h]: http://google3/third_party/ortools/ortools/graph/linear_assignment.h
-[max_flow_h]: http://google3/third_party/ortools/ortools/graph/max_flow.h
-[min_cost_flow_h]: http://google3/third_party/ortools/ortools/graph/min_cost_flow.h
-[samples]: http://google3/third_party/ortools/ortools/graph/samples/
+[bounded_dijkstra_h]: ../graph/bounded_dijkstra.h
+[bidirectional_dijkstra_h]: ../graph/bidirectional_dijkstra.h
+[shortest_paths_h]: ../graph/shortest_paths.h
+[dag_shortest_path_h]: ../graph/dag_shortest_path.h
+[dag_constrained_shortest_path_h]: ../graph/dag_constrained_shortest_path.h
+[hamiltonian_path_h]: ../graph/hamiltonian_path.h
+[eulerian_path_h]: ../graph/eulerian_path.h
+[connected_components_h]: ../graph/connected_components.h
+[strongly_connected_components_h]: ../graph/strongly_connected_components.h
+[cliques_h]: ../graph/cliques.h
+[linear_assignment_h]: ../graph/linear_assignment.h
+[max_flow_h]: ../graph/max_flow.h
+[min_cost_flow_h]: ../graph/min_cost_flow.h
+[samples]: ../graph/samples/
 [graph]: ../graph/

--- a/ortools/graph/assignment.cc
+++ b/ortools/graph/assignment.cc
@@ -65,6 +65,7 @@ SimpleLinearSumAssignment::Status SimpleLinearSumAssignment::Solve() {
   optimal_cost_ = 0;
   assignment_arcs_.clear();
   if (NumNodes() == 0) return OPTIMAL;
+
   // HACK(user): Detect overflows early. In ./linear_assignment.h, the cost of
   // each arc is internally multiplied by cost_scaling_factor_ (which is equal
   // to (num_nodes + 1)) without overflow checking.
@@ -72,6 +73,11 @@ SimpleLinearSumAssignment::Status SimpleLinearSumAssignment::Solve() {
       std::numeric_limits<CostValue>::max() / (NumNodes() + 1);
   for (const CostValue unscaled_arc_cost : arc_cost_) {
     if (unscaled_arc_cost > max_supported_arc_cost) return POSSIBLE_OVERFLOW;
+  }
+
+  // Fast path if the graph is complete.
+  if (const auto solve_satus = SolveIfCompleteBipartite()) {
+    return *solve_satus;
   }
 
   const ArcIndex num_arcs = arc_cost_.size();
@@ -89,6 +95,42 @@ SimpleLinearSumAssignment::Status SimpleLinearSumAssignment::Solve() {
   optimal_cost_ = assignment.GetCost();
   for (NodeIndex node = 0; node < num_nodes_; ++node) {
     assignment_arcs_.push_back(assignment.GetAssignmentArc(node));
+  }
+  return OPTIMAL;
+}
+
+std::optional<SimpleLinearSumAssignment::Status>
+SimpleLinearSumAssignment::SolveIfCompleteBipartite() {
+  // Quick check: only do something if we have the correct number of arcs.
+  const ArcIndex num_arcs = arc_cost_.size();
+  if (static_cast<int64_t>(num_arcs) !=
+      static_cast<int64_t>(num_nodes_) * num_nodes_) {
+    return std::nullopt;
+  }
+
+  // If there are no duplicate arcs, this is a complete bipartite graph!
+  // Otherwise, we will fall back to the general case.
+  ::util::CompleteBipartiteGraph<> graph(num_nodes_, num_nodes_);
+  std::vector<int> reverse_mapping(num_arcs, -1);
+  LinearSumAssignment<::util::CompleteBipartiteGraph<>, CostValue> assignment(
+      graph, num_nodes_);
+
+  for (ArcIndex user_index = 0; user_index < num_arcs; ++user_index) {
+    const ::util::CompleteBipartiteGraph<>::ArcIndex new_index =
+        graph.GetArc(arc_tail_[user_index], num_nodes_ + arc_head_[user_index]);
+
+    // Abort if we have duplicate arcs.
+    if (reverse_mapping[new_index] != -1) return std::nullopt;
+    reverse_mapping[new_index] = user_index;
+    assignment.SetArcCost(new_index, arc_cost_[user_index]);
+  }
+
+  if (!assignment.FinalizeSetup()) return POSSIBLE_OVERFLOW;
+  if (!assignment.ComputeAssignment()) return INFEASIBLE;
+  optimal_cost_ = assignment.GetCost();
+  for (NodeIndex node = 0; node < num_nodes_; ++node) {
+    assignment_arcs_.push_back(
+        reverse_mapping[assignment.GetAssignmentArc(node)]);
   }
   return OPTIMAL;
 }

--- a/ortools/graph/assignment.h
+++ b/ortools/graph/assignment.h
@@ -135,6 +135,10 @@ class SimpleLinearSumAssignment {
   }
 
  private:
+  // If the graph is a complete bipartite graph, solve with a faster data
+  // structure. Returns std::nullopt if this was not the case.
+  std::optional<Status> SolveIfCompleteBipartite();
+
   NodeIndex num_nodes_;
   std::vector<NodeIndex> arc_tail_;
   std::vector<NodeIndex> arc_head_;

--- a/ortools/graph/assignment_test.cc
+++ b/ortools/graph/assignment_test.cc
@@ -14,13 +14,7 @@
 #include "ortools/graph/assignment.h"
 
 #include <limits>
-#include <random>
-#include <tuple>
-#include <vector>
 
-#include "absl/log/check.h"
-#include "absl/random/distributions.h"
-#include "benchmark/benchmark.h"
 #include "gtest/gtest.h"
 
 namespace operations_research {
@@ -47,6 +41,38 @@ TEST(SimpleLinearSumAssignmentTest, OptimumMatching) {
   EXPECT_EQ(0, assignment.AssignmentCost(0));
   EXPECT_EQ(1, assignment.RightMate(1));
   EXPECT_EQ(4, assignment.AssignmentCost(1));
+}
+
+TEST(SimpleLinearSumAssignmentTest, OptimumMatchingOutOfOrder) {
+  SimpleLinearSumAssignment assignment;
+  EXPECT_EQ(0, assignment.AddArcWithCost(0, 0, 0));
+  EXPECT_EQ(1, assignment.AddArcWithCost(1, 0, 3));
+  EXPECT_EQ(2, assignment.AddArcWithCost(1, 1, 4));
+  EXPECT_EQ(3, assignment.AddArcWithCost(0, 1, 2));
+  EXPECT_EQ(2, assignment.NumNodes());
+  EXPECT_EQ(4, assignment.NumArcs());
+  EXPECT_EQ(SimpleLinearSumAssignment::OPTIMAL, assignment.Solve());
+  EXPECT_EQ(4, assignment.OptimalCost());
+  EXPECT_EQ(0, assignment.RightMate(0));
+  EXPECT_EQ(0, assignment.AssignmentCost(0));
+  EXPECT_EQ(1, assignment.RightMate(1));
+  EXPECT_EQ(4, assignment.AssignmentCost(1));
+}
+
+TEST(SimpleLinearSumAssignmentTest, OptimumMatchingMultiArcs) {
+  SimpleLinearSumAssignment assignment;
+  EXPECT_EQ(0, assignment.AddArcWithCost(0, 0, 0));
+  EXPECT_EQ(1, assignment.AddArcWithCost(1, 0, 3));
+  EXPECT_EQ(2, assignment.AddArcWithCost(1, 1, 4));
+  EXPECT_EQ(3, assignment.AddArcWithCost(1, 1, 2));
+  EXPECT_EQ(2, assignment.NumNodes());
+  EXPECT_EQ(4, assignment.NumArcs());
+  EXPECT_EQ(SimpleLinearSumAssignment::OPTIMAL, assignment.Solve());
+  EXPECT_EQ(2, assignment.OptimalCost());
+  EXPECT_EQ(0, assignment.RightMate(0));
+  EXPECT_EQ(0, assignment.AssignmentCost(0));
+  EXPECT_EQ(1, assignment.RightMate(1));
+  EXPECT_EQ(2, assignment.AssignmentCost(1));
 }
 
 TEST(SimpleLinearSumAssignmentTest, OptimumMatchingWithNegativeCost) {
@@ -83,37 +109,5 @@ TEST(SimpleLinearSumAssignmentTest, Overflow) {
   EXPECT_EQ(SimpleLinearSumAssignment::POSSIBLE_OVERFLOW, assignment.Solve());
   EXPECT_EQ(0, assignment.OptimalCost());
 }
-
-void BM_SimpleLinearSumAssignment(benchmark::State& state) {
-  using CostValue = SimpleLinearSumAssignment::CostValue;
-  constexpr CostValue kCostLimit = 1000000;
-
-  const int num_left = state.range(0);
-  const int degree = state.range(1);
-
-  std::mt19937 rng(12345);
-
-  // Each left node is connected to `degree` right nodes.
-  std::vector<std::tuple<int, int, CostValue>> arcs;
-  arcs.reserve(num_left * degree);
-  for (int left = 0; left < num_left; ++left) {
-    for (int i = 0; i < degree; ++i) {
-      const int right = (left + i) % num_left;
-      const CostValue cost =
-          absl::Uniform(rng, 0, absl::Uniform(rng, 0, kCostLimit));
-      arcs.emplace_back(left, right, cost);
-    }
-  }
-
-  for (auto _ : state) {
-    SimpleLinearSumAssignment assignment;
-    assignment.ReserveArcs(num_left * degree);
-    for (const auto& [left, right, cost] : arcs) {
-      assignment.AddArcWithCost(left, right, cost);
-    }
-    CHECK_EQ(assignment.Solve(), SimpleLinearSumAssignment::OPTIMAL);
-  }
-}
-BENCHMARK(BM_SimpleLinearSumAssignment)->ArgPair(100, 2)->ArgPair(100, 20);
 
 }  // namespace operations_research

--- a/ortools/graph/bidirectional_dijkstra_test.cc
+++ b/ortools/graph/bidirectional_dijkstra_test.cc
@@ -106,49 +106,50 @@ TEST(BidirectionalDijkstraTest, RandomizedCorrectnessTest) {
   const int kNumArcs = 10000;
   for (int graph_iter = 0; graph_iter < kNumGraphs; ++graph_iter) {
     // Build the random graphs.
-    StaticGraph<> forward_graph;
-    StaticGraph<> backward_graph;
+    StaticGraph<>::Builder forward_builder;
+    StaticGraph<>::Builder backward_builder;
     std::vector<double> forward_lengths;
     std::vector<double> backward_lengths;
     std::vector<int> forward_arc_of_backward_arc;
-    forward_graph.AddNode(kNumNodes - 1);
-    backward_graph.AddNode(kNumNodes - 1);
+    forward_builder.AddNode(kNumNodes - 1);
+    backward_builder.AddNode(kNumNodes - 1);
     for (int i = 0; i < kNumArcs; ++i) {
       const int a = absl::Uniform(random, 0, kNumNodes);
       const int b = absl::Uniform(random, 0, kNumNodes);
-      forward_graph.AddArc(a, b);
-      backward_graph.AddArc(b, a);
+      forward_builder.AddArc(a, b);
+      backward_builder.AddArc(b, a);
       forward_arc_of_backward_arc.push_back(i);
       const double length = absl::Uniform<double>(random, 0.0, 1.0);
       forward_lengths.push_back(length);
       backward_lengths.push_back(length);
     }
     std::vector<int> forward_perm;
-    forward_graph.Build(&forward_perm);
+    const auto forward_graph = std::move(forward_builder).Build(&forward_perm);
     util::Permute(forward_perm, &forward_lengths);
     for (int& a : forward_arc_of_backward_arc) {
       a = forward_perm[a];
     }
     std::vector<int> backward_perm;
-    backward_graph.Build(&backward_perm);
+    const auto backward_graph =
+        std::move(backward_builder).Build(&backward_perm);
     util::Permute(backward_perm, &backward_lengths);
     util::Permute(backward_perm, &forward_arc_of_backward_arc);
 
     // Initialize the tested Dijkstra and the reference Dijkstra.
     typedef BidirectionalDijkstra<StaticGraph<>, double> Dijkstra;
-    Dijkstra tested_dijkstra(&forward_graph, &forward_lengths, &backward_graph,
-                             &backward_lengths);
+    Dijkstra tested_dijkstra(forward_graph.get(), &forward_lengths,
+                             backward_graph.get(), &backward_lengths);
     BoundedDijkstraWrapper<StaticGraph<>, double> ref_dijkstra(
-        &forward_graph, &forward_lengths);
+        forward_graph.get(), &forward_lengths);
 
     // To print some debugging info in case the test fails.
     auto print_arc_path = [&](absl::Span<const int> arc_path) -> std::string {
       if (arc_path.empty()) return "<EMPTY>";
-      std::string out = absl::StrCat(forward_graph.Tail(arc_path[0]));
+      std::string out = absl::StrCat(forward_graph->Tail(arc_path[0]));
       double total_length = 0.0;
       for (const int arc : arc_path) {
         absl::StrAppend(&out, "--(#", arc, ":", (forward_lengths[arc]), ")-->",
-                        forward_graph.Head(arc));
+                        forward_graph->Head(arc));
         total_length += forward_lengths[arc];
       }
       absl::StrAppend(&out, "; Total length=", (total_length));

--- a/ortools/graph/bounded_dijkstra.h
+++ b/ortools/graph/bounded_dijkstra.h
@@ -684,22 +684,21 @@ std::pair<DistanceType, std::vector<NodeIndex>> SimpleOneToOneShortestPath(
 
   // Build the graph. Note that this permutes arc indices for speed, but we
   // don't care here since we will return a node path.
-  util::StaticGraph<NodeIndex, ArcIndex> graph(num_nodes, num_arcs);
+  typename util::StaticGraph<NodeIndex, ArcIndex>::Builder builder(num_nodes,
+                                                                   num_arcs);
   std::vector<DistanceType> arc_lengths(lengths.begin(), lengths.end());
   for (ArcIndex a = 0; a < num_arcs; ++a) {
     // Negative length can cause the algo to loop forever and/or use a lot of
     // memory. So it should be validated.
     CHECK_GE(lengths[a], 0);
-    graph.AddArc(tails[a], heads[a]);
+    builder.AddArc(tails[a], heads[a]);
   }
-  std::vector<int> permutation;
-  graph.Build(&permutation);
-  util::Permute(permutation, &arc_lengths);
+  const auto graph = std::move(builder).BuildAndPermute(arc_lengths);
 
   // Compute a shortest path.
   // This should work for both float/double or integer distances.
-  BoundedDijkstraWrapper<util::StaticGraph<>, DistanceType> wrapper(
-      &graph, &arc_lengths);
+  BoundedDijkstraWrapper<util::StaticGraph<NodeIndex, ArcIndex>, DistanceType>
+      wrapper(graph.get(), &arc_lengths);
   if (!wrapper.OneToOneShortestPath(source, destination, limit)) {
     // No path exists, or shortest_distance >= limit.
     return {limit, {}};

--- a/ortools/graph/bounded_dijkstra_test.cc
+++ b/ortools/graph/bounded_dijkstra_test.cc
@@ -16,24 +16,20 @@
 #include <algorithm>
 #include <cstdint>
 #include <functional>
-#include <limits>
-#include <memory>
 #include <random>
 #include <type_traits>
 #include <utility>
 #include <vector>
 
-#include "absl/log/check.h"
 #include "absl/random/distributions.h"
 #include "absl/random/random.h"
-#include "benchmark/benchmark.h"
 #include "gtest/gtest.h"
 #include "ortools/base/dump_vars.h"
 #include "ortools/base/gmock.h"
 #include "ortools/base/strong_int.h"
+#include "ortools/base/types.h"
 #include "ortools/graph_base/graph.h"
 #include "ortools/graph_base/io.h"
-#include "ortools/graph_base/test_util.h"
 #include "ortools/util/flat_matrix.h"
 
 namespace operations_research {
@@ -126,22 +122,22 @@ TEST(BoundedDijkstraWrapper, EmptyPath) {
 
 TEST(BoundedDijkstraWrapper, OverflowSafe) {
   TestGraph graph;
-  const int64_t int_max = std::numeric_limits<int64_t>::max();
-  DijkstraWrapper<int64_t>::ByArc<int64_t> arc_lengths = {int_max, int_max / 2,
-                                                          int_max / 2, 1};
+  DijkstraWrapper<int64_t>::ByArc<int64_t> arc_lengths = {
+      kint64max, kint64max / 2, kint64max / 2, 1};
   graph.AddArc(NodeIndex(0), NodeIndex(1));
   graph.AddArc(NodeIndex(0), NodeIndex(1));
   graph.AddArc(NodeIndex(1), NodeIndex(2));
   graph.AddArc(NodeIndex(2), NodeIndex(3));
 
   BoundedDijkstraWrapper<TestGraph, int64_t> dijkstra(&graph, &arc_lengths);
-  const auto reached = dijkstra.RunBoundedDijkstra(NodeIndex(0), int_max);
+  const auto reached = dijkstra.RunBoundedDijkstra(NodeIndex(0), kint64max);
 
-  // This works because int_max is odd, i.e. 2 * (int_max / 2) = int_max - 1
+  // This works because kint64max is odd, i.e. 2 * (kint64max / 2) = kint64max -
+  // 1
   EXPECT_THAT(reached, ElementsAre(NodeIndex(0), NodeIndex(1), NodeIndex(2)));
   EXPECT_EQ(0, dijkstra.distances()[NodeIndex(0)]);
-  EXPECT_EQ(int_max / 2, dijkstra.distances()[NodeIndex(1)]);
-  EXPECT_EQ(int_max - 1, dijkstra.distances()[NodeIndex(2)]);
+  EXPECT_EQ(kint64max / 2, dijkstra.distances()[NodeIndex(1)]);
+  EXPECT_EQ(kint64max - 1, dijkstra.distances()[NodeIndex(2)]);
 }
 
 TEST(BoundedDijkstraWrapper,
@@ -242,7 +238,7 @@ TEST(BoundedDijkstraWrapperTest, RandomDenseGraph) {
 }
 
 TEST(SimpleOneToOneShortestPathTest, PathTooLong) {
-  const int big_length = std::numeric_limits<int>::max() / 2;
+  const int big_length = kint32max / 2;
   std::vector<int> tails = {0, 1, 2};
   std::vector<int> heads = {1, 2, 3};
   std::vector<int> lengths = {big_length, big_length, big_length};
@@ -250,15 +246,15 @@ TEST(SimpleOneToOneShortestPathTest, PathTooLong) {
   {
     const auto [distance, path] =
         SimpleOneToOneShortestPath<int, int>(0, 3, tails, heads, lengths);
-    EXPECT_EQ(distance, std::numeric_limits<int>::max());
+    EXPECT_EQ(distance, kint32max);
     EXPECT_TRUE(path.empty());
   }
 
   {
-    // from 0 to 2 work because 2 * big_length < int_max.
+    // from 0 to 2 work because 2 * big_length < kint64max.
     const auto [distance, path] =
         SimpleOneToOneShortestPath<int, int>(0, 2, tails, heads, lengths);
-    EXPECT_EQ(distance, std::numeric_limits<int>::max() - 1);
+    EXPECT_EQ(distance, kint32max - 1);
     EXPECT_THAT(path, ElementsAre(0, 1, 2));
   }
 }
@@ -644,7 +640,6 @@ TEST(BoundedDijkstraWrapperTest, CustomSettledNodeCallback) {
 TEST(BoundedDisjktraTest, RandomizedStressTest) {
   std::mt19937 random;
   const int kNumTests = 10'000;
-  constexpr int kint32max = std::numeric_limits<int>::max();
   for (int test = 0; test < kNumTests; ++test) {
     // Generate a random graph with random weights.
     const NodeIndex num_nodes(absl::Uniform(random, 1, 12));
@@ -737,48 +732,6 @@ TEST(BoundedDisjktraTest, RandomizedStressTest) {
     }
   }
 }
-
-template <bool arc_lengths_are_discrete>
-void BM_GridGraph(benchmark::State& state) {
-  typedef util::StaticGraph<int> Graph;
-  const int64_t kWidth = 100;
-  const int64_t kHeight = 10000;
-  const int kSourceNode = static_cast<int>(kWidth * kHeight / 2);
-  std::unique_ptr<Graph> graph =
-      util::Create2DGridGraph<Graph>(/*width=*/kWidth, /*height=*/kHeight);
-  BoundedDijkstraWrapper<Graph, int64_t>::ByArc<int64_t> arc_lengths(
-      graph->num_arcs(), 0);
-  const int64_t min_length = arc_lengths_are_discrete ? 0 : 1;
-  const int64_t max_length = arc_lengths_are_discrete ? 2 : 1000000000000000L;
-  std::mt19937 random(12345);
-  for (int64_t& length : arc_lengths) {
-    length = absl::Uniform(random, min_length, max_length + 1);
-  }
-  BoundedDijkstraWrapper<Graph, int64_t> dijkstra(graph.get(), &arc_lengths);
-  const int64_t kSearchRadius = kWidth * (min_length + max_length) / 2;
-  // NOTE(user): The expected number of nodes visited is in ϴ(kWidth²),
-  // since the search radius is ϴ(kWidth). The exact constant is hard to
-  // derive mathematically as a function of the radius formula, so I measured
-  // it empirically and it was close to 0.5, which seemed about right.
-  const int64_t kExpectedApproximateSearchSize = kWidth * kWidth / 2;
-  int64_t total_nodes_visited = 0;
-  for (auto _ : state) {
-    const int num_nodes_visited =
-        dijkstra
-            .RunBoundedDijkstra(/*source_node=*/kSourceNode,
-                                /*distance_limit=*/kSearchRadius)
-            .size();
-    // We verify that the Dijkstra search size is in the expected range, to
-    // make sure that we're measuring what we want in this benchmark.
-    CHECK_GE(num_nodes_visited, kExpectedApproximateSearchSize / 2);
-    CHECK_GE(num_nodes_visited, kExpectedApproximateSearchSize * 2);
-    total_nodes_visited += num_nodes_visited;
-  }
-  state.SetItemsProcessed(total_nodes_visited);
-}
-
-BENCHMARK(BM_GridGraph<true>);
-BENCHMARK(BM_GridGraph<false>);
 
 }  // namespace
 }  // namespace operations_research

--- a/ortools/graph/christofides_test.cc
+++ b/ortools/graph/christofides_test.cc
@@ -15,19 +15,19 @@
 
 #include <cmath>
 #include <cstdint>
-#include <cstdlib>
 #include <functional>
 #include <limits>
 #include <string>
 #include <vector>
 
 #include "absl/log/check.h"
+#include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_format.h"
 #include "absl/types/span.h"
-#include "benchmark/benchmark.h"
 #include "gtest/gtest.h"
 #include "ortools/base/gmock.h"
+#include "ortools/base/types.h"
 
 namespace operations_research {
 
@@ -240,17 +240,16 @@ TEST(ChristofidesTest, SingleNodeModel) {
 
 TEST(ChristofidesTest, Int64OverflowMinimalMatching) {
   ChristofidesPathSolver<int64_t> chris_solver(
-      10, [](int, int) { return std::numeric_limits<int64_t>::max() / 2; });
+      10, [](int, int) { return kint64max / 2; });
   chris_solver.SetMatchingAlgorithm(
       ChristofidesPathSolver<
           int64_t>::MatchingAlgorithm::MINIMAL_WEIGHT_MATCHING);
-  EXPECT_THAT(chris_solver.TravelingSalesmanCost(),
-              IsOkAndHolds(std::numeric_limits<int64_t>::max()));
+  EXPECT_THAT(chris_solver.TravelingSalesmanCost(), IsOkAndHolds(kint64max));
 }
 
 TEST(ChristofidesTest, Int64OverflowMinimumMatching) {
   ChristofidesPathSolver<int64_t> chris_solver(
-      10, [](int, int) { return std::numeric_limits<int64_t>::max() / 2; });
+      10, [](int, int) { return kint64max / 2; });
   chris_solver.SetMatchingAlgorithm(
       ChristofidesPathSolver<
           int64_t>::MatchingAlgorithm::MINIMUM_WEIGHT_MATCHING);
@@ -271,11 +270,10 @@ TEST(ChristofidesTest, SaturatedDoubleWithMinimalMatching) {
 TEST(ChristofidesTest, NoPerfectMatching) {
   ChristofidesPathSolver<int64_t> chris_solver(4, [](int i, int j) {
     // 1 and 3 cannot be connected,
-    const int64_t cost[][4] = {
-        {0, 0, 0, 0},
-        {0, 0, 1, std::numeric_limits<int64_t>::max() / 2},
-        {0, 1, 0, 1},
-        {0, std::numeric_limits<int64_t>::max() / 2, 1, 0}};
+    const int64_t cost[][4] = {{0, 0, 0, 0},
+                               {0, 0, 1, kint64max / 2},
+                               {0, 1, 0, 1},
+                               {0, kint64max / 2, 1, 0}};
     return cost[i][j];
   });
   // NOTE(user): Add a test for which MIP matching fails too.
@@ -285,47 +283,5 @@ TEST(ChristofidesTest, NoPerfectMatching) {
   EXPECT_THAT(chris_solver.Solve(),
               StatusIs(absl::StatusCode::kInvalidArgument));
 }
-
-// Benchmark for the Christofides algorithm on a 'size' by 'size' grid of nodes.
-template <bool use_minimal_matching>
-void BM_ChristofidesPathSolver(benchmark::State& state) {
-  int size = state.range(0);
-  const int num_nodes = size * size;
-  std::vector<std::vector<int>> costs(num_nodes);
-  for (int i = 0; i < num_nodes; ++i) {
-    const int x_i = i / size;
-    const int y_i = i % size;
-    costs[i].resize(num_nodes, 0);
-    for (int j = 0; j < num_nodes; ++j) {
-      const int x_j = j / size;
-      const int y_j = j % size;
-      costs[i][j] = std::abs(x_i - x_j) + std::abs(y_i - y_j);
-    }
-  }
-  auto cost = [&costs](int i, int j) { return costs[i][j]; };
-  // TODO(user) MSVC v19.41 can't convert lambda to std::function.
-#if defined(_MSC_VER)
-  using Cost = std::function<int(int, int)>;
-#else
-  using Cost = decltype(cost);
-#endif
-  using MatchingAlgorithm =
-      typename ChristofidesPathSolver<int, int, int, Cost>::MatchingAlgorithm;
-  for (auto _ : state) {
-    ChristofidesPathSolver<int, int, int, Cost> chris_solver(num_nodes, cost);
-    if (use_minimal_matching) {
-      chris_solver.SetMatchingAlgorithm(
-          MatchingAlgorithm::MINIMAL_WEIGHT_MATCHING);
-    } else {
-      chris_solver.SetMatchingAlgorithm(
-          MatchingAlgorithm::MINIMUM_WEIGHT_MATCHING);
-    }
-    EXPECT_THAT(chris_solver.TravelingSalesmanCost(),
-                IsOkAndHolds(testing::Gt(0)));
-  }
-}
-
-BENCHMARK_TEMPLATE(BM_ChristofidesPathSolver, true)->Range(2, 1 << 5);
-BENCHMARK_TEMPLATE(BM_ChristofidesPathSolver, false)->Range(2, 1 << 5);
 
 }  // namespace operations_research

--- a/ortools/graph/cliques.cc
+++ b/ortools/graph/cliques.cc
@@ -156,6 +156,9 @@ void Search(std::function<bool(int, int)> graph,
     // Otherwise, do the recursive step.
     if (new_candidate_size == 0) {
       *stop = callback(*current_clique);
+      if (*stop) {
+        return;
+      }
     } else {
       if (new_first_candidate_index < new_candidate_size) {
         Search(graph, callback, new_candidates.data(),

--- a/ortools/graph/cliques.h
+++ b/ortools/graph/cliques.h
@@ -37,6 +37,7 @@
 #include "absl/strings/str_cat.h"
 #include "ortools/base/strong_int.h"
 #include "ortools/base/strong_vector.h"
+#include "ortools/base/types.h"
 #include "ortools/util/bitset.h"
 #include "ortools/util/time_limit.h"
 
@@ -208,7 +209,7 @@ class BronKerboschAlgorithm {
   // it returns COMPLETED any subsequent call to the method will resume the
   // search from the beginning.
   BronKerboschAlgorithmStatus RunWithTimeLimit(TimeLimit* time_limit) {
-    return RunWithTimeLimit(std::numeric_limits<int64_t>::max(), time_limit);
+    return RunWithTimeLimit(kint64max, time_limit);
   }
 
  private:
@@ -415,7 +416,7 @@ class WeightedBronKerboschBitsetAlgorithm {
 
  private:
   int64_t work_ = 0;
-  int64_t work_limit_ = std::numeric_limits<int64_t>::max();
+  int64_t work_limit_ = kint64max;
   double weight_threshold_ = 0.0;
 
   std::vector<double> weights_;
@@ -641,7 +642,7 @@ BronKerboschAlgorithmStatus BronKerboschAlgorithm<NodeIndex>::RunIterations(
 
 template <typename NodeIndex>
 BronKerboschAlgorithmStatus BronKerboschAlgorithm<NodeIndex>::Run() {
-  return RunIterations(std::numeric_limits<int64_t>::max());
+  return RunIterations(kint64max);
 }
 
 template <typename NodeIndex>

--- a/ortools/graph/cliques_test.cc
+++ b/ortools/graph/cliques_test.cc
@@ -31,8 +31,8 @@
 #include "absl/random/distributions.h"
 #include "absl/strings/str_cat.h"
 #include "absl/types/span.h"
-#include "benchmark/benchmark.h"
 #include "gtest/gtest.h"
+#include "ortools/base/types.h"
 #include "ortools/util/time_limit.h"
 
 namespace operations_research {
@@ -41,7 +41,7 @@ namespace {
 template <typename NodeIndex>
 class CliqueReporter {
  public:
-  CliqueReporter() : CliqueReporter(std::numeric_limits<int64_t>::max()) {}
+  CliqueReporter() : CliqueReporter(kint64max) {}
   explicit CliqueReporter(int64_t max_cliques)
       : remaining_cliques_(max_cliques) {}
 
@@ -154,6 +154,49 @@ void RunBronKerboschAlgorithmUntilCompletion(
       return;
     }
   }
+}
+
+TEST(FindCliques, CallbackGetsAllCliques) {
+  int64_t call_count = 0;
+  auto graph = std::bind_front(ModuloGraph, 3);
+  FindCliques(graph, 6, [&](const std::vector<int>& clique) {
+    call_count++;
+    EXPECT_EQ(clique.size(), 2);
+    return false;
+  });
+  EXPECT_EQ(call_count, 3);
+}
+TEST(FindCliques, CallbackStopsExploration) {
+  int64_t call_count = 0;
+  auto graph = std::bind_front(ModuloGraph, 2);
+  FindCliques(graph, 10, [&](const std::vector<int>& clique) {
+    call_count++;
+    EXPECT_EQ(clique.size(), 5);
+    return call_count == 2;
+  });
+  EXPECT_EQ(call_count, 2);
+}
+
+TEST(FindCliques, CallbackExplorationOnSmallGraph) {
+  int64_t call_count = 0;
+  // Adjacent numbers are connected. Cliques of [0, 1], [1, 2], [2, 3], etc.
+  auto graph = [](int64_t a, int64_t b) { return std::abs(a - b) <= 1; };
+  FindCliques(graph, 30, [&](const std::vector<int>& clique) {
+    call_count++;
+    return false;
+  });
+  EXPECT_EQ(call_count, 29);
+}
+
+TEST(FindCliques, CallbackStopsExplorationOnSmallGraph) {
+  int64_t call_count = 0;
+  // Adjacent numbers are connected. Cliques of [0, 1], [1, 2], [2, 3], etc.
+  auto graph = [](int64_t a, int64_t b) { return std::abs(a - b) <= 1; };
+  FindCliques(graph, 30, [&](const std::vector<int>& clique) {
+    call_count++;
+    return true;
+  });
+  EXPECT_EQ(call_count, 1);
 }
 
 TEST(BronKerbosch, CompleteGraph) {
@@ -554,7 +597,7 @@ TEST(WeightedBronKerboschBitsetAlgorithmTest, ModuloGraph) {
 // a one second time limit.
 //
 // The graph has approximately 2^58.6 maximal cliques, so they could be in
-// theory all enumerated within the std::numeric_limits<int64_t>::max()
+// theory all enumerated within the kint64max
 // iteration limit, but their number is too large that enumerating them would
 // take tens to hundreds of years with the current technology (as of August
 // 2015). As a result, the algorithm can end in the INTERRUPTED state only when
@@ -599,177 +642,6 @@ TEST(BronKerboschAlgorithmTest, DeterministicTimeLimit) {
   EXPECT_EQ(BronKerboschAlgorithmStatus::INTERRUPTED, status);
   EXPECT_TRUE(time_limit->LimitReached());
 }
-
-// A benchmark that finds all maximal cliques in a modulo graph of the given
-// size.
-void BM_FindCliquesInModuloGraph(benchmark::State& state) {
-  int num_partitions = state.range(0);
-  int partition_size = state.range(1);
-
-  const int kExpectedNumCliques = num_partitions;
-  const int kExpectedCliqueSize = partition_size;
-  const int kGraphSize = num_partitions * partition_size;
-  CliqueSizeVerifier verifier(kExpectedCliqueSize, kExpectedCliqueSize);
-
-  for (auto _ : state) {
-    auto graph = absl::bind_front(ModuloGraph, num_partitions);
-    auto callback =
-        absl::bind_front(&CliqueSizeVerifier::AppendClique, &verifier);
-
-    operations_research::FindCliques(graph, kGraphSize, callback);
-  }
-  EXPECT_EQ(state.max_iterations * kExpectedNumCliques, verifier.num_cliques());
-}
-
-BENCHMARK(BM_FindCliquesInModuloGraph)
-    ->ArgPair(5, 1000)
-    ->ArgPair(10, 500)
-    ->ArgPair(50, 100)
-    ->ArgPair(100, 50)
-    ->ArgPair(500, 10)
-    ->ArgPair(1000, 5);
-
-void BM_FindCliquesInModuloGraphWithBronKerboschAlgorithm(
-    benchmark::State& state) {
-  int num_partitions = state.range(0);
-  int partition_size = state.range(1);
-  const int kExpectedNumCliques = num_partitions;
-  const int kExpectedCliqueSize = partition_size;
-  const int kGraphSize = num_partitions * partition_size;
-  CliqueSizeVerifier verifier(kExpectedCliqueSize, kExpectedCliqueSize);
-  std::unique_ptr<TimeLimit> time_limit = TimeLimit::Infinite();
-
-  auto graph = [num_partitions](int index1, int index2) {
-    return ModuloGraph(num_partitions, index1, index2);
-  };
-
-  for (auto _ : state) {
-    BronKerboschAlgorithm<int> bron_kerbosch(graph, kGraphSize,
-                                             verifier.MakeCliqueCallback());
-    bron_kerbosch.RunWithTimeLimit(time_limit.get());
-  }
-  EXPECT_EQ(state.max_iterations * kExpectedNumCliques, verifier.num_cliques());
-  LOG(INFO) << time_limit->DebugString();
-}
-
-BENCHMARK(BM_FindCliquesInModuloGraphWithBronKerboschAlgorithm)
-    ->ArgPair(5, 1000)
-    ->ArgPair(10, 500)
-    ->ArgPair(50, 100)
-    ->ArgPair(100, 50)
-    ->ArgPair(500, 10)
-    ->ArgPair(1000, 5);
-
-void BM_FindCliquesInModuloGraphWithBitsetBK(benchmark::State& state) {
-  int num_partitions = state.range(0);
-  int partition_size = state.range(1);
-  const int kExpectedNumCliques = num_partitions;
-  const int kExpectedCliqueSize = partition_size;
-  const int num_nodes = num_partitions * partition_size;
-  for (auto _ : state) {
-    WeightedBronKerboschBitsetAlgorithm algo;
-    algo.Initialize(num_nodes);
-    for (int i = 0; i < num_nodes; ++i) {
-      for (int j = i + 1; j < num_nodes; ++j) {
-        if (ModuloGraph(num_partitions, i, j)) algo.AddEdge(i, j);
-      }
-    }
-
-    std::vector<std::vector<int>> cliques = algo.Run();
-    EXPECT_EQ(cliques.size(), kExpectedNumCliques);
-    for (const std::vector<int>& clique : cliques) {
-      EXPECT_EQ(kExpectedCliqueSize, clique.size());
-    }
-  }
-}
-
-BENCHMARK(BM_FindCliquesInModuloGraphWithBitsetBK)
-    ->ArgPair(5, 1000)
-    ->ArgPair(10, 500)
-    ->ArgPair(50, 100)
-    ->ArgPair(100, 50)
-    ->ArgPair(500, 10)
-    ->ArgPair(1000, 5);
-
-// A benchmark that finds all maximal cliques in a 7-partite graph (a graph
-// where the nodes are divided into 7 groups of size 7; each node is connected
-// to all nodes in other groups but to no node in the same group). This graph
-// contains a large number of relatively small cliques.
-void BM_FindCliquesInFull7PartiteGraph(benchmark::State& state) {
-  constexpr int kNumPartitions = 7;
-  constexpr int kExpectedNumCliques = 7 * 7 * 7 * 7 * 7 * 7 * 7;
-  constexpr int kExpectedCliqueSize = kNumPartitions;
-  CliqueSizeVerifier verifier(kExpectedCliqueSize, kExpectedCliqueSize);
-
-  for (auto _ : state) {
-    auto graph = absl::bind_front(FullKPartiteGraph, kNumPartitions);
-    auto callback =
-        absl::bind_front(&CliqueSizeVerifier::AppendClique, &verifier);
-
-    operations_research::FindCliques(graph, kNumPartitions * kNumPartitions,
-                                     callback);
-  }
-  EXPECT_EQ(state.max_iterations * kExpectedNumCliques, verifier.num_cliques());
-}
-
-BENCHMARK(BM_FindCliquesInFull7PartiteGraph);
-
-void BM_FindCliquesInFullKPartiteGraphWithBronKerboschAlgorithm(
-    benchmark::State& state) {
-  int num_partitions = state.range(0);
-  const int kExpectedNumCliques = std::pow(num_partitions, num_partitions);
-  const int kExpectedCliqueSize = num_partitions;
-
-  const auto graph = [num_partitions](int index1, int index2) {
-    return FullKPartiteGraph(num_partitions, index1, index2);
-  };
-  CliqueSizeVerifier verifier(kExpectedCliqueSize, kExpectedCliqueSize);
-  std::unique_ptr<TimeLimit> time_limit = TimeLimit::Infinite();
-
-  for (auto _ : state) {
-    BronKerboschAlgorithm<int> bron_kerbosch(
-        graph, num_partitions * num_partitions, verifier.MakeCliqueCallback());
-    bron_kerbosch.RunWithTimeLimit(time_limit.get());
-  }
-  EXPECT_EQ(state.max_iterations * kExpectedNumCliques, verifier.num_cliques());
-  LOG(INFO) << time_limit->DebugString();
-}
-
-BENCHMARK(BM_FindCliquesInFullKPartiteGraphWithBronKerboschAlgorithm)
-    ->Arg(5)
-    ->Arg(6)
-    ->Arg(7);
-
-void BM_FindCliquesInRandomGraphWithBronKerboschAlgorithm(
-    benchmark::State& state) {
-  int num_nodes = state.range(0);
-  int arc_probability_permille = state.range(1);
-  const double arc_probability = arc_probability_permille / 1000.0;
-  const absl::flat_hash_set<std::pair<int, int>> adjacency_matrix =
-      MakeRandomGraphAdjacencyMatrix(num_nodes, arc_probability,
-                                     GTEST_FLAG_GET(random_seed));
-  const auto graph = [adjacency_matrix](int index1, int index2) {
-    return BitmapGraph(adjacency_matrix, index1, index2);
-  };
-  CliqueSizeVerifier verifier(0, num_nodes);
-  std::unique_ptr<TimeLimit> time_limit = TimeLimit::Infinite();
-  for (auto _ : state) {
-    BronKerboschAlgorithm<int> bron_kerbosch(graph, num_nodes,
-                                             verifier.MakeCliqueCallback());
-    bron_kerbosch.RunWithTimeLimit(time_limit.get());
-  }
-  LOG(INFO) << time_limit->DebugString();
-}
-
-BENCHMARK(BM_FindCliquesInRandomGraphWithBronKerboschAlgorithm)
-    ->ArgPair(50, 800)
-    ->ArgPair(100, 500)
-    ->ArgPair(200, 100)
-    ->ArgPair(1000, 10)
-    ->ArgPair(1000, 20)
-    ->ArgPair(1000, 50)
-    ->ArgPair(1000, 100)
-    ->ArgPair(10000, 1);
 
 }  // namespace
 }  // namespace operations_research

--- a/ortools/graph/dag_constrained_shortest_path.cc
+++ b/ortools/graph/dag_constrained_shortest_path.cc
@@ -13,6 +13,7 @@
 
 #include "ortools/graph/dag_constrained_shortest_path.h"
 
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -46,7 +47,7 @@ PathWithLength ConstrainedShortestPathsOnDag(
   using ArcIndex = GraphType::ArcIndex;
 
   const int num_arcs = arcs_with_length_and_resources.size();
-  GraphType graph(num_nodes, num_arcs);
+  GraphType::Builder builder(num_nodes, num_arcs);
   std::vector<double> arc_lengths;
   arc_lengths.reserve(num_arcs);
   std::vector<std::vector<double>> arc_resources(max_resources.size());
@@ -54,7 +55,7 @@ PathWithLength ConstrainedShortestPathsOnDag(
     arc_resources[i].reserve(num_arcs);
   }
   for (const auto& arc : arcs_with_length_and_resources) {
-    graph.AddArc(arc.from, arc.to);
+    builder.AddArc(arc.from, arc.to);
     arc_lengths.push_back(arc.length);
     for (int i = 0; i < arc.resources.size(); ++i) {
       arc_resources[i].push_back(arc.resources[i]);
@@ -62,7 +63,7 @@ PathWithLength ConstrainedShortestPathsOnDag(
   }
 
   std::vector<ArcIndex> permutation;
-  graph.Build(&permutation);
+  const auto graph = std::move(builder).Build(&permutation);
   util::Permute(permutation, &arc_lengths);
   for (int i = 0; i < max_resources.size(); ++i) {
     util::Permute(permutation, &arc_resources[i]);
@@ -72,15 +73,15 @@ PathWithLength ConstrainedShortestPathsOnDag(
       internal::GetInversePermutation(permutation);
 
   const absl::StatusOr<std::vector<NodeIndex>> topological_order =
-      util::graph::FastTopologicalSort(graph);
+      util::graph::FastTopologicalSort(*graph);
   CHECK_OK(topological_order) << "arcs_with_length form a cycle.";
 
   std::vector<NodeIndex> sources = {source};
   std::vector<NodeIndex> destinations = {destination};
   ConstrainedShortestPathsOnDagWrapper<util::StaticGraph<>>
-      constrained_shortest_path_on_dag(&graph, &arc_lengths, &arc_resources,
-                                       *topological_order, sources,
-                                       destinations, &max_resources);
+      constrained_shortest_path_on_dag(graph.get(), &arc_lengths,
+                                       &arc_resources, *topological_order,
+                                       sources, destinations, &max_resources);
 
   GraphPathWithLength<GraphType> path_with_length =
       constrained_shortest_path_on_dag.RunConstrainedShortestPathOnDag();

--- a/ortools/graph/dag_constrained_shortest_path.h
+++ b/ortools/graph/dag_constrained_shortest_path.h
@@ -16,6 +16,7 @@
 
 #include <cmath>
 #include <limits>
+#include <memory>
 #include <optional>
 #include <vector>
 
@@ -223,7 +224,7 @@ class ConstrainedShortestPathsOnDagWrapper {
   // an additional linked to sources (resp. destinations) for the forward (resp.
   // backward) direction. For the forward (resp. backward) direction, nodes are
   // indexed using the original (resp. reverse) topological order.
-  GraphType sub_reverse_graph_[2];
+  std::unique_ptr<const GraphType> sub_reverse_graph_[2];
   std::vector<std::vector<double>> sub_arc_resources_[2];
   // `sub_full_arc_indices_[dir]` has size `sub_reverse_graph_[dir].num_arcs()`
   // such that `sub_full_arc_indices_[dir][sub_arc] = arc` where `sub_arc` is
@@ -354,12 +355,12 @@ ConstrainedShortestPathsOnDagWrapper<GraphType>::
   full_topological_order[FORWARD] = topological_order;
   full_sources[FORWARD] = sources;
   // Backward.
-  GraphType full_backward_graph(num_nodes, num_arcs);
+  typename GraphType::Builder builder(num_nodes, num_arcs);
   for (ArcIndex arc_index = 0; arc_index < num_arcs; ++arc_index) {
-    full_backward_graph.AddArc(graph->Head(arc_index), graph->Tail(arc_index));
+    builder.AddArc(graph->Head(arc_index), graph->Tail(arc_index));
   }
   std::vector<ArcIndex> full_permutation;
-  full_backward_graph.Build(&full_permutation);
+  const auto full_backward_graph = std::move(builder).Build(&full_permutation);
   const std::vector<ArcIndex> full_inverse_arc_indices =
       internal::GetInversePermutation(full_permutation);
   std::vector<std::vector<double>> backward_arc_resources(num_resources_);
@@ -372,7 +373,7 @@ ConstrainedShortestPathsOnDagWrapper<GraphType>::
   for (int i = num_nodes - 1; i >= 0; --i) {
     full_backward_topological_order.push_back(topological_order[i]);
   }
-  full_graph[BACKWARD] = &full_backward_graph;
+  full_graph[BACKWARD] = full_backward_graph.get();
   full_arc_resources[BACKWARD] = &backward_arc_resources;
   full_topological_order[BACKWARD] = full_backward_topological_order;
   full_sources[BACKWARD] = destinations;
@@ -476,7 +477,8 @@ ConstrainedShortestPathsOnDagWrapper<GraphType>::
     // node is indexed with the last index. All added arcs are given to have an
     // arc index in the original graph of -1.
     const int sub_arcs_count = num_arcs + full_sources[dir].size();
-    sub_reverse_graph_[dir] = GraphType(sub_nodes.size() + 1, sub_arcs_count);
+    typename GraphType::Builder graph_builder(sub_nodes.size() + 1,
+                                              sub_arcs_count);
     sub_arc_resources_[dir].resize(num_resources_);
     for (int r = 0; r < num_resources_; ++r) {
       sub_arc_resources_[dir][r].reserve(sub_arcs_count);
@@ -491,7 +493,7 @@ ConstrainedShortestPathsOnDagWrapper<GraphType>::
       if (from == -1 || to == -1) {
         continue;
       }
-      sub_reverse_graph_[dir].AddArc(from, to);
+      graph_builder.AddArc(from, to);
       ArcIndex sub_full_arc_index;
       if (dir == FORWARD && !full_inverse_arc_indices.empty()) {
         sub_full_arc_index = full_inverse_arc_indices[arc_index];
@@ -509,14 +511,14 @@ ConstrainedShortestPathsOnDagWrapper<GraphType>::
       if (sub_source == -1) {
         continue;
       }
-      sub_reverse_graph_[dir].AddArc(sub_source, sub_nodes.size());
+      graph_builder.AddArc(sub_source, sub_nodes.size());
       for (int r = 0; r < num_resources_; ++r) {
         sub_arc_resources_[dir][r].push_back(0.0);
       }
       sub_full_arc_indices_[dir].push_back(-1);
     }
     std::vector<ArcIndex> sub_permutation;
-    sub_reverse_graph_[dir].Build(&sub_permutation);
+    sub_reverse_graph_[dir] = std::move(graph_builder).Build(&sub_permutation);
     for (int r = 0; r < num_resources_; ++r) {
       util::Permute(sub_permutation, &sub_arc_resources_[dir][r]);
     }
@@ -528,8 +530,8 @@ ConstrainedShortestPathsOnDagWrapper<GraphType>::
   // better performance.
   for (const Direction dir : {FORWARD, BACKWARD}) {
     resources_from_sources_[dir].resize(num_resources_);
-    node_first_label_[dir].resize(sub_reverse_graph_[dir].size());
-    node_num_labels_[dir].resize(sub_reverse_graph_[dir].size());
+    node_first_label_[dir].resize(sub_reverse_graph_[dir]->num_nodes());
+    node_num_labels_[dir].resize(sub_reverse_graph_[dir]->num_nodes());
   }
 }
 
@@ -543,9 +545,9 @@ GraphPathWithLength<GraphType> ConstrainedShortestPathsOnDagWrapper<
   // Assign lengths on sub-relevant graphs.
   std::vector<double> sub_arc_lengths[2];
   for (const Direction dir : {FORWARD, BACKWARD}) {
-    sub_arc_lengths[dir].reserve(sub_reverse_graph_[dir].num_arcs());
+    sub_arc_lengths[dir].reserve(sub_reverse_graph_[dir]->num_arcs());
     for (ArcIndex sub_arc_index = 0;
-         sub_arc_index < sub_reverse_graph_[dir].num_arcs(); ++sub_arc_index) {
+         sub_arc_index < sub_reverse_graph_[dir]->num_arcs(); ++sub_arc_index) {
       const ArcIndex arc_index = sub_full_arc_indices_[dir][sub_arc_index];
       if (arc_index == -1) {
         sub_arc_lengths[dir].push_back(0.0);
@@ -560,7 +562,7 @@ GraphPathWithLength<GraphType> ConstrainedShortestPathsOnDagWrapper<
     for (const Direction dir : {FORWARD, BACKWARD}) {
       search_threads.Schedule([this, dir, &sub_arc_lengths]() {
         RunHalfConstrainedShortestPathOnDag(
-            /*reverse_graph=*/sub_reverse_graph_[dir],
+            /*reverse_graph=*/*sub_reverse_graph_[dir],
             /*arc_lengths=*/sub_arc_lengths[dir],
             /*arc_resources=*/sub_arc_resources_[dir],
             /*min_arc_resources=*/sub_min_arc_resources_[dir],

--- a/ortools/graph/dag_constrained_shortest_path_test.cc
+++ b/ortools/graph/dag_constrained_shortest_path_test.cc
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <limits>
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -24,7 +25,6 @@
 #include "absl/random/random.h"
 #include "absl/strings/str_cat.h"
 #include "absl/types/span.h"
-#include "benchmark/benchmark.h"
 #include "gtest/gtest.h"
 #include "ortools/base/dump_vars.h"
 #include "ortools/base/gmock.h"
@@ -361,23 +361,24 @@ TEST(ConstrainedShortestPathsOnDagWrapperTest,
   const int source_2 = 1;
   const int destination = 2;
   const int num_nodes = 3;
-  util::ListGraph<> graph(num_nodes, /*arc_capacity=*/2);
+  util::ListGraph<>::Builder builder(num_nodes, /*arc_capacity=*/2);
   std::vector<double> arc_lengths;
   std::vector<std::vector<double>> arc_resources(1);
-  graph.AddArc(source_1, source_2);
+  builder.AddArc(source_1, source_2);
   arc_lengths.push_back(-7.0);
   arc_resources[0].push_back(2.0);
-  graph.AddArc(source_2, destination);
+  builder.AddArc(source_2, destination);
   arc_lengths.push_back(3.0);
   arc_resources[0].push_back(3.0);
+  auto graph = std::move(builder).Build(nullptr);
   const std::vector<int> topological_order = {source_1, source_2, destination};
   const std::vector<int> sources = {source_1, source_2};
   const std::vector<int> destinations = {destination};
   const std::vector<double> max_resources = {6.0};
   ConstrainedShortestPathsOnDagWrapper<util::ListGraph<>>
-      constrained_shortest_path_on_dag(&graph, &arc_lengths, &arc_resources,
-                                       topological_order, sources, destinations,
-                                       &max_resources);
+      constrained_shortest_path_on_dag(graph.get(), &arc_lengths,
+                                       &arc_resources, topological_order,
+                                       sources, destinations, &max_resources);
 
   EXPECT_THAT(
       constrained_shortest_path_on_dag.RunConstrainedShortestPathOnDag(),
@@ -391,18 +392,19 @@ TEST(ConstrainedShortestPathsOnDagWrapperTest, MultipleDestinations) {
   const int destination_2 = 2;
   const int destination_3 = 3;
   const int num_nodes = 4;
-  util::ListGraph<> graph(num_nodes, /*arc_capacity=*/3);
+  util::ListGraph<>::Builder builder(num_nodes, /*arc_capacity=*/3);
   std::vector<double> arc_lengths;
   std::vector<std::vector<double>> arc_resources(1);
-  graph.AddArc(source, destination_1);
+  builder.AddArc(source, destination_1);
   arc_lengths.push_back(3.0);
   arc_resources[0].push_back(5.0);
-  graph.AddArc(source, destination_2);
+  builder.AddArc(source, destination_2);
   arc_lengths.push_back(1.0);
   arc_resources[0].push_back(7.0);
-  graph.AddArc(source, destination_3);
+  builder.AddArc(source, destination_3);
   arc_lengths.push_back(2.0);
   arc_resources[0].push_back(6.0);
+  auto graph = std::move(builder).Build(nullptr);
   const std::vector<int> sources = {source};
   const std::vector<int> destinations = {destination_1, destination_2,
                                          destination_3};
@@ -410,9 +412,9 @@ TEST(ConstrainedShortestPathsOnDagWrapperTest, MultipleDestinations) {
                                               destination_1, destination_2};
   const std::vector<double> max_resources = {6.0};
   ConstrainedShortestPathsOnDagWrapper<util::ListGraph<>>
-      constrained_shortest_path_on_dag(&graph, &arc_lengths, &arc_resources,
-                                       topological_order, sources, destinations,
-                                       &max_resources);
+      constrained_shortest_path_on_dag(graph.get(), &arc_lengths,
+                                       &arc_resources, topological_order,
+                                       sources, destinations, &max_resources);
 
   EXPECT_THAT(
       constrained_shortest_path_on_dag.RunConstrainedShortestPathOnDag(),
@@ -426,33 +428,34 @@ TEST(ConstrainedShortestPathsOnDagWrapperTest, UpdateArcsLength) {
   const int a = 2;
   const int b = 3;
   const int num_nodes = 4;
-  util::ListGraph<> graph(num_nodes, /*arc_capacity=*/4);
+  util::ListGraph<>::Builder builder(num_nodes, /*arc_capacity=*/4);
   std::vector<double> arc_lengths;
   std::vector<std::vector<double>> arc_resources(2);
-  graph.AddArc(source, a);
+  builder.AddArc(source, a);
   arc_lengths.push_back(5.0);
   arc_resources[0].push_back(1.0);
   arc_resources[1].push_back(3.0);
-  graph.AddArc(source, b);
+  builder.AddArc(source, b);
   arc_lengths.push_back(2.0);
   arc_resources[0].push_back(4.0);
   arc_resources[1].push_back(10.0);
-  graph.AddArc(a, destination);
+  builder.AddArc(a, destination);
   arc_lengths.push_back(3.0);
   arc_resources[0].push_back(5.0);
   arc_resources[1].push_back(9.0);
-  graph.AddArc(b, destination);
+  builder.AddArc(b, destination);
   arc_lengths.push_back(20.0);
   arc_resources[0].push_back(2.0);
   arc_resources[1].push_back(2.0);
+  auto graph = std::move(builder).Build(nullptr);
   const std::vector<int> topological_order = {source, a, b, destination};
   const std::vector<int> sources = {source};
   const std::vector<int> destinations = {destination};
   const std::vector<double> max_resources = {6.0, 12.0};
   ConstrainedShortestPathsOnDagWrapper<util::ListGraph<>>
-      constrained_shortest_path_on_dag(&graph, &arc_lengths, &arc_resources,
-                                       topological_order, sources, destinations,
-                                       &max_resources);
+      constrained_shortest_path_on_dag(graph.get(), &arc_lengths,
+                                       &arc_resources, topological_order,
+                                       sources, destinations, &max_resources);
 
   EXPECT_THAT(
       constrained_shortest_path_on_dag.RunConstrainedShortestPathOnDag(),
@@ -473,26 +476,27 @@ TEST(ConstrainedShortestPathsOnDagWrapperTest, LimitMaximumNumberOfLabels) {
   const int destination = 1;
   const int a = 2;
   const int num_nodes = 3;
-  util::ListGraph<> graph(num_nodes, /*arc_capacity=*/2);
+  util::ListGraph<>::Builder builder(num_nodes, /*arc_capacity=*/2);
   std::vector<double> arc_lengths;
   std::vector<std::vector<double>> arc_resources(1);
-  graph.AddArc(source, a);
+  builder.AddArc(source, a);
   arc_lengths.push_back(5.0);
   arc_resources[0].push_back(2.0);
-  graph.AddArc(a, destination);
+  builder.AddArc(a, destination);
   arc_lengths.push_back(-2.0);
   arc_resources[0].push_back(1.0);
+  auto graph = std::move(builder).Build(nullptr);
   const std::vector<int> topological_order = {source, a, destination};
   const std::vector<int> sources = {source};
   const std::vector<int> destinations = {destination};
   const std::vector<double> max_resources = {6.0};
   ConstrainedShortestPathsOnDagWrapper<util::ListGraph<>>
       constrained_shortest_path_on_dag_with_one_label(
-          &graph, &arc_lengths, &arc_resources, topological_order, sources,
+          graph.get(), &arc_lengths, &arc_resources, topological_order, sources,
           destinations, &max_resources, /*max_num_created_labels=*/1);
   ConstrainedShortestPathsOnDagWrapper<util::ListGraph<>>
       constrained_shortest_path_on_dag_with_four_labels(
-          &graph, &arc_lengths, &arc_resources, topological_order, sources,
+          graph.get(), &arc_lengths, &arc_resources, topological_order, sources,
           destinations, &max_resources, /*max_num_created_labels=*/4);
 
   EXPECT_THAT(constrained_shortest_path_on_dag_with_one_label
@@ -510,7 +514,8 @@ TEST(ConstrainedShortestPathsOnDagWrapperTest, LimitMaximumNumberOfLabels) {
 // the first and num_nodes-1 the last element in the topological order. Note
 // that the graph always include at least one arc from 0 to num_nodes-1.
 template <typename NodeIndex = int32_t, typename ArcIndex = int32_t>
-std::pair<util::StaticGraph<NodeIndex, ArcIndex>, std::vector<NodeIndex>>
+std::pair<std::unique_ptr<util::StaticGraph<NodeIndex, ArcIndex>>,
+          std::vector<NodeIndex>>
 BuildRandomDag(const NodeIndex num_nodes, const ArcIndex num_arcs) {
   absl::BitGen bit_gen;
   CHECK_GE(num_nodes, 2);
@@ -523,16 +528,18 @@ BuildRandomDag(const NodeIndex num_nodes, const ArcIndex num_arcs) {
   absl::c_iota(non_start_end, 1);
   absl::c_shuffle(non_start_end, bit_gen);
   ArcIndex edges_added = 0;
-  util::StaticGraph<NodeIndex, ArcIndex> graph(num_nodes, num_arcs);
-  graph.AddArc(0, num_nodes - 1);
+  typename util::StaticGraph<NodeIndex, ArcIndex>::Builder builder(num_nodes,
+                                                                   num_arcs);
+  builder.AddArc(0, num_nodes - 1);
   while (edges_added < num_arcs - 1) {
     NodeIndex start_index = absl::Uniform(bit_gen, 0, num_nodes - 1);
     NodeIndex end_index = absl::Uniform(bit_gen, start_index + 1, num_nodes);
-    graph.AddArc(topological_order[start_index], topological_order[end_index]);
+    builder.AddArc(topological_order[start_index],
+                   topological_order[end_index]);
     edges_added++;
   }
-  graph.Build();
-  return {graph, topological_order};
+  auto graph = std::move(builder).Build(nullptr);
+  return {std::move(graph), topological_order};
 }
 
 // The length of each arc is drawn uniformly at random within a given interval
@@ -628,178 +635,34 @@ TEST(ConstrainedShortestPathsOnDagWrapperTest,
     const auto [graph, topological_order] = BuildRandomDag(num_nodes, num_arcs);
     std::vector<double> arc_lengths(num_arcs);
     std::vector<std::vector<double>> arc_resources(1);
-    arc_resources[0] = GenerateRandomIntegerValues(graph, /*min_value=*/1.0,
+    arc_resources[0] = GenerateRandomIntegerValues(*graph, /*min_value=*/1.0,
                                                    /*max_value=*/10.0,
                                                    /*start_to_end_value=*/1.0);
     const std::vector<int> sources = {0};
     const std::vector<int> destinations = {num_nodes - 1};
     const std::vector<double> max_resources = {15.0};
     ConstrainedShortestPathsOnDagWrapper<util::StaticGraph<>>
-        constrained_shortest_path_on_dag(&graph, &arc_lengths, &arc_resources,
-                                         topological_order, sources,
-                                         destinations, &max_resources);
+        constrained_shortest_path_on_dag(graph.get(), &arc_lengths,
+                                         &arc_resources, topological_order,
+                                         sources, destinations, &max_resources);
     const int kNumSamples = 5;
     for (int _ = 0; _ < kNumSamples; ++_) {
-      arc_lengths = GenerateRandomIntegerValues(graph);
+      arc_lengths = GenerateRandomIntegerValues(*graph);
       const GraphPathWithLength<util::StaticGraph<>> path_with_length =
           constrained_shortest_path_on_dag.RunConstrainedShortestPathOnDag();
 
       EXPECT_NEAR(path_with_length.length,
                   SolveConstrainedShortestPathUsingIntegerProgramming(
-                      graph, arc_lengths, arc_resources, max_resources, sources,
-                      destinations),
+                      *graph, arc_lengths, arc_resources, max_resources,
+                      sources, destinations),
                   1e-5);
 
       ASSERT_FALSE(HasFailure())
           << DUMP_VARS(num_nodes, num_arcs, arc_lengths) << "\n With graph :\n "
-          << util::GraphToString(graph, util::PRINT_GRAPH_ARCS);
+          << util::GraphToString(*graph, util::PRINT_GRAPH_ARCS);
     }
   }
 }
-
-// -----------------------------------------------------------------------------
-// Benchmark.
-// -----------------------------------------------------------------------------
-template <typename NodeIndex = int32_t, typename ArcIndex = int32_t>
-void BM_RandomDag(benchmark::State& state) {
-  absl::BitGen bit_gen;
-  // Generate a fixed random DAG.
-  const NodeIndex num_nodes = state.range(0);
-  const ArcIndex num_arcs = num_nodes * state.range(1);
-  const auto [graph, topological_order] = BuildRandomDag(num_nodes, num_arcs);
-  // Generate 20 scenarios of random arc lengths.
-  const int num_scenarios = 20;
-  std::vector<std::vector<double>> arc_lengths_scenarios;
-  for (int _ = 0; _ < num_scenarios; ++_) {
-    arc_lengths_scenarios.push_back(GenerateRandomIntegerValues(graph));
-  }
-  std::vector<double> arc_lengths(num_arcs);
-  std::vector<std::vector<double>> arc_resources(1);
-  arc_resources[0] =
-      GenerateRandomIntegerValues(graph, /*min_value=*/1.0,
-                                  /*max_value=*/10.0,
-                                  /*start_to_end_value=*/num_nodes * 0.2);
-  const std::vector<NodeIndex> sources = {0};
-  const std::vector<NodeIndex> destinations = {num_nodes - 1};
-  const std::vector<double> max_resources = {num_nodes * 0.2};
-  ConstrainedShortestPathsOnDagWrapper<util::StaticGraph<NodeIndex, ArcIndex>>
-      constrained_shortest_path_on_dag(&graph, &arc_lengths, &arc_resources,
-                                       topological_order, sources, destinations,
-                                       &max_resources);
-
-  int total_label_count = 0;
-  for (auto _ : state) {
-    // Pick a arc lengths scenario at random.
-    arc_lengths =
-        arc_lengths_scenarios[absl::Uniform(bit_gen, 0, num_scenarios)];
-    const GraphPathWithLength<util::StaticGraph<NodeIndex, ArcIndex>>
-        path_with_length =
-            constrained_shortest_path_on_dag.RunConstrainedShortestPathOnDag();
-    total_label_count += constrained_shortest_path_on_dag.label_count();
-    CHECK_GE(path_with_length.length, 0.0);
-    CHECK_LE(path_with_length.length, 10000.0);
-  }
-  state.SetItemsProcessed(std::max(1, total_label_count));
-}
-
-BENCHMARK(BM_RandomDag<int32_t, int32_t>)
-    ->ArgPair(1 << 10, 16)
-    ->ArgPair(1 << 16, 4)
-    ->ArgPair(1 << 16, 16)
-    ->ArgPair(1 << 19, 4);
-BENCHMARK(BM_RandomDag<int64_t, int64_t>)
-    ->ArgPair(1 << 19, 16)
-    ->ArgPair(1 << 22, 4);
-
-// Generate a 2-dimensional grid DAG.
-// Eg. for width=3, height=2, it generates this:
-// 0 ----> 1 ----> 2
-// |       |       |
-// |       |       |
-// v       v       v
-// 3 ----> 4 ----> 5
-void BM_GridDAG(benchmark::State& state) {
-  const int64_t width = state.range(0);
-  const int64_t height = state.range(1);
-  const int num_resources = state.range(2);
-  const int num_nodes = width * height;
-  const int num_arcs = 2 * num_nodes - width - height;
-  util::StaticGraph<> graph(num_nodes, num_arcs);
-  // Add horizontal edges.
-  for (int i = 0; i < height; ++i) {
-    for (int j = 1; j < width; ++j) {
-      const int left = i * width + (j - 1);
-      const int right = i * width + j;
-      graph.AddArc(left, right);
-    }
-  }
-  // Add vertical edges.
-  for (int i = 1; i < height; ++i) {
-    for (int j = 0; j < width; ++j) {
-      const int up = (i - 1) * width + j;
-      const int down = i * width + j;
-      graph.AddArc(up, down);
-    }
-  }
-  graph.Build();
-  std::vector<int> topological_order(num_nodes);
-  absl::c_iota(topological_order, 0);
-
-  // Generate 20 scenarios of random arc lengths.
-  absl::BitGen bit_gen;
-  const int kNumScenarios = 20;
-  std::vector<std::vector<double>> arc_lengths_scenarios;
-  for (int unused = 0; unused < kNumScenarios; ++unused) {
-    std::vector<double> arc_lengths(graph.num_arcs());
-    for (int i = 0; i < graph.num_arcs(); ++i) {
-      arc_lengths[i] = absl::Uniform<double>(bit_gen, 0, 1);
-    }
-    arc_lengths_scenarios.push_back(arc_lengths);
-  }
-
-  std::vector<std::vector<double>> arc_resources(num_resources);
-  for (int r = 0; r < num_resources; ++r) {
-    arc_resources[r].resize(graph.num_arcs());
-    for (int i = 0; i < graph.num_arcs(); ++i) {
-      arc_resources[r][i] = absl::Uniform<double>(bit_gen, 0, 1);
-    }
-  }
-
-  std::vector<double> arc_lengths(num_arcs);
-  const std::vector<int> sources = {0};
-  const std::vector<int> destinations = {num_nodes - 1};
-  std::vector<double> max_resources(num_resources);
-  // Each path from source to destination has `(width + height - 2)` arcs. Each
-  // arc has mean resource(s) 0.5. We want to consider paths with half (0.5) the
-  // mean resource(s).
-  const double max_resource = (width + height - 2) * 0.5 * 0.5;
-  for (int r = 0; r < num_resources; ++r) {
-    max_resources[r] = max_resource;
-  }
-
-  ConstrainedShortestPathsOnDagWrapper<util::StaticGraph<>>
-      constrained_shortest_path_on_dag(&graph, &arc_lengths, &arc_resources,
-                                       topological_order, sources, destinations,
-                                       &max_resources);
-
-  int total_label_count = 0;
-  for (auto _ : state) {
-    // Pick a arc lengths scenario at random.
-    arc_lengths =
-        arc_lengths_scenarios[absl::Uniform<int>(bit_gen, 0, kNumScenarios)];
-    const GraphPathWithLength<util::StaticGraph<>> path_with_length =
-        constrained_shortest_path_on_dag.RunConstrainedShortestPathOnDag();
-    total_label_count += constrained_shortest_path_on_dag.label_count();
-    CHECK_GE(path_with_length.length, 0.0);
-  }
-  state.SetItemsProcessed(std::max(1, total_label_count));
-}
-
-BENCHMARK(BM_GridDAG)
-    ->Args({100, 100, 1})
-    ->Args({100, 100, 2})
-    ->Args({1000, 100, 1})
-    ->Args({1000, 100, 2});
 
 // -----------------------------------------------------------------------------
 // Debug tests.
@@ -861,19 +724,20 @@ TEST(ConstrainedShortestPathsOnDagWrapperTest, ValidateTopologicalOrder) {
   const int source = 0;
   const int destination = 1;
   const int num_nodes = 2;
-  util::ListGraph<> graph(num_nodes, /*arc_capacity=*/1);
+  util::ListGraph<>::Builder builder(num_nodes, /*arc_capacity=*/1);
   std::vector<double> arc_lengths;
   std::vector<std::vector<double>> arc_resources(1);
-  graph.AddArc(source, destination);
+  builder.AddArc(source, destination);
   arc_lengths.push_back(1.0);
   arc_resources[0].push_back({1.0});
+  auto graph = std::move(builder).Build(nullptr);
   const std::vector<int> topological_order = {source};
   const std::vector<int> sources = {source};
   const std::vector<int> destinations = {destination};
   const std::vector<double> max_resources = {0.0};
 
   EXPECT_DEATH(ConstrainedShortestPathsOnDagWrapper<util::ListGraph<>>(
-                   &graph, &arc_lengths, &arc_resources, topological_order,
+                   graph.get(), &arc_lengths, &arc_resources, topological_order,
                    sources, destinations, &max_resources),
                "Invalid topological order");
 }

--- a/ortools/graph/dag_shortest_path.cc
+++ b/ortools/graph/dag_shortest_path.cc
@@ -39,15 +39,15 @@ struct ShortestPathOnDagProblem {
 
 ShortestPathOnDagProblem ReadProblem(
     const int num_nodes, absl::Span<const ArcWithLength> arcs_with_length) {
-  GraphType graph(num_nodes, arcs_with_length.size());
+  GraphType::Builder builder(num_nodes, arcs_with_length.size());
   std::vector<double> arc_lengths;
   arc_lengths.reserve(arcs_with_length.size());
   for (const auto& arc : arcs_with_length) {
-    graph.AddArc(arc.from, arc.to);
+    builder.AddArc(arc.from, arc.to);
     arc_lengths.push_back(arc.length);
   }
   std::vector<ArcIndex> permutation;
-  graph.Build(&permutation);
+  auto graph = std::move(builder).Build(&permutation);
   util::Permute(permutation, &arc_lengths);
 
   std::vector<ArcIndex> original_arc_indices(permutation.size());
@@ -58,11 +58,11 @@ ShortestPathOnDagProblem ReadProblem(
   }
 
   absl::StatusOr<std::vector<NodeIndex>> topological_order =
-      util::graph::FastTopologicalSort(graph);
+      util::graph::FastTopologicalSort(*graph);
   CHECK_OK(topological_order) << "arcs_with_length form a cycle.";
 
   return ShortestPathOnDagProblem{
-      .graph = std::move(graph),
+      .graph = std::move(*graph),
       .arc_lengths = std::move(arc_lengths),
       .original_arc_indices = std::move(original_arc_indices),
       .topological_order = std::move(topological_order).value()};

--- a/ortools/graph/dag_shortest_path.h
+++ b/ortools/graph/dag_shortest_path.h
@@ -18,6 +18,7 @@
 #include <cstddef>
 #include <functional>
 #include <limits>
+#include <memory>
 #include <vector>
 
 #include "absl/algorithm/container.h"
@@ -231,7 +232,7 @@ class KShortestPathsOnDagWrapper {
   absl::Span<const NodeIndex> const topological_order_;
   const int path_count_;
 
-  GraphType reverse_graph_;
+  std::unique_ptr<const GraphType> reverse_graph_;
   // Maps reverse arc indices to indices in the original graph.
   std::vector<ArcIndex> arc_indices_;
 
@@ -469,12 +470,12 @@ KShortestPathsOnDagWrapper<GraphType, ArcLengths>::KShortestPathsOnDagWrapper(
   // TODO(b/332475713): Optimize if reverse graph is already provided in
   // `GraphType`.
   const ArcIndex num_arcs = graph_->num_arcs();
-  reverse_graph_ = GraphType(graph_->num_nodes(), num_arcs);
+  typename GraphType::Builder reverse_builder(graph_->num_nodes(), num_arcs);
   for (ArcIndex arc_index(0); arc_index < num_arcs; ++arc_index) {
-    reverse_graph_.AddArc(graph->Head(arc_index), graph->Tail(arc_index));
+    reverse_builder.AddArc(graph->Head(arc_index), graph->Tail(arc_index));
   }
   std::vector<ArcIndex> permutation;
-  reverse_graph_.Build(&permutation);
+  reverse_graph_ = std::move(reverse_builder).Build(&permutation);
   arc_indices_.resize(permutation.size());
   if (!permutation.empty()) {
     for (int i = 0; i < permutation.size(); ++i) {
@@ -547,7 +548,7 @@ void KShortestPathsOnDagWrapper<GraphType, ArcLengths>::RunKShortestPathOnDag(
     if (is_source_[static_cast<size_t>(to)]) {
       min_heap.push_back({.arc_index = GraphType::kNilArc});
     }
-    for (const ArcIndex reverse_arc_index : reverse_graph_.OutgoingArcs(to)) {
+    for (const ArcIndex reverse_arc_index : reverse_graph_->OutgoingArcs(to)) {
       const ArcIndex arc_index =
           arc_indices.empty()
               ? reverse_arc_index

--- a/ortools/graph/dag_shortest_path_test.cc
+++ b/ortools/graph/dag_shortest_path_test.cc
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <limits>
+#include <memory>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -25,7 +26,6 @@
 #include "absl/random/random.h"
 #include "absl/status/status.h"
 #include "absl/types/span.h"
-#include "benchmark/benchmark.h"
 #include "gtest/gtest.h"
 #include "ortools/base/dump_vars.h"
 #include "ortools/base/gmock.h"
@@ -446,8 +446,8 @@ TEST(ShortestPathsOnDagWrapperTest, UpdateCost) {
 // Builds a random DAG with a given number of nodes and arcs where 0 is always
 // the first and num_nodes-1 the last element in the topological order. Note
 // that the graph always include at least one arc from 0 to num_nodes-1.
-std::pair<util::StaticGraph<>, std::vector<int>> BuildRandomDag(
-    const int64_t num_nodes, const int64_t num_arcs) {
+std::pair<std::unique_ptr<const util::StaticGraph<>>, std::vector<int>>
+BuildRandomDag(const int64_t num_nodes, const int64_t num_arcs) {
   absl::BitGen bit_gen;
   CHECK_GE(num_nodes, 2);
   CHECK_GE(num_arcs, 1);
@@ -459,16 +459,16 @@ std::pair<util::StaticGraph<>, std::vector<int>> BuildRandomDag(
   absl::c_iota(non_start_end, 1);
   absl::c_shuffle(non_start_end, bit_gen);
   int edges_added = 0;
-  util::StaticGraph<> graph(num_nodes, num_arcs);
-  graph.AddArc(0, num_nodes - 1);
+  util::StaticGraph<>::Builder builder(num_nodes, num_arcs);
+  builder.AddArc(0, num_nodes - 1);
   while (edges_added < num_arcs - 1) {
     int start_index = absl::Uniform(bit_gen, 0, num_nodes - 1);
     int end_index = absl::Uniform(bit_gen, start_index + 1, num_nodes);
-    graph.AddArc(topological_order[start_index], topological_order[end_index]);
+    builder.AddArc(topological_order[start_index],
+                   topological_order[end_index]);
     edges_added++;
   }
-  graph.Build();
-  return {graph, topological_order};
+  return {std::move(builder).Build(nullptr), topological_order};
 }
 
 // The length of each arc is drawn uniformly at random within a given interval
@@ -504,12 +504,12 @@ TEST(ShortestPathsOnDagWrapperTest, RandomizedStressTest) {
         bit_gen, 1, std::min(num_nodes * (num_nodes - 1) / 2, 15));
     // Generate a random DAG with random lengths.
     const auto [graph, topological_order] = BuildRandomDag(num_nodes, num_arcs);
-    const std::vector<double> arc_lengths = GenerateRandomLengths(graph);
+    const std::vector<double> arc_lengths = GenerateRandomLengths(*graph);
 
     // Run Floyd-Warshall as a 'reference' shortest path algorithm.
     FlatMatrix<double> ref_dist(num_nodes, num_nodes, kInf);
     for (int a = 0; a < num_arcs; ++a) {
-      double& d = ref_dist[graph.Tail(a)][graph.Head(a)];
+      double& d = ref_dist[graph->Tail(a)][graph->Head(a)];
       if (arc_lengths[a] < d) d = arc_lengths[a];
     }
     for (int node = 0; node < num_nodes; ++node) {
@@ -528,7 +528,7 @@ TEST(ShortestPathsOnDagWrapperTest, RandomizedStressTest) {
     // the FW (Floyd-Warshall) which is O(N³), we run more than one shortest
     // path per FW.
     ShortestPathsOnDagWrapper<util::StaticGraph<>> shortest_path_on_dag(
-        &graph, &arc_lengths, topological_order);
+        graph.get(), &arc_lengths, topological_order);
     for (int _ = 0; _ < 20; ++_) {
       // Draw sources (*with* repetition) with initial distances.
       const int num_sources = absl::Uniform(bit_gen, 1, 5);
@@ -558,7 +558,7 @@ TEST(ShortestPathsOnDagWrapperTest, RandomizedStressTest) {
       ASSERT_FALSE(HasFailure())
           << DUMP_VARS(num_nodes, num_arcs, num_sources, sources, arc_lengths)
           << "\n With graph:\n"
-          << util::GraphToString(graph, util::PRINT_GRAPH_ARCS);
+          << util::GraphToString(*graph, util::PRINT_GRAPH_ARCS);
     }
   }
 }
@@ -595,71 +595,6 @@ TEST(ShortestPathsOnDagWrapperTest, ValidateTopologicalOrder) {
                "Invalid topological order");
 }
 #endif  // NDEBUG
-
-// -----------------------------------------------------------------------------
-// ShortestPathsOnDagWrapper benchmarks.
-// -----------------------------------------------------------------------------
-void BM_RandomDag(benchmark::State& state) {
-  absl::BitGen bit_gen;
-  // Generate a fixed random DAG.
-  const int num_nodes = state.range(0);
-  const int num_arcs = num_nodes * state.range(1);
-  const auto [graph, topological_order] = BuildRandomDag(num_nodes, num_arcs);
-  // Generate 10 scenarios of random arc lengths.
-  const int num_scenarios = 10;
-  std::vector<std::vector<double>> arc_lengths_scenarios;
-  for (int _ = 0; _ < num_scenarios; ++_) {
-    arc_lengths_scenarios.push_back(GenerateRandomLengths(graph));
-  }
-  std::vector<double> arc_lengths = arc_lengths_scenarios.front();
-  ShortestPathsOnDagWrapper<util::StaticGraph<>> shortest_path_on_dag(
-      &graph, &arc_lengths, topological_order);
-  for (auto _ : state) {
-    // Pick a arc lengths scenario at random.
-    arc_lengths =
-        arc_lengths_scenarios[absl::Uniform(bit_gen, 0, num_scenarios)];
-    shortest_path_on_dag.RunShortestPathOnDag({0});
-    CHECK(shortest_path_on_dag.IsReachable(num_nodes - 1));
-    const double minimum_length = shortest_path_on_dag.LengthTo(num_nodes - 1);
-    CHECK_GE(minimum_length, 0.0);
-    CHECK_LE(minimum_length, 10000.0);
-  }
-  state.SetItemsProcessed(state.iterations() * (num_nodes + num_arcs));
-}
-
-BENCHMARK(BM_RandomDag)
-    ->ArgPair(1000, 10)
-    ->ArgPair(1 << 16, 4)
-    ->ArgPair(1 << 16, 16)
-    ->ArgPair(1 << 22, 4)
-    ->ArgPair(1 << 22, 16)
-    ->ArgPair(1 << 26, 4);  // Don't go bigger, can't run on work station.
-
-void BM_LineDag(benchmark::State& state) {
-  const int num_nodes = state.range(0);
-  const int num_edges = num_nodes - 1;
-  std::vector<int> topological_order(num_nodes);
-  util::StaticGraph<> graph(num_nodes, num_edges);
-  absl::c_iota(topological_order, 0);
-  for (int i = 0; i < num_nodes - 1; ++i) {
-    graph.AddArc(i, i + 1);
-  }
-  graph.Build();
-  std::vector<double> arc_lengths(num_edges, 1);
-  ShortestPathsOnDagWrapper<util::StaticGraph<>> shortest_path_on_dag(
-      &graph, &arc_lengths, topological_order);
-  for (auto _ : state) {
-    shortest_path_on_dag.RunShortestPathOnDag({0});
-    CHECK(shortest_path_on_dag.IsReachable(num_nodes - 1));
-    CHECK_EQ(shortest_path_on_dag.LengthTo(num_nodes - 1), num_nodes - 1);
-    CHECK_EQ(shortest_path_on_dag.ArcPathTo(num_nodes - 1).size(),
-             num_nodes - 1);
-    CHECK_EQ(shortest_path_on_dag.NodePathTo(num_nodes - 1).size(), num_nodes);
-  }
-  state.SetItemsProcessed(state.iterations() * num_nodes);
-}
-
-BENCHMARK(BM_LineDag)->Arg(1 << 16)->Arg(1 << 22)->Arg(1 << 24);
 
 // -----------------------------------------------------------------------------
 // KShortestPathOnDagTest and KShortestPathsOnDagWrapperTest.
@@ -1110,13 +1045,13 @@ TEST(KShortestPathsOnDagWrapperTest, RandomizedStressTest) {
         bit_gen, 1, std::min(num_nodes * (num_nodes - 1) / 2, 15));
     // Generate a random DAG with random lengths.
     const auto [graph, topological_order] = BuildRandomDag(num_nodes, num_arcs);
-    const std::vector<double> arc_lengths = GenerateRandomLengths(graph);
+    const std::vector<double> arc_lengths = GenerateRandomLengths(*graph);
 
     ShortestPathsOnDagWrapper<util::StaticGraph<>> shortest_path_on_dag(
-        &graph, &arc_lengths, topological_order);
+        graph.get(), &arc_lengths, topological_order);
     const int path_count = 5;
     KShortestPathsOnDagWrapper<util::StaticGraph<>> shortest_paths_on_dag(
-        &graph, &arc_lengths, topological_order, path_count);
+        graph.get(), &arc_lengths, topological_order, path_count);
     for (int _ = 0; _ < 20; ++_) {
       // Draw sources (*with* repetition) with initial distances.
       const int num_sources = absl::Uniform(bit_gen, 1, 5);
@@ -1130,8 +1065,8 @@ TEST(KShortestPathsOnDagWrapperTest, RandomizedStressTest) {
         all_paths_count[source] = 1;
       }
       for (const int from : topological_order) {
-        for (const int arc : graph.OutgoingArcs(from)) {
-          const int to = graph.Head(arc);
+        for (const int arc : graph->OutgoingArcs(from)) {
+          const int to = graph->Head(arc);
           all_paths_count[to] += all_paths_count[from];
         }
       }
@@ -1150,7 +1085,7 @@ TEST(KShortestPathsOnDagWrapperTest, RandomizedStressTest) {
       ASSERT_FALSE(HasFailure())
           << DUMP_VARS(num_nodes, num_arcs, num_sources, sources, arc_lengths)
           << "\n With graph:\n"
-          << util::GraphToString(graph, util::PRINT_GRAPH_ARCS);
+          << util::GraphToString(*graph, util::PRINT_GRAPH_ARCS);
     }
   }
 }
@@ -1188,48 +1123,6 @@ TEST(KShortestPathsOnDagWrapperTest, ValidateTopologicalOrder) {
                "Invalid topological order");
 }
 #endif  // NDEBUG
-
-// -----------------------------------------------------------------------------
-// KShortestPathsOnDagWrapper benchmarks.
-// -----------------------------------------------------------------------------
-void BM_RandomDag_K(benchmark::State& state) {
-  absl::BitGen bit_gen;
-  // Generate a fixed random DAG.
-  const int num_nodes = state.range(0);
-  const int num_arcs = num_nodes * state.range(1);
-  const int path_count = state.range(2);
-  const auto [graph, topological_order] = BuildRandomDag(num_nodes, num_arcs);
-  // Generate 10 scenarios of random arc lengths.
-  const int num_scenarios = 10;
-  std::vector<std::vector<double>> arc_lengths_scenarios;
-  for (int _ = 0; _ < num_scenarios; ++_) {
-    arc_lengths_scenarios.push_back(GenerateRandomLengths(graph));
-  }
-  std::vector<double> arc_lengths = arc_lengths_scenarios.front();
-  KShortestPathsOnDagWrapper<util::StaticGraph<>> shortest_paths_on_dag(
-      &graph, &arc_lengths, topological_order, path_count);
-  for (auto _ : state) {
-    // Pick a arc lengths scenario at random.
-    arc_lengths =
-        arc_lengths_scenarios[absl::Uniform(bit_gen, 0, num_scenarios)];
-    shortest_paths_on_dag.RunKShortestPathOnDag({0});
-    CHECK(shortest_paths_on_dag.IsReachable(num_nodes - 1));
-    const std::vector<double> lengths =
-        shortest_paths_on_dag.LengthsTo(num_nodes - 1);
-    CHECK_GE(lengths[0], 0.0);
-    CHECK_LE(lengths[0], 10000.0);
-  }
-  state.SetItemsProcessed(state.iterations() * (num_nodes + num_arcs));
-}
-
-BENCHMARK(BM_RandomDag_K)
-    ->Args({1000, 10, 4})
-    ->Args({1 << 16, 4, 4})
-    ->Args({1 << 16, 4, 16})
-    ->Args({1 << 16, 16, 4})
-    ->Args({1 << 16, 16, 16})
-    ->Args({1 << 22, 4, 4})
-    ->Args({1 << 22, 4, 16});
 
 TEST(ShortestPathOnDagIncrementalTest, ChangeSources) {
   util::ListGraph<> graph(4, /*arc_capacity=*/4);

--- a/ortools/graph/eulerian_path_test.cc
+++ b/ortools/graph/eulerian_path_test.cc
@@ -16,7 +16,6 @@
 #include <vector>
 
 #include "absl/base/macros.h"
-#include "benchmark/benchmark.h"
 #include "gtest/gtest.h"
 #include "ortools/base/gmock.h"
 #include "ortools/graph_base/graph.h"
@@ -216,33 +215,6 @@ TEST(EulerianPathTest, EulerianTourWithSuccessfulConnectivityCheck) {
   EXPECT_THAT(BuildEulerianTour(graph, /*assume_connectivity=*/false),
               ElementsAre(0, 1, 0));
 }
-template <typename GraphType>
-static void BM_EulerianTourOnGrid(benchmark::State& state) {
-  int size = state.range(0);
-  const int num_nodes = size * size;
-  const int num_edges = 2 * size * (size - 1) + 2 * size - 4;
-  util::ReverseArcListGraph<int, int> graph(num_nodes, num_edges);
-  for (int i = 0; i < size; ++i) {
-    for (int j = 0; j < size; ++j) {
-      if (j < size - 1) {
-        graph.AddArc(i * size + j, i * size + j + 1);
-      }
-      if (i < size - 1) {
-        graph.AddArc(i * size + j, (i + 1) * size + j);
-      }
-    }
-  }
-  for (int i = 1; i < size - 1; ++i) {
-    graph.AddArc(i * size, i * size + size - 1);
-    graph.AddArc(i, (size - 1) * size + i);
-  }
-  for (auto _ : state) {
-    ASSERT_EQ(num_edges + 1, BuildEulerianTour(graph).size());
-  }
-}
-
-BENCHMARK_TEMPLATE(BM_EulerianTourOnGrid, util::ReverseArcStaticGraph<>)
-    ->Range(2, 1 << 10);
 
 }  // namespace
 }  // namespace operations_research

--- a/ortools/graph/generic_max_flow_test.cc
+++ b/ortools/graph/generic_max_flow_test.cc
@@ -28,7 +28,6 @@
 #include "absl/random/random.h"
 #include "absl/strings/str_format.h"
 #include "absl/types/span.h"
-#include "benchmark/benchmark.h"
 #include "gtest/gtest.h"
 #include "ortools/base/gmock.h"
 #include "ortools/base/log_severity.h"
@@ -55,14 +54,14 @@ typename GenericMaxFlow<Graph>::Status MaxFlowTester(
         nullptr,
     const std::vector<typename Graph::NodeIndex>* expected_sink_min_cut =
         nullptr) {
-  Graph graph(num_nodes, num_arcs);
+  typename Graph::Builder graph_builder(num_nodes, num_arcs);
   for (int i = 0; i < num_arcs; ++i) {
-    graph.AddArc(tail[i], head[i]);
+    graph_builder.AddArc(tail[i], head[i]);
   }
   std::vector<typename Graph::ArcIndex> permutation;
-  graph.Build(&permutation);
+  const auto graph = std::move(graph_builder).Build(&permutation);
 
-  GenericMaxFlow<Graph> max_flow(&graph, 0, num_nodes - 1);
+  GenericMaxFlow<Graph> max_flow(graph.get(), 0, num_nodes - 1);
   for (typename Graph::ArcIndex arc = 0; arc < num_arcs; ++arc) {
     const int image = arc < permutation.size() ? permutation[arc] : arc;
 
@@ -317,17 +316,17 @@ TYPED_TEST(GenericMaxFlowTest, SmallFlowTypes) {
 
   // Lets generate and build a random graph.
   // We should have more than enough arc to make it fully connected.
-  TypeParam graph(num_nodes, num_arcs);
+  typename TypeParam::Builder graph_builder(num_nodes, num_arcs);
   for (int arc = 0; arc < num_arcs; ++arc) {
-    graph.AddArc(absl::Uniform(random, 0, num_nodes),
-                 absl::Uniform(random, 0, num_nodes));
+    graph_builder.AddArc(absl::Uniform(random, 0, num_nodes),
+                         absl::Uniform(random, 0, num_nodes));
   }
-  graph.Build();
+  const auto graph = std::move(graph_builder).Build(nullptr);
 
   typedef GenericMaxFlow<TypeParam, StrongUint16, int64_t> MaxFlowA;
   typedef GenericMaxFlow<TypeParam, int64_t, int64_t> MaxFlowB;
-  MaxFlowA max_flow_A(&graph, /*source=*/0, /*sink=*/num_nodes - 1);
-  MaxFlowB max_flow_B(&graph, /*source=*/0, /*sink=*/num_nodes - 1);
+  MaxFlowA max_flow_A(graph.get(), /*source=*/0, /*sink=*/num_nodes - 1);
+  MaxFlowB max_flow_B(graph.get(), /*source=*/0, /*sink=*/num_nodes - 1);
   for (int arc = 0; arc < num_arcs; ++arc) {
     const uint16_t capa =
         absl::Uniform(random, 0, std::numeric_limits<uint16_t>::max() / 2);
@@ -343,31 +342,33 @@ TYPED_TEST(GenericMaxFlowTest, SmallFlowTypes) {
 
 template <typename Graph>
 void AddSourceAndSink(const typename Graph::NodeIndex num_tails,
-                      const typename Graph::NodeIndex num_heads, Graph* graph) {
+                      const typename Graph::NodeIndex num_heads,
+                      typename Graph::Builder& graph_builder) {
   const typename Graph::NodeIndex source = num_tails + num_heads;
   const typename Graph::NodeIndex sink = num_tails + num_heads + 1;
   for (typename Graph::NodeIndex tail = 0; tail < num_tails; ++tail) {
-    graph->AddArc(source, tail);
+    graph_builder.AddArc(source, tail);
   }
   for (typename Graph::NodeIndex head = 0; head < num_heads; ++head) {
-    graph->AddArc(num_tails + head, sink);
+    graph_builder.AddArc(num_tails + head, sink);
   }
 }
 
 template <typename Graph>
 void GenerateCompleteGraphWithSourceAndSink(
     const typename Graph::NodeIndex num_tails,
-    const typename Graph::NodeIndex num_heads, Graph* graph) {
+    const typename Graph::NodeIndex num_heads,
+    typename Graph::Builder& graph_builder) {
   const typename Graph::NodeIndex num_nodes = num_tails + num_heads + 2;
   const typename Graph::ArcIndex num_arcs =
       num_tails * num_heads + num_tails + num_heads;
-  graph->Reserve(num_nodes, num_arcs);
+  graph_builder.Reserve(num_nodes, num_arcs);
   for (typename Graph::NodeIndex tail = 0; tail < num_tails; ++tail) {
     for (typename Graph::NodeIndex head = 0; head < num_heads; ++head) {
-      graph->AddArc(tail, head + num_tails);
+      graph_builder.AddArc(tail, head + num_tails);
     }
   }
-  AddSourceAndSink(num_tails, num_heads, graph);
+  AddSourceAndSink<Graph>(num_tails, num_heads, graph_builder);
 }
 
 // Generate a bipartite graph where each right node is connected to `degree`
@@ -377,28 +378,28 @@ void GeneratePartialRandomGraph(absl::BitGenRef random,
                                 const typename Graph::NodeIndex num_tails,
                                 const typename Graph::NodeIndex num_heads,
                                 const typename Graph::NodeIndex degree,
-                                Graph* graph) {
+                                typename Graph::Builder& graph_builder) {
   const typename Graph::NodeIndex num_nodes = num_tails + num_heads + 2;
   const typename Graph::ArcIndex num_arcs =
       num_tails * degree + num_tails + num_heads;
-  graph->Reserve(num_nodes, num_arcs);
+  graph_builder.Reserve(num_nodes, num_arcs);
   for (typename Graph::NodeIndex tail = 0; tail < num_tails; ++tail) {
     for (typename Graph::NodeIndex d = 0; d < degree; ++d) {
       const typename Graph::NodeIndex head =
           absl::Uniform(random, 0, num_heads);
-      graph->AddArc(tail, head + num_tails);
+      graph_builder.AddArc(tail, head + num_tails);
     }
   }
-  AddSourceAndSink(num_tails, num_heads, graph);
+  AddSourceAndSink<Graph>(num_tails, num_heads, graph_builder);
 }
 
 template <typename Graph>
-void GenerateRandomArcValuations(absl::BitGenRef random, const Graph& graph,
+void GenerateRandomArcValuations(absl::BitGenRef random,
+                                 const typename Graph::ArcIndex num_arcs,
                                  const int64_t max_range,
                                  std::vector<int64_t>* arc_valuation) {
-  const typename Graph::ArcIndex num_arcs = graph.num_arcs();
   arc_valuation->resize(num_arcs);
-  for (typename Graph::ArcIndex arc = 0; arc < graph.num_arcs(); ++arc) {
+  for (typename Graph::ArcIndex arc = 0; arc < num_arcs; ++arc) {
     (*arc_valuation)[arc] = absl::Uniform(random, 0, max_range);
   }
 }
@@ -472,12 +473,13 @@ void FullAssignment(std::optional<FlowQuantity> unused,
                     typename MaxFlowSolver<Graph>::Solver f,
                     typename Graph::NodeIndex num_tails,
                     typename Graph::NodeIndex num_heads) {
-  Graph graph;
-  GenerateCompleteGraphWithSourceAndSink(num_tails, num_heads, &graph);
-  graph.Build();
-  std::vector<int64_t> arc_capacity(graph.num_arcs(), 1);
+  typename Graph::Builder graph_builder;
+  GenerateCompleteGraphWithSourceAndSink<Graph>(num_tails, num_heads,
+                                                graph_builder);
+  const auto graph = std::move(graph_builder).Build(nullptr);
+  std::vector<int64_t> arc_capacity(graph->num_arcs(), 1);
   std::unique_ptr<GenericMaxFlow<Graph>> max_flow(new GenericMaxFlow<Graph>(
-      &graph, graph.num_nodes() - 2, graph.num_nodes() - 1));
+      graph.get(), graph->num_nodes() - 2, graph->num_nodes() - 1));
   SetUpNetworkData(arc_capacity, max_flow.get());
 
   // In a complete graph we should always reach the maximum flow.
@@ -497,17 +499,18 @@ void PartialRandomAssignment(std::optional<FlowQuantity> expected_flow,
                                : absl::BitGenRef(absl_random);
 
   const typename Graph::NodeIndex kDegree = 3;
-  Graph graph;
-  GeneratePartialRandomGraph(random, num_tails, num_heads, kDegree, &graph);
-  std::vector<int64_t> arc_capacity(graph.num_arcs(), 1);
+  typename Graph::Builder graph_builder;
+  GeneratePartialRandomGraph<Graph>(random, num_tails, num_heads, kDegree,
+                                    graph_builder);
+  std::vector<int64_t> arc_capacity(graph_builder.num_arcs(), 1);
 
   std::vector<int> permutation;
-  graph.Build(&permutation);
-  arc_capacity.resize(graph.num_arcs(), 0);
+  const auto graph = std::move(graph_builder).Build(&permutation);
+  arc_capacity.resize(graph->num_arcs(), 0);  // In case Build() adds more arcs.
   util::Permute(permutation, &arc_capacity);
 
   std::unique_ptr<GenericMaxFlow<Graph>> max_flow(new GenericMaxFlow<Graph>(
-      &graph, graph.num_nodes() - 2, graph.num_nodes() - 1));
+      graph.get(), graph->num_nodes() - 2, graph->num_nodes() - 1));
   SetUpNetworkData(arc_capacity, max_flow.get());
 
   const FlowQuantity flow = f(max_flow.get());
@@ -544,18 +547,20 @@ void PartialRandomFlow(std::optional<FlowQuantity> expected_flow,
   const typename Graph::NodeIndex kDegree = 10;
   const FlowQuantity kCapacityRange = 10000;
   const FlowQuantity kCapacityDelta = 1000;
-  Graph graph;
-  GeneratePartialRandomGraph(random, num_tails, num_heads, kDegree, &graph);
-  std::vector<int64_t> arc_capacity(graph.num_arcs());
-  GenerateRandomArcValuations(random, graph, kCapacityRange, &arc_capacity);
+  typename Graph::Builder graph_builder;
+  GeneratePartialRandomGraph<Graph>(random, num_tails, num_heads, kDegree,
+                                    graph_builder);
+  std::vector<int64_t> arc_capacity(graph_builder.num_arcs());
+  GenerateRandomArcValuations<Graph>(random, graph_builder.num_arcs(),
+                                     kCapacityRange, &arc_capacity);
 
   std::vector<typename Graph::ArcIndex> permutation;
-  graph.Build(&permutation);
-  arc_capacity.resize(graph.num_arcs(), 0);  // In case Build() adds more arcs.
+  const auto graph = std::move(graph_builder).Build(&permutation);
+  arc_capacity.resize(graph->num_arcs(), 0);  // In case Build() adds more arcs.
   util::Permute(permutation, &arc_capacity);
 
   std::unique_ptr<GenericMaxFlow<Graph>> max_flow(new GenericMaxFlow<Graph>(
-      &graph, graph.num_nodes() - 2, graph.num_nodes() - 1));
+      graph.get(), graph->num_nodes() - 2, graph->num_nodes() - 1));
   SetUpNetworkData(arc_capacity, max_flow.get());
 
   if (expected_flow != std::nullopt) {
@@ -592,18 +597,19 @@ void FullRandomFlow(std::optional<FlowQuantity> expected_flow,
 
   const FlowQuantity kCapacityRange = 10000;
   const FlowQuantity kCapacityDelta = 1000;
-  Graph graph;
-  GenerateCompleteGraphWithSourceAndSink(num_tails, num_heads, &graph);
-  std::vector<int64_t> arc_capacity(graph.num_arcs());
-  GenerateRandomArcValuations(random, graph, kCapacityRange, &arc_capacity);
-
+  typename Graph::Builder graph_builder;
+  GenerateCompleteGraphWithSourceAndSink<Graph>(num_tails, num_heads,
+                                                graph_builder);
+  std::vector<int64_t> arc_capacity(graph_builder.num_arcs());
+  GenerateRandomArcValuations<Graph>(random, graph_builder.num_arcs(),
+                                     kCapacityRange, &arc_capacity);
   std::vector<typename Graph::ArcIndex> permutation;
-  graph.Build(&permutation);
-  arc_capacity.resize(graph.num_arcs(), 0);  // In case Build() adds more arcs.
+  const auto graph = std::move(graph_builder).Build(&permutation);
+  arc_capacity.resize(graph->num_arcs(), 0);  // In case Build() adds more arcs.
   util::Permute(permutation, &arc_capacity);
 
   std::unique_ptr<GenericMaxFlow<Graph>> max_flow(new GenericMaxFlow<Graph>(
-      &graph, graph.num_nodes() - 2, graph.num_nodes() - 1));
+      graph.get(), graph->num_nodes() - 2, graph->num_nodes() - 1));
   SetUpNetworkData(arc_capacity, max_flow.get());
 
   if (expected_flow != std::nullopt) {
@@ -646,59 +652,6 @@ LP_AND_FLOW_TEST(PartialRandomAssignment, 100);
 LP_AND_FLOW_TEST(PartialRandomAssignment, 1000);
 LP_AND_FLOW_TEST(PartialRandomFlow, 400);
 LP_AND_FLOW_TEST(FullRandomFlow, 100);
-
-template <typename Graph>
-static void BM_FullRandomAssignment(benchmark::State& state) {
-  const int kSize = 3000;
-  for (auto _ : state) {
-    FullAssignment<Graph>(std::nullopt, SolveMaxFlow, kSize, kSize);
-  }
-  state.SetItemsProcessed(static_cast<int64_t>(state.max_iterations) * kSize);
-}
-
-template <typename Graph>
-static void BM_PartialRandomAssignment(benchmark::State& state) {
-  const int kSize = 10100;
-  for (auto _ : state) {
-    PartialRandomAssignment<Graph>(9512, SolveMaxFlow, kSize, kSize);
-  }
-  state.SetItemsProcessed(static_cast<int64_t>(state.max_iterations) * kSize);
-}
-
-template <typename Graph>
-static void BM_PartialRandomFlow(benchmark::State& state) {
-  const int kSize = 800;
-  for (auto _ : state) {
-    PartialRandomFlow<Graph>(3939172, SolveMaxFlow, kSize, kSize);
-  }
-  state.SetItemsProcessed(static_cast<int64_t>(state.max_iterations) * kSize);
-}
-
-template <typename Graph>
-static void BM_FullRandomFlow(benchmark::State& state) {
-  const int kSize = 800;
-  for (auto _ : state) {
-    FullRandomFlow<Graph>(3952652, SolveMaxFlow, kSize, kSize);
-  }
-  state.SetItemsProcessed(static_cast<int64_t>(state.max_iterations) * kSize);
-}
-
-// Note that these benchmark include the graph creation and generation...
-BENCHMARK_TEMPLATE(BM_FullRandomAssignment, util::FlowGraph<>);
-BENCHMARK_TEMPLATE(BM_FullRandomAssignment, util::ReverseArcListGraph<>);
-BENCHMARK_TEMPLATE(BM_FullRandomAssignment, util::ReverseArcStaticGraph<>);
-
-BENCHMARK_TEMPLATE(BM_PartialRandomFlow, util::FlowGraph<>);
-BENCHMARK_TEMPLATE(BM_PartialRandomFlow, util::ReverseArcListGraph<>);
-BENCHMARK_TEMPLATE(BM_PartialRandomFlow, util::ReverseArcStaticGraph<>);
-
-BENCHMARK_TEMPLATE(BM_FullRandomFlow, util::FlowGraph<>);
-BENCHMARK_TEMPLATE(BM_FullRandomFlow, util::ReverseArcListGraph<>);
-BENCHMARK_TEMPLATE(BM_FullRandomFlow, util::ReverseArcStaticGraph<>);
-
-BENCHMARK_TEMPLATE(BM_PartialRandomAssignment, util::FlowGraph<>);
-BENCHMARK_TEMPLATE(BM_PartialRandomAssignment, util::ReverseArcListGraph<>);
-BENCHMARK_TEMPLATE(BM_PartialRandomAssignment, util::ReverseArcStaticGraph<>);
 
 #undef LP_AND_FLOW_TEST
 

--- a/ortools/graph/hamiltonian_path.h
+++ b/ortools/graph/hamiltonian_path.h
@@ -97,6 +97,7 @@
 
 #include "absl/log/check.h"
 #include "absl/types/span.h"
+#include "ortools/base/types.h"
 #include "ortools/util/flat_matrix.h"
 #include "ortools/util/saturated_arithmetic.h"
 
@@ -551,16 +552,16 @@ class HamiltonianPathSolver {
     static int32_t Add(int32_t a, int32_t b) {
       const int64_t a64 = a;
       const int64_t b64 = b;
-      const int64_t min_int32 = std::numeric_limits<int32_t>::min();
-      const int64_t max_int32 = std::numeric_limits<int32_t>::max();
+      const int64_t min_int32 = kint32min;
+      const int64_t max_int32 = kint32max;
       return static_cast<int32_t>(
           std::max(min_int32, std::min(max_int32, a64 + b64)));
     }
     static int32_t Sub(int32_t a, int32_t b) {
       const int64_t a64 = a;
       const int64_t b64 = b;
-      const int64_t min_int32 = std::numeric_limits<int32_t>::min();
-      const int64_t max_int32 = std::numeric_limits<int32_t>::max();
+      const int64_t min_int32 = kint32min;
+      const int64_t max_int32 = kint32max;
       return static_cast<int32_t>(
           std::max(min_int32, std::min(max_int32, a64 - b64)));
     }

--- a/ortools/graph/k_shortest_paths_test.cc
+++ b/ortools/graph/k_shortest_paths_test.cc
@@ -14,6 +14,7 @@
 #include "ortools/graph/k_shortest_paths.h"
 
 #include <algorithm>
+#include <memory>
 #include <random>
 #include <set>
 #include <string>
@@ -26,7 +27,6 @@
 #include "absl/random/distributions.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
-#include "benchmark/benchmark.h"
 #include "gtest/gtest.h"
 #include "ortools/base/gmock.h"
 #include "ortools/graph/shortest_paths.h"
@@ -43,123 +43,124 @@ using util::Permute;
 using util::StaticGraph;
 
 TEST(KShortestPathsYenDeathTest, EmptyGraph) {
-  StaticGraph<> graph;
+  StaticGraph<>::Builder builder;
+  const auto graph = std::move(builder).Build(nullptr);
   std::vector<PathDistance> lengths;
 
-  EXPECT_DEATH(YenKShortestPaths(graph, lengths, /*source=*/0,
+  EXPECT_DEATH(YenKShortestPaths(*graph, lengths, /*source=*/0,
                                  /*destination=*/1, /*k=*/10),
                "graph.num_nodes\\(\\) > 0");
 }
 
 TEST(KShortestPathsYenDeathTest, NoArcGraph) {
-  StaticGraph<> graph;
-  graph.AddNode(1);
-  (void)graph.Build();
+  StaticGraph<>::Builder builder;
+  builder.AddNode(1);
+  const auto graph = std::move(builder).Build(nullptr);
   std::vector<PathDistance> lengths;
 
-  EXPECT_DEATH(YenKShortestPaths(graph, lengths, /*source=*/0,
+  EXPECT_DEATH(YenKShortestPaths(*graph, lengths, /*source=*/0,
                                  /*destination=*/1, /*k=*/10),
                "graph.num_arcs\\(\\) > 0");
 }
 
 TEST(KShortestPathsYenDeathTest, NonExistingSourceBecauseNegative) {
-  StaticGraph<> graph;
-  graph.AddNode(1);
-  graph.AddArc(0, 1);
-  (void)graph.Build();
+  StaticGraph<>::Builder builder;
+  builder.AddNode(1);
+  builder.AddArc(0, 1);
+  const auto graph = std::move(builder).Build(nullptr);
   std::vector<PathDistance> lengths{0};
 
-  EXPECT_DEATH(YenKShortestPaths(graph, lengths, /*source=*/-1,
+  EXPECT_DEATH(YenKShortestPaths(*graph, lengths, /*source=*/-1,
                                  /*destination=*/1, /*k=*/10),
                "source >= 0");
 }
 
 TEST(KShortestPathsYenDeathTest, NonExistingSourceBecauseTooLarge) {
-  StaticGraph<> graph;
-  graph.AddNode(1);
-  graph.AddArc(0, 1);
-  (void)graph.Build();
+  StaticGraph<>::Builder builder;
+  builder.AddNode(1);
+  builder.AddArc(0, 1);
+  const auto graph = std::move(builder).Build(nullptr);
   std::vector<PathDistance> lengths{0};
 
-  EXPECT_DEATH(YenKShortestPaths(graph, lengths, /*source=*/1'000,
+  EXPECT_DEATH(YenKShortestPaths(*graph, lengths, /*source=*/1'000,
                                  /*destination=*/1, /*k=*/10),
                "source < graph.num_nodes()");
 }
 
 TEST(KShortestPathsYenDeathTest, NonExistingDestinationBecauseNegative) {
-  StaticGraph<> graph;
-  graph.AddNode(1);
-  graph.AddArc(0, 1);
-  (void)graph.Build();
+  StaticGraph<>::Builder builder;
+  builder.AddNode(1);
+  builder.AddArc(0, 1);
+  const auto graph = std::move(builder).Build(nullptr);
   std::vector<PathDistance> lengths{0};
 
-  EXPECT_DEATH(YenKShortestPaths(graph, lengths, /*source=*/0,
+  EXPECT_DEATH(YenKShortestPaths(*graph, lengths, /*source=*/0,
                                  /*destination=*/-1, /*k=*/10),
                "destination >= 0");
 }
 
 TEST(KShortestPathsYenDeathTest, NonExistingDestinationBecauseTooLarge) {
-  StaticGraph<> graph;
-  graph.AddNode(1);
-  graph.AddArc(0, 1);
-  (void)graph.Build();
+  StaticGraph<>::Builder builder;
+  builder.AddNode(1);
+  builder.AddArc(0, 1);
+  const auto graph = std::move(builder).Build(nullptr);
   std::vector<PathDistance> lengths{0};
 
-  EXPECT_DEATH(YenKShortestPaths(graph, lengths, /*source=*/0,
+  EXPECT_DEATH(YenKShortestPaths(*graph, lengths, /*source=*/0,
                                  /*destination=*/1'000, /*k=*/10),
                "destination < graph.num_nodes()");
 }
 
 TEST(KShortestPathsYenDeathTest, KEqualsZero) {
-  StaticGraph<> graph;
-  graph.AddArc(0, 1);
-  graph.AddArc(1, 2);
-  (void)graph.Build();
+  StaticGraph<>::Builder builder;
+  builder.AddArc(0, 1);
+  builder.AddArc(1, 2);
+  const auto graph = std::move(builder).Build(nullptr);
   std::vector<PathDistance> lengths{1, 1};
 
-  EXPECT_DEATH(YenKShortestPaths(graph, lengths, /*source=*/0,
+  EXPECT_DEATH(YenKShortestPaths(*graph, lengths, /*source=*/0,
                                  /*destination=*/2, /*k=*/0),
                "k != 0");
 }
 
 TEST(KShortestPathsYenTest, ReducesToShortestPath) {
-  StaticGraph<> graph;
-  graph.AddArc(0, 1);
-  graph.AddArc(1, 2);
-  (void)graph.Build();
+  StaticGraph<>::Builder builder;
+  builder.AddArc(0, 1);
+  builder.AddArc(1, 2);
+  const auto graph = std::move(builder).Build(nullptr);
   std::vector<PathDistance> lengths{1, 1};
 
   const KShortestPaths<StaticGraph<>> paths =
-      YenKShortestPaths(graph, lengths, /*source=*/0,
+      YenKShortestPaths(*graph, lengths, /*source=*/0,
                         /*destination=*/2, /*k=*/1);
   EXPECT_THAT(paths.paths, ElementsAre(std::vector<int>{0, 1, 2}));
   EXPECT_THAT(paths.distances, ElementsAre(2));
 }
 
 TEST(KShortestPathsYenTest, OnlyHasOnePath) {
-  StaticGraph<> graph;
-  graph.AddArc(0, 1);
-  graph.AddArc(1, 2);
-  (void)graph.Build();
+  StaticGraph<>::Builder builder;
+  builder.AddArc(0, 1);
+  builder.AddArc(1, 2);
+  const auto graph = std::move(builder).Build(nullptr);
   std::vector<PathDistance> lengths{1, 1};
 
   const KShortestPaths<StaticGraph<>> paths =
-      YenKShortestPaths(graph, lengths, /*source=*/0,
+      YenKShortestPaths(*graph, lengths, /*source=*/0,
                         /*destination=*/2, /*k=*/10);
   EXPECT_THAT(paths.paths, ElementsAre(std::vector<int>{0, 1, 2}));
   EXPECT_THAT(paths.distances, ElementsAre(2));
 }
 
 TEST(KShortestPathsYenTest, HasTwoPaths) {
-  StaticGraph<> graph;
-  graph.AddArc(0, 1);
-  graph.AddArc(0, 2);
-  graph.AddArc(1, 2);
-  (void)graph.Build();
+  StaticGraph<>::Builder builder;
+  builder.AddArc(0, 1);
+  builder.AddArc(0, 2);
+  builder.AddArc(1, 2);
+  const auto graph = std::move(builder).Build(nullptr);
   std::vector<PathDistance> lengths{1, 30, 1};
 
   const KShortestPaths<StaticGraph<>> paths =
-      YenKShortestPaths(graph, lengths, /*source=*/0,
+      YenKShortestPaths(*graph, lengths, /*source=*/0,
                         /*destination=*/2, /*k=*/10);
   EXPECT_THAT(paths.paths,
               ElementsAre(std::vector<int>{0, 1, 2}, std::vector<int>{0, 2}));
@@ -167,17 +168,17 @@ TEST(KShortestPathsYenTest, HasTwoPaths) {
 }
 
 TEST(KShortestPathsYenTest, HasTwoPathsWithLongerPath) {
-  StaticGraph<> graph;
-  graph.AddArc(0, 1);
-  graph.AddArc(0, 4);
-  graph.AddArc(1, 2);
-  graph.AddArc(2, 3);
-  graph.AddArc(3, 4);
-  (void)graph.Build();
+  StaticGraph<>::Builder builder;
+  builder.AddArc(0, 1);
+  builder.AddArc(0, 4);
+  builder.AddArc(1, 2);
+  builder.AddArc(2, 3);
+  builder.AddArc(3, 4);
+  const auto graph = std::move(builder).Build(nullptr);
   std::vector<PathDistance> lengths{1, 30, 1, 1, 1};
 
   const KShortestPaths<StaticGraph<>> paths =
-      YenKShortestPaths(graph, lengths, /*source=*/0,
+      YenKShortestPaths(*graph, lengths, /*source=*/0,
                         /*destination=*/4, /*k=*/10);
   EXPECT_THAT(paths.paths, ElementsAre(std::vector<int>{0, 1, 2, 3, 4},
                                        std::vector<int>{0, 4}));
@@ -185,18 +186,18 @@ TEST(KShortestPathsYenTest, HasTwoPathsWithLongerPath) {
 }
 
 TEST(KShortestPathsYenTest, ReturnsTheRightNumberOfPaths) {
-  StaticGraph<> graph;
-  graph.AddArc(0, 1);
-  graph.AddArc(0, 2);
-  graph.AddArc(0, 3);
-  graph.AddArc(1, 2);
-  graph.AddArc(3, 2);
+  StaticGraph<>::Builder builder;
+  builder.AddArc(0, 1);
+  builder.AddArc(0, 2);
+  builder.AddArc(0, 3);
+  builder.AddArc(1, 2);
+  builder.AddArc(3, 2);
 
-  (void)graph.Build();
+  const auto graph = std::move(builder).Build(nullptr);
   std::vector<PathDistance> lengths{1, 1, 1, 1, 1};
 
   const KShortestPaths<StaticGraph<>> paths =
-      YenKShortestPaths(graph, lengths, /*source=*/0,
+      YenKShortestPaths(*graph, lengths, /*source=*/0,
                         /*destination=*/2, /*k=*/2);
   EXPECT_THAT(paths.paths,
               ElementsAre(std::vector<int>{0, 2}, std::vector<int>{0, 1, 2}));
@@ -219,7 +220,7 @@ TEST(KShortestPathsYenTest, ShortestPathSelectedFromCandidates) {
   //    |  /\  |  /\  |
   //    | /  \ | /  \ |
   //    4 ---- 5 ---- 8
-  StaticGraph<> graph;
+  StaticGraph<>::Builder builder;
 
   using TailHeadCost = std::tuple<int, int, int>;
   std::vector<TailHeadCost> arcs = {
@@ -237,16 +238,16 @@ TEST(KShortestPathsYenTest, ShortestPathSelectedFromCandidates) {
   std::vector<PathDistance> lengths;
   lengths.reserve(arcs.size());
   for (const auto& [tail, head, cost] : arcs) {
-    graph.AddArc(tail, head);
+    builder.AddArc(tail, head);
     lengths.push_back(cost);
   }
 
   std::vector<int> permutation;
-  graph.Build(&permutation);
+  const auto graph = std::move(builder).Build(&permutation);
   Permute(permutation, &lengths);
 
   const KShortestPaths<StaticGraph<>> paths =
-      YenKShortestPaths(graph, lengths, /*source=*/0,
+      YenKShortestPaths(*graph, lengths, /*source=*/0,
                         /*destination=*/6, /*k=*/14);
 
   EXPECT_THAT(paths.distances,
@@ -277,8 +278,9 @@ namespace internal {
 
 template <typename Graph, typename NodeIndexType, typename ArcIndexType,
           typename URBG, bool IsDirected>
-Graph GenerateUniformGraph(URBG&& urbg, const NodeIndexType num_nodes,
-                           const ArcIndexType num_edges) {
+std::unique_ptr<Graph> GenerateUniformGraph(URBG&& urbg,
+                                            const NodeIndexType num_nodes,
+                                            const ArcIndexType num_edges) {
   // TODO(user): make these utility functions so they can be reused.
   const auto pick_one_node = [&urbg, num_nodes]() -> NodeIndexType {
     const NodeIndexType node = absl::Uniform(urbg, 0, num_nodes);
@@ -306,8 +308,8 @@ Graph GenerateUniformGraph(URBG&& urbg, const NodeIndexType num_nodes,
   // arcs, whichever is lower. The set is useful to ensure the graph does not
   // contain the same arc more than once (the result would be a multigraph).
   // TODO(user): this is an awful way to generate a complete graph.
-  StaticGraph<> graph;
-  graph.AddNode(num_nodes - 1);
+  StaticGraph<>::Builder builder;
+  builder.AddNode(num_nodes - 1);
 
   std::set<std::pair<NodeIndexType, NodeIndexType>> arcs;
   for (ArcIndexType i = 0; i < std::min(num_edges, max_num_arcs); ++i) {
@@ -317,19 +319,17 @@ Graph GenerateUniformGraph(URBG&& urbg, const NodeIndexType num_nodes,
     if (IsDirected && (arcs.find({dst, src}) != arcs.end())) continue;
 
     arcs.insert({src, dst});
-    graph.AddArc(src, dst);
+    builder.AddArc(src, dst);
 
     if (IsDirected) {
       arcs.insert({dst, src});
-      graph.AddArc(dst, src);
+      builder.AddArc(dst, src);
     }
   }
 
   // No need to keep the permutation when building, as there are no associated
   // attributes such as lengths in this function.
-  graph.Build(nullptr);
-
-  return graph;
+  return std::move(builder).Build(nullptr);
 }
 
 }  // namespace internal
@@ -346,8 +346,9 @@ Graph GenerateUniformGraph(URBG&& urbg, const NodeIndexType num_nodes,
 template <typename NodeIndexType, typename ArcIndexType,
           typename Graph = StaticGraph<NodeIndexType, ArcIndexType>,
           typename URBG>
-Graph GenerateUniformGraph(URBG&& urbg, const NodeIndexType num_nodes,
-                           const ArcIndexType num_edges) {
+std::unique_ptr<Graph> GenerateUniformGraph(URBG&& urbg,
+                                            const NodeIndexType num_nodes,
+                                            const ArcIndexType num_edges) {
   return internal::GenerateUniformGraph<Graph, NodeIndexType, ArcIndexType,
                                         URBG, /*IsDirected=*/false>(
       urbg, num_nodes, num_edges);
@@ -355,8 +356,8 @@ Graph GenerateUniformGraph(URBG&& urbg, const NodeIndexType num_nodes,
 template <typename NodeIndexType, typename ArcIndexType,
           typename Graph = StaticGraph<NodeIndexType, ArcIndexType>,
           typename URBG>
-Graph GenerateUniformDirectedGraph(URBG&& urbg, const NodeIndexType num_nodes,
-                                   const ArcIndexType num_arcs) {
+std::unique_ptr<Graph> GenerateUniformDirectedGraph(
+    URBG&& urbg, const NodeIndexType num_nodes, const ArcIndexType num_arcs) {
   return internal::GenerateUniformGraph<Graph, NodeIndexType, ArcIndexType,
                                         URBG, /*IsDirected=*/true>(
       urbg, num_nodes, num_arcs);
@@ -396,10 +397,10 @@ TEST(KShortestPathsYenTest, RandomTest) {
   for (int graph_iter = 0; graph_iter < kNumGraphs; ++graph_iter) {
     (void)graph_iter;
 
-    StaticGraph<> graph =
+    const auto graph =
         GenerateUniformDirectedGraph(random, kNumNodes, kNumArcs);
     std::vector<PathDistance> lengths;
-    for (int i = 0; i < graph.num_arcs(); ++i) {
+    for (int i = 0; i < graph->num_arcs(); ++i) {
       lengths.push_back(absl::Uniform(random, kMinLength, kMaxLength));
     }
 
@@ -424,8 +425,8 @@ TEST(KShortestPathsYenTest, RandomTest) {
         tentative_paths.erase(tentative_paths.begin());
 
         const int last_node = partial_path.back();
-        for (const int next_arc : graph.OutgoingArcs(last_node)) {
-          const int next_node = graph.Head(next_arc);
+        for (const int next_arc : graph->OutgoingArcs(last_node)) {
+          const int next_node = graph->Head(next_arc);
           ASSERT_NE(last_node, next_node);
 
           if (absl::c_find(partial_path, next_node) != partial_path.end()) {
@@ -454,12 +455,12 @@ TEST(KShortestPathsYenTest, RandomTest) {
 
       // Use the algorithm-under-test to generate as many paths as possible.
       const KShortestPaths yen_paths =
-          YenKShortestPaths(graph, lengths, src, dst,
+          YenKShortestPaths(*graph, lengths, src, dst,
                             /*k=*/brute_force_paths.size());
 
       // The two sets of paths must correspond.
       EXPECT_THAT(brute_force_paths, UnorderedElementsAreArray(yen_paths.paths))
-          << "[" << util::GraphToString(graph, util::PRINT_GRAPH_ARCS)
+          << "[" << util::GraphToString(*graph, util::PRINT_GRAPH_ARCS)
           << "] Brute-force paths: ["
           << absl::StrJoin(brute_force_paths, ", ", format_path)
           << "] Yen paths: ["
@@ -467,49 +468,6 @@ TEST(KShortestPathsYenTest, RandomTest) {
     }
   }
 }
-
-void BM_Yen(benchmark::State& state) {
-  const int num_nodes = state.range(0);
-  // Use half the maximum number of arcs, so that the graph is a bit sparse.
-  const int num_arcs = num_nodes * (num_nodes - 1) / 4;
-  // TODO(user): when supported, also benchmark negative weights
-  // (separately?).
-  constexpr int kMinLength = 0;
-  constexpr int kMaxLength = 1'000;
-
-  std::mt19937 random(12345);
-  const auto pick_one_node = [&random, num_nodes]() -> int {
-    int node = absl::Uniform(random, 0, num_nodes);
-    CHECK_GE(node, 0);
-    CHECK_LT(node, num_nodes);
-    return node;
-  };
-  const auto pick_two_distinct_nodes =
-      [&pick_one_node]() -> std::pair<int, int> {
-    int src = pick_one_node();
-    int dst;
-    do {
-      dst = pick_one_node();
-    } while (src == dst);
-    CHECK_NE(src, dst);
-    return {src, dst};
-  };
-
-  StaticGraph<> graph =
-      GenerateUniformDirectedGraph(random, num_nodes, num_arcs);
-  std::vector<PathDistance> lengths;
-  for (int i = 0; i < graph.num_arcs(); ++i) {
-    lengths.push_back(absl::Uniform(random, kMinLength, kMaxLength));
-  }
-
-  for (auto unused : state) {
-    int src, dst;
-    std::tie(src, dst) = pick_two_distinct_nodes();
-    YenKShortestPaths(graph, lengths, src, dst, /*k=*/10);
-  }
-}
-
-BENCHMARK(BM_Yen)->Range(10, 1'000);
 
 }  // namespace
 }  // namespace operations_research

--- a/ortools/graph/linear_assignment.h
+++ b/ortools/graph/linear_assignment.h
@@ -40,26 +40,22 @@
 //   const int num_nodes = ...
 //   const int num_arcs = ...
 //   const int num_left_nodes = num_nodes / 2;
-//   Graph graph(num_nodes, num_arcs);
+//   Graph::Builder builder(num_nodes, num_arcs);
 //   std::vector<operations_research::CostValue> arc_costs(num_arcs);
 //   for (int arc = 0; arc < num_arcs; ++arc) {
 //     const int arc_tail = ...   // must be in [0, num_left_nodes)
 //     const int arc_head = ...   // must be in [num_left_nodes, num_nodes)
-//     graph.AddArc(arc_tail, arc_head);
+//     builder.AddArc(arc_tail, arc_head);
 //     arc_costs[arc] = ...
 //   }
 //
 //   // Build the StaticGraph. You can skip this step by using a ListGraph<>
 //   // instead, but then the ComputeAssignment() below will be slower. It is
 //   // okay if your graph is small and performance is not critical though.
-//   {
-//     std::vector<Graph::ArcIndex> arc_permutation;
-//     graph.Build(&arc_permutation);
-//     util::Permute(arc_permutation, &arc_costs);
-//   }
+//   const auto graph = std::move(builder).BuildAndPermute(&arc_costs);
 //
 //   // Construct the LinearSumAssignment.
-//   ::operations_research::LinearSumAssignment<Graph> a(graph, num_left_nodes);
+//   operations_research::LinearSumAssignment<Graph> a(*graph, num_left_nodes);
 //   for (int arc = 0; arc < num_arcs; ++arc) {
 //      // You can also replace 'arc_costs[arc]' by something like
 //      //   ComputeArcCost(permutation.empty() ? arc : permutation[arc])

--- a/ortools/graph/linear_assignment_test.cc
+++ b/ortools/graph/linear_assignment_test.cc
@@ -16,15 +16,12 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <random>
+#include <utility>
 #include <vector>
 
-#include "absl/flags/declare.h"
 #include "absl/flags/flag.h"
 #include "absl/log/check.h"
-#include "absl/random/distributions.h"
 #include "absl/types/span.h"
-#include "benchmark/benchmark.h"
 #include "gtest/gtest.h"
 #include "ortools/base/gmock.h"
 #include "ortools/graph_base/graph.h"
@@ -44,7 +41,7 @@ struct AssignmentProblemSetup {
   // The usual constructor, for normal tests where the graph is balanced.
   AssignmentProblemSetup(NodeIndex num_left_nodes, ArcIndex num_arcs)
       : num_left_nodes(num_left_nodes),
-        graph(2 * num_left_nodes, num_arcs),
+        builder(2 * num_left_nodes, num_arcs),
         arc_costs(num_arcs) {}
 
   // A constructor with separate specification of the numbers of left and right
@@ -53,7 +50,7 @@ struct AssignmentProblemSetup {
   AssignmentProblemSetup(NodeIndex num_left_nodes, NodeIndex num_right_nodes,
                          ArcIndex num_arcs)
       : num_left_nodes(num_left_nodes),
-        graph(num_left_nodes + num_right_nodes, num_arcs),
+        builder(num_left_nodes + num_right_nodes, num_arcs),
         arc_costs(num_arcs) {}
 
   // This type is neither copyable nor movable.
@@ -61,24 +58,25 @@ struct AssignmentProblemSetup {
   AssignmentProblemSetup& operator=(const AssignmentProblemSetup&) = delete;
 
   ArcIndex CreateArcWithCost(NodeIndex tail, NodeIndex head, CostValue cost) {
-    const ArcIndex arc = graph.AddArc(tail, head);
+    const ArcIndex arc = builder.AddArc(tail, head);
     arc_costs[arc] = cost;
     return arc;
   }
 
   void Finalize() {
-    CHECK_EQ(graph.num_arcs(), arc_costs.size());
-    graph.Build(&arc_permutation);
+    CHECK_EQ(builder.num_arcs(), arc_costs.size());
+    graph = std::move(builder).Build(&arc_permutation);
     util::Permute(arc_permutation, &arc_costs);
     assignment = std::make_unique<LinearSumAssignment<GraphType, CostValue>>(
-        graph, num_left_nodes);
+        *graph, num_left_nodes);
     for (int arc = 0; arc < arc_costs.size(); ++arc) {
       assignment->SetArcCost(arc, arc_costs[arc]);
     }
   }
 
   const int num_left_nodes;
-  GraphType graph;
+  typename GraphType::Builder builder;
+  std::unique_ptr<const GraphType> graph;
   std::vector<CostValue> arc_costs;
   std::unique_ptr<LinearSumAssignment<GraphType, CostValue>> assignment;
   std::vector<ArcIndex> arc_permutation;
@@ -352,7 +350,7 @@ TYPED_TEST(LinearSumAssignmentTestWithGraphBuilder, InfeasibleProblems) {
 }
 
 // A helper function template for setting up assignment problems based on
-// dynamic graph types without a need to `Build()`.
+// dynamic graph types without a need to build.
 template <typename GraphType>
 static typename GraphType::ArcIndex CreateArcWithCost(
     typename GraphType::NodeIndex tail, typename GraphType::NodeIndex head,
@@ -465,106 +463,6 @@ INSTANTIATE_TEST_CASE_P(MacholWienProblems, MacholWien,
                                            ::testing::Bool()));
 #endif  // LARGE
 
-// Same as ConstructRandomAssignment, but for the new API.
-template <typename GraphType>
-void ConstructRandomAssignmentForNewGraphApi(
-    const int left_nodes, const int average_degree, const int cost_limit,
-    std::unique_ptr<GraphType>* graph,
-    std::unique_ptr<LinearSumAssignment<GraphType, int64_t>>* assignment) {
-  const int kNodes = 2 * left_nodes;
-  const int kArcs = left_nodes * average_degree;
-  const int kRandomSeed = 0;
-  std::mt19937 randomizer(kRandomSeed);
-  std::vector<int64_t> arc_costs;
-  arc_costs.reserve(kArcs);
-  graph->reset(new GraphType(kNodes, kArcs));
-  for (int i = 0; i < kArcs; ++i) {
-    const int left = absl::Uniform(randomizer, 0, left_nodes);
-    const int right = left_nodes + absl::Uniform(randomizer, 0, left_nodes);
-    const int64_t cost = absl::Uniform(randomizer, 0, cost_limit);
-    graph->get()->AddArc(left, right);
-    arc_costs.push_back(cost);
-  }
-
-  // Finalize the graph.
-  std::vector<typename GraphType::ArcIndex> permutation;
-  graph->get()->Build(&permutation);
-  util::Permute(permutation, &arc_costs);
-
-  // Create the assignment.
-  assignment->reset(
-      new LinearSumAssignment<GraphType, int64_t>(*(graph->get()), left_nodes));
-  for (int arc = 0; arc < kArcs; ++arc) {
-    assignment->get()->SetArcCost(arc, arc_costs[arc]);
-  }
-}
-
-template <typename GraphType>
-void BM_ConstructRandomAssignmentProblemWithNewGraphApi(
-    benchmark::State& state) {
-  const int kLeftNodes = 10000;
-  const int kAverageDegree = 250;
-  const int64_t kCostLimit = 1000000;
-  for (auto _ : state) {
-    std::unique_ptr<GraphType> graph;
-    std::unique_ptr<LinearSumAssignment<GraphType, int64_t>> assignment;
-    ConstructRandomAssignmentForNewGraphApi<GraphType>(
-        kLeftNodes, kAverageDegree, kCostLimit, &graph, &assignment);
-  }
-  state.SetItemsProcessed(static_cast<int64_t>(state.max_iterations) *
-                          kLeftNodes * kAverageDegree);
-}
-
-BENCHMARK_TEMPLATE(BM_ConstructRandomAssignmentProblemWithNewGraphApi,
-                   util::ListGraph<>);
-BENCHMARK_TEMPLATE(BM_ConstructRandomAssignmentProblemWithNewGraphApi,
-                   util::StaticGraph<>);
-
-template <typename GraphType>
-void BM_SolveRandomAssignmentProblemWithNewGraphApi(benchmark::State& state) {
-  const int kLeftNodes = 10000;
-  const int kAverageDegree = 250;
-  const int64_t kCostLimit = 1000000;
-  std::unique_ptr<GraphType> graph;
-  std::unique_ptr<LinearSumAssignment<GraphType, int64_t>> assignment;
-  ConstructRandomAssignmentForNewGraphApi<GraphType>(
-      kLeftNodes, kAverageDegree, kCostLimit, &graph, &assignment);
-  for (auto _ : state) {
-    assignment->ComputeAssignment();
-    EXPECT_EQ(65415697, assignment->GetCost());
-  }
-  state.SetItemsProcessed(static_cast<int64_t>(state.max_iterations) *
-                          kLeftNodes * kAverageDegree);
-}
-
-BENCHMARK_TEMPLATE(BM_SolveRandomAssignmentProblemWithNewGraphApi,
-                   util::ListGraph<>);
-BENCHMARK_TEMPLATE(BM_SolveRandomAssignmentProblemWithNewGraphApi,
-                   util::StaticGraph<>);
-
-template <typename GraphType>
-void BM_ConstructAndSolveRandomAssignmentProblemWithNewGraphApi(
-    benchmark::State& state) {
-  const int kLeftNodes = 10000;
-  const int kAverageDegree = 250;
-  const int64_t kCostLimit = 1000000;
-  for (auto _ : state) {
-    std::unique_ptr<GraphType> graph;
-    std::unique_ptr<LinearSumAssignment<GraphType, int64_t>> assignment;
-    ConstructRandomAssignmentForNewGraphApi<GraphType>(
-        kLeftNodes, kAverageDegree, kCostLimit, &graph, &assignment);
-    assignment->ComputeAssignment();
-    EXPECT_EQ(65415697, assignment->GetCost());
-  }
-  state.SetItemsProcessed(static_cast<int64_t>(state.max_iterations) *
-                          kLeftNodes * kAverageDegree);
-}
-
-BENCHMARK_TEMPLATE(BM_ConstructAndSolveRandomAssignmentProblemWithNewGraphApi,
-                   util::ListGraph<>);
-BENCHMARK_TEMPLATE(BM_ConstructAndSolveRandomAssignmentProblemWithNewGraphApi,
-                   util::StaticGraph<>);
-
 // The order of initializing the edges in the graph made the difference between
 // finding an optimal assignment and erroneously failing to finding one because
 // an unlucky order of edges could cause price reductions greater than the slack
@@ -582,22 +480,18 @@ class ReorderedGraphTest : public testing::Test {
   void TestMe(const size_t left_nodes, absl::Span<const Edge> ordered_edges) {
     std::vector<int64_t> edge_costs;
     typedef util::StaticGraph<size_t, size_t> GraphType;
-    GraphType graph(2 * left_nodes, ordered_edges.size());
+    GraphType::Builder builder(2 * left_nodes, ordered_edges.size());
 
     for (const auto& edge : ordered_edges) {
-      graph.AddArc(/* tail= */ edge.from_node,
-                   /* head= */ edge.to_node);
+      builder.AddArc(/* tail= */ edge.from_node,
+                     /* head= */ edge.to_node);
       edge_costs.push_back(edge.cost);
     }
-    ASSERT_THAT(edge_costs.size(), Eq(graph.num_arcs()));
+    ASSERT_THAT(edge_costs.size(), Eq(builder.num_arcs()));
 
-    {
-      std::vector<typename GraphType::ArcIndex> arc_permutation;
-      graph.Build(&arc_permutation);
-      util::Permute(arc_permutation, &edge_costs);
-    }
+    const auto graph = std::move(builder).BuildAndPermute(edge_costs);
 
-    LinearSumAssignment<GraphType> assignment(graph, left_nodes);
+    LinearSumAssignment<GraphType> assignment(*graph, left_nodes);
     for (size_t arc = 0; arc != edge_costs.size(); ++arc) {
       assignment.SetArcCost(arc, edge_costs[arc]);
     }

--- a/ortools/graph/max_flow.cc
+++ b/ortools/graph/max_flow.cc
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "ortools/graph/generic_max_flow.h"
@@ -61,7 +62,7 @@ SimpleMaxFlow::Status SimpleMaxFlow::Solve(NodeIndex source, NodeIndex sink) {
   const ArcIndex num_arcs = arc_capacity_.size();
   arc_flow_.assign(num_arcs, 0);
   underlying_max_flow_.reset();
-  underlying_graph_.reset();
+  underlying_graph_ = nullptr;
   optimal_flow_ = 0;
   if (source == sink || source < 0 || sink < 0) {
     return BAD_INPUT;
@@ -69,13 +70,13 @@ SimpleMaxFlow::Status SimpleMaxFlow::Solve(NodeIndex source, NodeIndex sink) {
   if (source >= num_nodes_ || sink >= num_nodes_) {
     return OPTIMAL;
   }
-  underlying_graph_ = std::make_unique<Graph>(num_nodes_, num_arcs);
-  underlying_graph_->AddNode(source);
-  underlying_graph_->AddNode(sink);
+  Graph::Builder builder(num_nodes_, num_arcs);
+  builder.AddNode(source);
+  builder.AddNode(sink);
   for (int arc = 0; arc < num_arcs; ++arc) {
-    underlying_graph_->AddArc(arc_tail_[arc], arc_head_[arc]);
+    builder.AddArc(arc_tail_[arc], arc_head_[arc]);
   }
-  underlying_graph_->Build(&arc_permutation_);
+  underlying_graph_ = std::move(builder).Build(&arc_permutation_);
   underlying_max_flow_ = std::make_unique<GenericMaxFlow<Graph>>(
       underlying_graph_.get(), source, sink);
   for (ArcIndex arc = 0; arc < num_arcs; ++arc) {

--- a/ortools/graph/min_cost_flow.cc
+++ b/ortools/graph/min_cost_flow.cc
@@ -20,6 +20,7 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/base/attributes.h"
@@ -1016,6 +1017,29 @@ template class GenericMinCostFlow<
     /*ArcFlowType=*/int16_t,
     /*ArcScaledCostType=*/int32_t>;
 
+absl::string_view StatusName(MinCostFlowBase::Status status) {
+  switch (status) {
+    case MinCostFlowBase::NOT_SOLVED:
+      return "NOT_SOLVED";
+    case MinCostFlowBase::OPTIMAL:
+      return "OPTIMAL";
+    case MinCostFlowBase::FEASIBLE:
+      return "FEASIBLE";
+    case MinCostFlowBase::INFEASIBLE:
+      return "INFEASIBLE";
+    case MinCostFlowBase::UNBALANCED:
+      return "UNBALANCED";
+    case MinCostFlowBase::BAD_RESULT:
+      return "BAD_RESULT";
+    case MinCostFlowBase::BAD_COST_RANGE:
+      return "BAD_COST_RANGE";
+    case MinCostFlowBase::BAD_CAPACITY_RANGE:
+      return "BAD_CAPACITY_RANGE";
+  }
+  LOG(DFATAL) << "Unknown MinCostFlow status: " << static_cast<int>(status);
+  return "UNKNOWN_STATUS";
+}
+
 SimpleMinCostFlow::SimpleMinCostFlow(NodeIndex reserve_num_nodes,
                                      ArcIndex reserve_num_arcs) {
   if (reserve_num_nodes > 0) {
@@ -1097,23 +1121,23 @@ SimpleMinCostFlow::Status SimpleMinCostFlow::SolveWithPossibleAdjustment(
   const NodeIndex sink = num_nodes + 1;
   const NodeIndex augmented_num_nodes = num_nodes + 2;
 
-  Graph graph(augmented_num_nodes, augmented_num_arcs);
+  Graph::Builder builder(augmented_num_nodes, augmented_num_arcs);
   for (ArcIndex arc = 0; arc < num_arcs; ++arc) {
-    graph.AddArc(arc_tail_[arc], arc_head_[arc]);
+    builder.AddArc(arc_tail_[arc], arc_head_[arc]);
   }
 
   for (NodeIndex node = 0; node < num_nodes; ++node) {
     if (node_supply_[node] > 0) {
-      graph.AddArc(source, node);
+      builder.AddArc(source, node);
     } else if (node_supply_[node] < 0) {
-      graph.AddArc(node, sink);
+      builder.AddArc(node, sink);
     }
   }
 
-  graph.Build(&arc_permutation_);
+  const auto graph = std::move(builder).Build(&arc_permutation_);
 
   {
-    GenericMaxFlow<Graph> max_flow(&graph, source, sink);
+    GenericMaxFlow<Graph> max_flow(graph.get(), source, sink);
     ArcIndex arc;
     for (arc = 0; arc < num_arcs; ++arc) {
       max_flow.SetArcCapacity(PermutedArc(arc), arc_capacity_[arc]);
@@ -1145,7 +1169,7 @@ SimpleMinCostFlow::Status SimpleMinCostFlow::SolveWithPossibleAdjustment(
     return INFEASIBLE;
   }
 
-  GenericMinCostFlow<Graph> min_cost_flow(&graph);
+  GenericMinCostFlow<Graph> min_cost_flow(graph.get());
   ArcIndex arc;
   for (arc = 0; arc < num_arcs; ++arc) {
     ArcIndex permuted_arc = PermutedArc(arc);

--- a/ortools/graph/min_cost_flow.h
+++ b/ortools/graph/min_cost_flow.h
@@ -247,6 +247,9 @@ class MinCostFlowBase {
   };
 };
 
+// Returns a string representation of the Status enum.
+absl::string_view StatusName(MinCostFlowBase::Status status);
+
 // A simple and efficient min-cost flow interface. This is as fast as
 // GenericMinCostFlow<ReverseArcStaticGraph>, which is the fastest, but is uses
 // more memory in order to hide the somewhat involved construction of the

--- a/ortools/graph/min_cost_flow_test.cc
+++ b/ortools/graph/min_cost_flow_test.cc
@@ -110,15 +110,15 @@ void GenericMinCostFlowTester(
     const FlowQuantity* capacity, const CostValue expected_flow_cost,
     const FlowQuantity* expected_flow,
     const typename GenericMinCostFlow<Graph>::Status expected_status) {
-  Graph graph(num_nodes, num_arcs);
+  typename Graph::Builder builder(num_nodes, num_arcs);
   for (int arc = 0; arc < num_arcs; ++arc) {
-    graph.AddArc(tail[arc], head[arc]);
+    builder.AddArc(tail[arc], head[arc]);
   }
   std::vector<typename Graph::ArcIndex> permutation;
-  graph.Build(&permutation);
+  const auto graph = std::move(builder).Build(&permutation);
   EXPECT_TRUE(permutation.empty());
 
-  GenericMinCostFlow<Graph> min_cost_flow(&graph);
+  GenericMinCostFlow<Graph> min_cost_flow(graph.get());
   for (int arc = 0; arc < num_arcs; ++arc) {
     min_cost_flow.SetArcUnitCost(arc, cost[arc]);
     min_cost_flow.SetArcCapacity(arc, capacity[arc]);
@@ -245,19 +245,20 @@ TYPED_TEST(GenericMinCostFlowTest, Small4x4Matrix) {
                                                      {125, 95, 90, 105},
                                                      {45, 110, 95, 115}};
   const CostValue kExpectedCost = 275;
-  TypeParam graph(kNumSources + kNumTargets, kNumSources * kNumTargets);
+  typename TypeParam::Builder builder(kNumSources + kNumTargets,
+                                      kNumSources * kNumTargets);
   for (typename TypeParam::NodeIndex source = 0; source < kNumSources;
        ++source) {
     for (typename TypeParam::NodeIndex target = 0; target < kNumTargets;
          ++target) {
-      graph.AddArc(source, kNumSources + target);
+      builder.AddArc(source, kNumSources + target);
     }
   }
   std::vector<typename TypeParam::ArcIndex> permutation;
-  graph.Build(&permutation);
+  const auto graph = std::move(builder).Build(&permutation);
   EXPECT_TRUE(permutation.empty());
 
-  GenericMinCostFlow<TypeParam> min_cost_flow(&graph);
+  GenericMinCostFlow<TypeParam> min_cost_flow(graph.get());
   int arc = 0;
   for (typename TypeParam::NodeIndex source = 0; source < kNumSources;
        ++source) {
@@ -339,6 +340,22 @@ TEST(GenericMinCostFlowTest, SelfLoop) {
   EXPECT_EQ(mcf.GetOptimalCost(), kMaxCost);  // Indicate overflow.
   EXPECT_EQ(mcf.Flow(arc), kMaxCost - 1);
 }
+
+#define OR_TEST_MIN_COST_FLOW_STATUS_STR(status) \
+  EXPECT_EQ(StatusName(MinCostFlowBase::status), #status)
+
+TEST(StatusNameTest, ReturnsCorrectName) {
+  OR_TEST_MIN_COST_FLOW_STATUS_STR(NOT_SOLVED);
+  OR_TEST_MIN_COST_FLOW_STATUS_STR(OPTIMAL);
+  OR_TEST_MIN_COST_FLOW_STATUS_STR(FEASIBLE);
+  OR_TEST_MIN_COST_FLOW_STATUS_STR(INFEASIBLE);
+  OR_TEST_MIN_COST_FLOW_STATUS_STR(UNBALANCED);
+  OR_TEST_MIN_COST_FLOW_STATUS_STR(BAD_RESULT);
+  OR_TEST_MIN_COST_FLOW_STATUS_STR(BAD_COST_RANGE);
+  OR_TEST_MIN_COST_FLOW_STATUS_STR(BAD_CAPACITY_RANGE);
+}
+
+#undef OR_TEST_MIN_COST_FLOW_STATUS_STR
 
 TEST(SimpleMinCostFlowTest, Empty) {
   SimpleMinCostFlow min_cost_flow;
@@ -499,42 +516,46 @@ TEST(SimpleMinCostFlowTest, OverflowCostBound) {
 }
 
 template <typename Graph>
-void GenerateCompleteGraph(const typename Graph::NodeIndex num_sources,
-                           const typename Graph::NodeIndex num_targets,
-                           Graph* graph) {
+typename Graph::Builder GetCompleteGraphBuilder(
+    const typename Graph::NodeIndex num_sources,
+    const typename Graph::NodeIndex num_targets) {
   const typename Graph::NodeIndex num_nodes = num_sources + num_targets;
   const typename Graph::ArcIndex num_arcs = num_sources * num_targets;
-  graph->Reserve(num_nodes, num_arcs);
+  typename Graph::Builder builder;
+  builder.Reserve(num_nodes, num_arcs);
   for (typename Graph::NodeIndex source = 0; source < num_sources; ++source) {
     for (typename Graph::NodeIndex target = 0; target < num_targets; ++target) {
-      graph->AddArc(source, target + num_sources);
+      builder.AddArc(source, target + num_sources);
     }
   }
+  return builder;
 }
 
 template <typename Graph>
-void GeneratePartialRandomGraph(const typename Graph::NodeIndex num_sources,
-                                const typename Graph::NodeIndex num_targets,
-                                const typename Graph::NodeIndex degree,
-                                Graph* graph) {
+typename Graph::Builder GetPartialRandomGraphBuilder(
+    const typename Graph::NodeIndex num_sources,
+    const typename Graph::NodeIndex num_targets,
+    const typename Graph::NodeIndex degree) {
   const typename Graph::NodeIndex num_nodes = num_sources + num_targets;
   const typename Graph::ArcIndex num_arcs = num_sources * degree;
-  graph->Reserve(num_nodes, num_arcs);
+  typename Graph::Builder builder;
+  builder.Reserve(num_nodes, num_arcs);
   std::mt19937 randomizer(12345);
   for (typename Graph::NodeIndex source = 0; source < num_sources; ++source) {
     // For each source, we create degree - 1 random arcs.
     for (typename Graph::NodeIndex d = 0; d < degree - 1; ++d) {
       typename Graph::NodeIndex target =
           absl::Uniform(randomizer, 0, num_targets);
-      graph->AddArc(source, target + num_sources);
+      builder.AddArc(source, target + num_sources);
     }
   }
   // Make sure that each target has at least one corresponding source.
   for (typename Graph::NodeIndex target = 0; target < num_targets; ++target) {
     typename Graph::NodeIndex source =
         absl::Uniform(randomizer, 0, num_sources);
-    graph->AddArc(source, target + num_sources);
+    builder.AddArc(source, target + num_sources);
   }
+  return builder;
 }
 
 template <typename Graph>
@@ -663,19 +684,18 @@ void FullRandomAssignment(typename MinCostFlowSolver<Graph>::Solver f,
                           CostValue expected_cost1,
                           CostValue /*expected_cost2*/) {
   const CostValue kCostRange = 1000;
-  Graph graph;
-  GenerateCompleteGraph(num_sources, num_targets, &graph);
   std::vector<typename Graph::ArcIndex> permutation;
-  graph.Build(&permutation);
+  const auto graph = GetCompleteGraphBuilder<Graph>(num_sources, num_targets)
+                         .Build(&permutation);
 
   std::vector<int64_t> supply;
   GenerateAssignmentSupply<Graph>(num_sources, num_targets, &supply);
-  EXPECT_TRUE(CheckAssignmentFeasibility(graph, supply));
-  std::vector<int64_t> arc_capacity(graph.num_arcs(), 1);
-  std::vector<int64_t> arc_cost(graph.num_arcs());
-  GenerateRandomArcValuations<Graph>(graph.num_arcs(), kCostRange, &arc_cost);
-  GenericMinCostFlow<Graph> min_cost_flow(&graph);
-  SetUpNetworkData(permutation, supply, arc_cost, arc_capacity, &graph,
+  EXPECT_TRUE(CheckAssignmentFeasibility(*graph, supply));
+  std::vector<int64_t> arc_capacity(graph->num_arcs(), 1);
+  std::vector<int64_t> arc_cost(graph->num_arcs());
+  GenerateRandomArcValuations<Graph>(graph->num_arcs(), kCostRange, &arc_cost);
+  GenericMinCostFlow<Graph> min_cost_flow(graph.get());
+  SetUpNetworkData(permutation, supply, arc_cost, arc_capacity, graph.get(),
                    &min_cost_flow);
 
   CostValue cost = f(&min_cost_flow);
@@ -690,21 +710,21 @@ void PartialRandomAssignment(typename MinCostFlowSolver<Graph>::Solver f,
                              CostValue /*expected_cost2*/) {
   const typename Graph::NodeIndex kDegree = 10;
   const CostValue kCostRange = 1000;
-  Graph graph;
-  GeneratePartialRandomGraph(num_sources, num_targets, kDegree, &graph);
   std::vector<typename Graph::ArcIndex> permutation;
-  graph.Build(&permutation);
+  const auto graph =
+      GetPartialRandomGraphBuilder<Graph>(num_sources, num_targets, kDegree)
+          .Build(&permutation);
 
   std::vector<int64_t> supply;
   GenerateAssignmentSupply<Graph>(num_sources, num_targets, &supply);
-  EXPECT_TRUE(CheckAssignmentFeasibility(graph, supply));
+  EXPECT_TRUE(CheckAssignmentFeasibility(*graph, supply));
 
-  EXPECT_EQ(graph.num_arcs(), num_sources * kDegree);
-  std::vector<int64_t> arc_capacity(graph.num_arcs(), 1);
-  std::vector<int64_t> arc_cost(graph.num_arcs());
-  GenerateRandomArcValuations<Graph>(graph.num_arcs(), kCostRange, &arc_cost);
-  GenericMinCostFlow<Graph> min_cost_flow(&graph);
-  SetUpNetworkData(permutation, supply, arc_cost, arc_capacity, &graph,
+  EXPECT_EQ(graph->num_arcs(), num_sources * kDegree);
+  std::vector<int64_t> arc_capacity(graph->num_arcs(), 1);
+  std::vector<int64_t> arc_cost(graph->num_arcs());
+  GenerateRandomArcValuations<Graph>(graph->num_arcs(), kCostRange, &arc_cost);
+  GenericMinCostFlow<Graph> min_cost_flow(graph.get());
+  SetUpNetworkData(permutation, supply, arc_cost, arc_capacity, graph.get(),
                    &min_cost_flow);
   CostValue cost = f(&min_cost_flow);
   EXPECT_EQ(expected_cost1, cost);
@@ -742,22 +762,22 @@ void PartialRandomFlow(typename MinCostFlowSolver<Graph>::Solver f,
   const CostValue kCostRange = 1000;
   const FlowQuantity kCapacityDelta = 500;
   const float kProbability = 0.9;
-  Graph graph;
-  GeneratePartialRandomGraph(num_sources, num_targets, kDegree, &graph);
   std::vector<typename Graph::ArcIndex> permutation;
-  graph.Build(&permutation);
+  const auto graph =
+      GetPartialRandomGraphBuilder<Graph>(num_sources, num_targets, kDegree)
+          .Build(&permutation);
 
   std::vector<int64_t> supply;
   GenerateRandomSupply<Graph>(num_sources, num_targets, kSupplyGens,
                               kSupplyRange, &supply);
-  EXPECT_TRUE(CheckAssignmentFeasibility(graph, supply));
-  std::vector<int64_t> arc_capacity(graph.num_arcs());
-  GenerateRandomArcValuations<Graph>(graph.num_arcs(), kCapacityRange,
+  EXPECT_TRUE(CheckAssignmentFeasibility(*graph, supply));
+  std::vector<int64_t> arc_capacity(graph->num_arcs());
+  GenerateRandomArcValuations<Graph>(graph->num_arcs(), kCapacityRange,
                                      &arc_capacity);
-  std::vector<int64_t> arc_cost(graph.num_arcs());
-  GenerateRandomArcValuations<Graph>(graph.num_arcs(), kCostRange, &arc_cost);
-  GenericMinCostFlow<Graph> min_cost_flow(&graph);
-  SetUpNetworkData(permutation, supply, arc_cost, arc_capacity, &graph,
+  std::vector<int64_t> arc_cost(graph->num_arcs());
+  GenerateRandomArcValuations<Graph>(graph->num_arcs(), kCostRange, &arc_cost);
+  GenericMinCostFlow<Graph> min_cost_flow(graph.get());
+  SetUpNetworkData(permutation, supply, arc_cost, arc_capacity, graph.get(),
                    &min_cost_flow);
 
   CostValue cost = f(&min_cost_flow);
@@ -782,23 +802,22 @@ void FullRandomFlow(typename MinCostFlowSolver<Graph>::Solver f,
   const CostValue kCostRange = 1000;
   const FlowQuantity kCapacityDelta = 1000;
   const float kProbability = 0.9;
-  Graph graph;
-  GenerateCompleteGraph(num_sources, num_targets, &graph);
   std::vector<typename Graph::ArcIndex> permutation;
-  graph.Build(&permutation);
+  const auto graph = GetCompleteGraphBuilder<Graph>(num_sources, num_targets)
+                         .Build(&permutation);
 
   std::vector<int64_t> supply;
   GenerateRandomSupply<Graph>(num_sources, num_targets, kSupplyGens,
                               kSupplyRange, &supply);
-  EXPECT_TRUE(CheckAssignmentFeasibility(graph, supply));
-  std::vector<int64_t> arc_capacity(graph.num_arcs());
-  GenerateRandomArcValuations<Graph>(graph.num_arcs(), kCapacityRange,
+  EXPECT_TRUE(CheckAssignmentFeasibility(*graph, supply));
+  std::vector<int64_t> arc_capacity(graph->num_arcs());
+  GenerateRandomArcValuations<Graph>(graph->num_arcs(), kCapacityRange,
                                      &arc_capacity);
-  std::vector<int64_t> arc_cost(graph.num_arcs());
-  GenerateRandomArcValuations<Graph>(graph.num_arcs(), kCostRange, &arc_cost);
-  GenericMinCostFlow<Graph> min_cost_flow(&graph);
+  std::vector<int64_t> arc_cost(graph->num_arcs());
+  GenerateRandomArcValuations<Graph>(graph->num_arcs(), kCostRange, &arc_cost);
+  GenericMinCostFlow<Graph> min_cost_flow(graph.get());
 
-  SetUpNetworkData(permutation, supply, arc_cost, arc_capacity, &graph,
+  SetUpNetworkData(permutation, supply, arc_cost, arc_capacity, graph.get(),
                    &min_cost_flow);
 
   CostValue cost = f(&min_cost_flow);

--- a/ortools/graph/minimum_spanning_tree_test.cc
+++ b/ortools/graph/minimum_spanning_tree_test.cc
@@ -16,13 +16,10 @@
 #include <algorithm>
 #include <cstdint>
 #include <limits>
-#include <random>
 #include <vector>
 
 #include "absl/base/macros.h"
-#include "absl/random/distributions.h"
 #include "absl/types/span.h"
-#include "benchmark/benchmark.h"
 #include "gtest/gtest.h"
 #include "ortools/base/gmock.h"
 #include "ortools/base/types.h"
@@ -32,7 +29,6 @@ namespace operations_research {
 namespace {
 
 using ::testing::UnorderedElementsAreArray;
-using ::util::CompleteGraph;
 using ::util::ListGraph;
 
 TEST(MSTTest, EmptyGraph) {
@@ -85,7 +81,7 @@ void CheckMSTWithPrim(const ListGraph<int, int>& graph,
   EXPECT_THAT(expected_arcs, UnorderedElementsAreArray(prim_mst));
 }
 
-// Testing Kruskal MST on a small undirectedgraph:
+// Testing Kruskal MST on a small undirected graph:
 // - original graph:
 // 0 -(1)- 1 -(2)- 2
 //         |       |
@@ -118,8 +114,7 @@ TEST(MSTTest, SmallGraph) {
 TEST(MSTTest, SmallGraphWithMaxValueArcs) {
   const int kArcs[][2] = {{0, 1}, {1, 2}};
   const int kNodes = 3;
-  const int64_t kCosts[] = {std::numeric_limits<int64_t>::max(),
-                            std::numeric_limits<int64_t>::max()};
+  const int64_t kCosts[] = {kint64max, kint64max};
   ListGraph<int, int> graph(kNodes, ABSL_ARRAYSIZE(kArcs) * 2);
   std::vector<int64_t> costs(ABSL_ARRAYSIZE(kArcs) * 2, 0);
   for (int i = 0; i < ABSL_ARRAYSIZE(kArcs); ++i) {
@@ -186,139 +181,6 @@ TEST(MSTTest, SmallDisconnectedGraph) {
   }
   CheckMSTWithKruskal(graph, costs, {0, 2, 4});
 }
-
-// Benchmark on a grid graph with random arc costs; 'size' corresponds to the
-// number of nodes on a row/column of the grid.
-template <typename GraphType>
-void BM_KruskalMinimimumSpanningTreeOnGrid(benchmark::State& state) {
-  int size = state.range(0);
-  const int64_t kCostLimit = 1000000;
-  std::mt19937 randomizer(0);
-  const int num_nodes = size * size;
-  const int num_edges = 2 * (2 * size * (size - 1) + 2 * size - 4);
-  std::vector<int64_t> edge_costs(num_edges, 0);
-  ListGraph<int, int> graph(num_nodes, num_edges);
-  for (int i = 0; i < size; ++i) {
-    for (int j = 0; j < size; ++j) {
-      if (j < size - 1) {
-        const int64_t cost = absl::Uniform(randomizer, 0, kCostLimit);
-        edge_costs[graph.AddArc(i * size + j, i * size + j + 1)] = cost;
-        edge_costs[graph.AddArc(i * size + j + 1, i * size + j)] = cost;
-      }
-      if (i < size - 1) {
-        const int64_t cost = absl::Uniform(randomizer, 0, kCostLimit);
-        edge_costs[graph.AddArc(i * size + j, (i + 1) * size + j)] = cost;
-        edge_costs[graph.AddArc((i + 1) * size + j, i * size + j)] = cost;
-      }
-    }
-  }
-  for (int i = 1; i < size - 1; ++i) {
-    const int64_t cost = absl::Uniform(randomizer, 0, kCostLimit);
-    edge_costs[graph.AddArc(i * size, i * size + size - 1)] = cost;
-    edge_costs[graph.AddArc(i * size + size - 1, i * size)] = cost;
-  }
-  for (int i = 1; i < size - 1; ++i) {
-    const int64_t cost = absl::Uniform(randomizer, 0, kCostLimit);
-    edge_costs[graph.AddArc(i, (size - 1) * size + i)] = cost;
-    edge_costs[graph.AddArc((size - 1) * size + i, i)] = cost;
-  }
-  for (auto _ : state) {
-    const std::vector<int> mst = BuildKruskalMinimumSpanningTree(
-        graph,
-        [&edge_costs](int a, int b) { return edge_costs[a] < edge_costs[b]; });
-    EXPECT_EQ(num_nodes - 1, mst.size());
-  }
-}
-
-BENCHMARK_TEMPLATE(BM_KruskalMinimimumSpanningTreeOnGrid, ListGraph<>)
-    ->Range(2, 1 << 8);
-
-template <typename GraphType>
-void BM_PrimMinimimumSpanningTreeOnGrid(benchmark::State& state) {
-  int size = state.range(0);
-  const int64_t kCostLimit = 1000000;
-  std::mt19937 randomizer(0);
-  const int num_nodes = size * size;
-  const int num_edges = 2 * (2 * size * (size - 1) + 2 * size - 4);
-  std::vector<int64_t> edge_costs(num_edges, 0);
-  ListGraph<int, int> graph(num_nodes, num_edges);
-  for (int i = 0; i < size; ++i) {
-    for (int j = 0; j < size; ++j) {
-      if (j < size - 1) {
-        const int64_t cost = absl::Uniform(randomizer, 0, kCostLimit);
-        edge_costs[graph.AddArc(i * size + j, i * size + j + 1)] = cost;
-        edge_costs[graph.AddArc(i * size + j + 1, i * size + j)] = cost;
-      }
-      if (i < size - 1) {
-        const int64_t cost = absl::Uniform(randomizer, 0, kCostLimit);
-        edge_costs[graph.AddArc(i * size + j, (i + 1) * size + j)] = cost;
-        edge_costs[graph.AddArc((i + 1) * size + j, i * size + j)] = cost;
-      }
-    }
-  }
-  for (int i = 1; i < size - 1; ++i) {
-    const int64_t cost = absl::Uniform(randomizer, 0, kCostLimit);
-    edge_costs[graph.AddArc(i * size, i * size + size - 1)] = cost;
-    edge_costs[graph.AddArc(i * size + size - 1, i * size)] = cost;
-  }
-  for (int i = 1; i < size - 1; ++i) {
-    const int64_t cost = absl::Uniform(randomizer, 0, kCostLimit);
-    edge_costs[graph.AddArc(i, (size - 1) * size + i)] = cost;
-    edge_costs[graph.AddArc((size - 1) * size + i, i)] = cost;
-  }
-  for (auto _ : state) {
-    const std::vector<int> mst = BuildPrimMinimumSpanningTree(
-        graph, [&edge_costs](int arc) { return edge_costs[arc]; });
-    EXPECT_EQ(num_nodes - 1, mst.size());
-  }
-}
-
-BENCHMARK_TEMPLATE(BM_PrimMinimimumSpanningTreeOnGrid, ListGraph<>)
-    ->Range(2, 1 << 8);
-
-// Benchmark on complete graph with random arc costs.
-void BM_KruskalMinimimumSpanningTreeOnCompleteGraph(benchmark::State& state) {
-  int num_nodes = state.range(0);
-  const int64_t kCostLimit = 1000000;
-  std::mt19937 randomizer(0);
-  CompleteGraph<int, int> graph(num_nodes);
-  std::vector<int64_t> edge_costs(graph.num_arcs(), 0);
-  for (const int node : graph.AllNodes()) {
-    for (const auto arc : graph.OutgoingArcs(node)) {
-      const int64_t cost = absl::Uniform(randomizer, 0, kCostLimit);
-      edge_costs[arc] = cost;
-    }
-  }
-  for (auto _ : state) {
-    const std::vector<int> mst = BuildKruskalMinimumSpanningTree(
-        graph,
-        [&edge_costs](int a, int b) { return edge_costs[a] < edge_costs[b]; });
-    EXPECT_EQ(num_nodes - 1, mst.size());
-  }
-}
-
-BENCHMARK(BM_KruskalMinimimumSpanningTreeOnCompleteGraph)->Range(2, 1 << 10);
-
-void BM_PrimMinimimumSpanningTreeOnCompleteGraph(benchmark::State& state) {
-  int num_nodes = state.range(0);
-  const int64_t kCostLimit = 1000000;
-  std::mt19937 randomizer(0);
-  CompleteGraph<int, int> graph(num_nodes);
-  std::vector<int64_t> edge_costs(graph.num_arcs(), 0);
-  for (const int node : graph.AllNodes()) {
-    for (const auto arc : graph.OutgoingArcs(node)) {
-      const int64_t cost = absl::Uniform(randomizer, 0, kCostLimit);
-      edge_costs[arc] = cost;
-    }
-  }
-  for (auto _ : state) {
-    const std::vector<int> mst = BuildPrimMinimumSpanningTree(
-        graph, [&edge_costs](int arc) { return edge_costs[arc]; });
-    EXPECT_EQ(num_nodes - 1, mst.size());
-  }
-}
-
-BENCHMARK(BM_PrimMinimimumSpanningTreeOnCompleteGraph)->Range(2, 1 << 10);
 
 }  // namespace
 }  // namespace operations_research

--- a/ortools/graph/minimum_vertex_cover_test.cc
+++ b/ortools/graph/minimum_vertex_cover_test.cc
@@ -16,7 +16,6 @@
 #include <vector>
 
 #include "absl/algorithm/container.h"
-#include "benchmark/benchmark.h"
 #include "gtest/gtest.h"
 
 namespace operations_research {
@@ -74,22 +73,6 @@ TEST(BipartiteMinimumVertexCoverTest, Empty) {
                           false),
             6);
 }
-
-void BM_CompleteBipartite(benchmark::State& state) {
-  const int num_left = state.range(0);
-  const int num_right = state.range(1);
-  std::vector<std::vector<int>> left_to_right =
-      MakeCompleteBipartiteGraph(num_left, num_right);
-  for (auto _ : state) {
-    BipartiteMinimumVertexCover(left_to_right, num_right);
-  }
-}
-BENCHMARK(BM_CompleteBipartite)
-    ->ArgPair(1, 128)
-    ->ArgPair(128, 1)
-    ->ArgPair(32, 32)
-    ->ArgPair(8, 64)
-    ->ArgPair(64, 8);
 
 }  // namespace
 }  // namespace operations_research

--- a/ortools/graph/multi_dijkstra_test.cc
+++ b/ortools/graph/multi_dijkstra_test.cc
@@ -113,8 +113,9 @@ TEST(MultiDijkstraTest, RandomizedStressTest) {
     const int num_nodes = absl::Uniform(random, 0, max_num_nodes);
     const int num_arcs =
         num_nodes == 0 ? 0 : absl::Uniform(random, 0, max_num_arcs);
-    std::unique_ptr<util::StaticGraph<>> graph = util::GenerateRandomMultiGraph(
-        num_nodes, num_arcs, /*finalized=*/true, random);
+    std::unique_ptr<util::StaticGraph<>> graph =
+        util::GenerateRandomMultiGraph(num_nodes, num_arcs, random)
+            .Build(nullptr);
 
     // Set up the input source sets.
     int num_sources =

--- a/ortools/graph/perfect_matching.cc
+++ b/ortools/graph/perfect_matching.cc
@@ -27,6 +27,7 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
 #include "ortools/base/log_severity.h"
+#include "ortools/base/types.h"
 #include "ortools/util/saturated_arithmetic.h"
 
 namespace operations_research {
@@ -112,8 +113,7 @@ MinCostPerfectMatching::Status MinCostPerfectMatching::Solve() {
 
   optimal_solution_found_ = true;
   optimal_cost_ = graph_->DualObjective().value();
-  if (optimal_cost_ == std::numeric_limits<int64_t>::max())
-    return Status::COST_OVERFLOW;
+  if (optimal_cost_ == kint64max) return Status::COST_OVERFLOW;
   return Status::OPTIMAL;
 }
 
@@ -125,7 +125,7 @@ const BlossomGraph::NodeIndex BlossomGraph::kNoNodeIndex =
 const BlossomGraph::EdgeIndex BlossomGraph::kNoEdgeIndex =
     BlossomGraph::EdgeIndex(-1);
 const BlossomGraph::CostValue BlossomGraph::kMaxCostValue =
-    BlossomGraph::CostValue(std::numeric_limits<int64_t>::max());
+    BlossomGraph::CostValue(kint64max);
 
 BlossomGraph::BlossomGraph(int num_nodes) {
   graph_.resize(num_nodes);
@@ -1272,8 +1272,8 @@ CostValue BlossomGraph::Dual(const Node& node) const {
 }
 
 CostValue BlossomGraph::DualObjective() const {
-  if (dual_objective_ == CostValue(std::numeric_limits<int64_t>::max())) {
-    return CostValue(std::numeric_limits<int64_t>::max());
+  if (dual_objective_ == CostValue(kint64max)) {
+    return CostValue(kint64max);
   }
   CHECK_EQ(dual_objective_ % 2, CostValue(0));
   return dual_objective_ / 2;

--- a/ortools/graph/perfect_matching_test.cc
+++ b/ortools/graph/perfect_matching_test.cc
@@ -26,6 +26,7 @@
 #include "absl/types/span.h"
 #include "gtest/gtest.h"
 #include "ortools/base/log_severity.h"
+#include "ortools/base/types.h"
 #include "ortools/linear_solver/linear_solver.pb.h"
 #include "ortools/linear_solver/solve_mp_model.h"
 
@@ -82,21 +83,21 @@ TEST(MinCostPerfectMatchingTest, LargerBipartiteInfeasibleProblem) {
 
 TEST(MinCostPerfectMatchingTest, IntegerOverflow) {
   MinCostPerfectMatching matcher(4);
-  matcher.AddEdgeWithCost(0, 2, std::numeric_limits<int64_t>::max());
-  matcher.AddEdgeWithCost(0, 3, std::numeric_limits<int64_t>::max());
-  matcher.AddEdgeWithCost(1, 2, std::numeric_limits<int64_t>::max());
-  matcher.AddEdgeWithCost(1, 3, std::numeric_limits<int64_t>::max());
+  matcher.AddEdgeWithCost(0, 2, kint64max);
+  matcher.AddEdgeWithCost(0, 3, kint64max);
+  matcher.AddEdgeWithCost(1, 2, kint64max);
+  matcher.AddEdgeWithCost(1, 3, kint64max);
   ASSERT_EQ(matcher.Solve(), MinCostPerfectMatching::INTEGER_OVERFLOW);
 }
 
 TEST(MinCostPerfectMatchingTest, CostOverflow) {
   MinCostPerfectMatching matcher(4);
-  matcher.AddEdgeWithCost(0, 2, std::numeric_limits<int64_t>::max() / 3);
-  matcher.AddEdgeWithCost(0, 3, std::numeric_limits<int64_t>::max() / 3);
-  matcher.AddEdgeWithCost(1, 2, std::numeric_limits<int64_t>::max() / 3);
-  matcher.AddEdgeWithCost(1, 3, std::numeric_limits<int64_t>::max() / 3);
+  matcher.AddEdgeWithCost(0, 2, kint64max / 3);
+  matcher.AddEdgeWithCost(0, 3, kint64max / 3);
+  matcher.AddEdgeWithCost(1, 2, kint64max / 3);
+  matcher.AddEdgeWithCost(1, 3, kint64max / 3);
   ASSERT_EQ(matcher.Solve(), MinCostPerfectMatching::COST_OVERFLOW);
-  EXPECT_EQ(matcher.OptimalCost(), std::numeric_limits<int64_t>::max());
+  EXPECT_EQ(matcher.OptimalCost(), kint64max);
 }
 
 class MacholWienTest : public ::testing::TestWithParam<int> {};
@@ -271,8 +272,7 @@ void CheckOptimalSolution(const MinCostPerfectMatching& matcher,
   EXPECT_EQ(num_seen, matches.size());
 
   // Check that the matching returned has the correct cost.
-  std::vector<int64_t> costs(matches.size(),
-                             std::numeric_limits<int64_t>::max());
+  std::vector<int64_t> costs(matches.size(), kint64max);
   for (const Edge e : edges) {
     if (matches[e.node1] == e.node2) {
       const int rep = std::min(e.node1, e.node2);
@@ -283,7 +283,7 @@ void CheckOptimalSolution(const MinCostPerfectMatching& matcher,
   }
   int64_t actual_cost = 0;
   for (int i = 0; i < costs.size(); ++i) {
-    CHECK_NE(costs[i], std::numeric_limits<int64_t>::max());
+    CHECK_NE(costs[i], kint64max);
     actual_cost += costs[i];
   }
   EXPECT_EQ(matcher.OptimalCost(), actual_cost);

--- a/ortools/graph/rooted_tree_test.cc
+++ b/ortools/graph/rooted_tree_test.cc
@@ -13,16 +13,12 @@
 
 #include "ortools/graph/rooted_tree.h"
 
-#include <algorithm>
 #include <cstdint>
 #include <utility>
 #include <vector>
 
 #include "absl/algorithm/container.h"
-#include "absl/log/check.h"
-#include "absl/random/random.h"
 #include "absl/status/status.h"
-#include "benchmark/benchmark.h"
 #include "gtest/gtest.h"
 #include "ortools/base/gmock.h"
 #include "ortools/graph_base/graph.h"
@@ -617,37 +613,6 @@ REGISTER_TYPED_TEST_SUITE_P(
 using NodeTypes =
     ::testing::Types<int16_t, int32_t, int64_t, uint16_t, uint32_t, uint64_t>;
 INSTANTIATE_TYPED_TEST_SUITE_P(AllRootedTreeTests, RootedTreeTest, NodeTypes);
-
-////////////////////////////////////////////////////////////////////////////////
-// Benchmarks
-////////////////////////////////////////////////////////////////////////////////
-
-std::vector<int> RandomTreeRootedZero(int num_nodes) {
-  absl::BitGen bit_gen;
-  std::vector<int> nodes(num_nodes);
-  absl::c_iota(nodes, 0);
-  std::shuffle(nodes.begin() + 1, nodes.end(), bit_gen);
-  std::vector<int> result(num_nodes);
-  result[0] = -1;
-  for (int i = 1; i < num_nodes; ++i) {
-    int target = absl::Uniform<int>(bit_gen, 0, i);
-    result[i] = target;
-  }
-  return result;
-}
-
-void BM_RootedTreeShortestPath(benchmark::State& state) {
-  const int num_nodes = state.range(0);
-  std::vector<int> random_tree_data = RandomTreeRootedZero(num_nodes);
-  for (auto s : state) {
-    const RootedTree<int> tree =
-        RootedTree<int>::Create(0, random_tree_data).value();
-    std::vector<int> path = tree.PathToRoot(num_nodes - 1);
-    CHECK_GE(path.size(), 2);
-  }
-}
-
-BENCHMARK(BM_RootedTreeShortestPath)->Arg(100)->Arg(10'000)->Arg(1'000'000);
 
 }  // namespace
 }  // namespace operations_research

--- a/ortools/graph/samples/dag_constrained_shortest_path_sequential.cc
+++ b/ortools/graph/samples/dag_constrained_shortest_path_sequential.cc
@@ -48,7 +48,7 @@ int main(int argc, char** argv) {
   const int source = n;
   const int dest = n + 1;
   const int num_arcs = 3 * n - 1;
-  util::StaticGraph<> graph;
+  util::StaticGraph<>::Builder builder;
   // There are 3 types of arcs: (1) source to M, (2) M to dest, and (3) within
   // M. This vector stores all of them, first of type (1), then type (2),
   // then type (3). The arcs are ordered by i in M within each type.
@@ -57,17 +57,17 @@ int main(int argc, char** argv) {
   std::vector<std::vector<double>> resources(1, std::vector<double>(num_arcs));
 
   for (int i = 0; i < n; ++i) {
-    graph.AddArc(source, i);
+    builder.AddArc(source, i);
     weights[i] = 100.0;
     resources[0][i] = 0.0;
   }
   for (int i = 0; i < n; ++i) {
-    graph.AddArc(i, dest);
+    builder.AddArc(i, dest);
     weights[n + i] = 100.0;
     resources[0][n + i] = 0.0;
   }
   for (int i = 0; i + 1 < n; ++i) {
-    graph.AddArc(i, i + 1);
+    builder.AddArc(i, i + 1);
     weights[2 * n + i] = 1.0;
     resources[0][2 * n + i] = 1.0;
   }
@@ -75,7 +75,7 @@ int main(int argc, char** argv) {
   // Static graph reorders the arcs at Build() time, use permutation to get from
   // the old ordering to the new one.
   std::vector<int32_t> permutation;
-  graph.Build(&permutation);
+  const auto graph = std::move(builder).Build(&permutation);
   util::Permute(permutation, &weights);
   util::Permute(permutation, &resources[0]);
   // [END graph]
@@ -95,7 +95,7 @@ int main(int argc, char** argv) {
   const std::vector<double> max_resources = {1.0};
 
   operations_research::ConstrainedShortestPathsOnDagWrapper<util::StaticGraph<>>
-      constrained_shortest_path_on_dag(&graph, &weights, &resources,
+      constrained_shortest_path_on_dag(graph.get(), &weights, &resources,
                                        topological_order, sources, destinations,
                                        &max_resources);
   operations_research::GraphPathWithLength<util::StaticGraph<>>

--- a/ortools/graph/samples/dag_multiple_shortest_paths_one_to_all.cc
+++ b/ortools/graph/samples/dag_multiple_shortest_paths_one_to_all.cc
@@ -31,32 +31,32 @@
 namespace {
 
 absl::Status Main() {
-  util::StaticGraph<> graph;
+  util::StaticGraph<>::Builder builder;
   std::vector<double> weights;
-  graph.AddArc(0, 1);
+  builder.AddArc(0, 1);
   weights.push_back(2.0);
-  graph.AddArc(0, 2);
+  builder.AddArc(0, 2);
   weights.push_back(5.0);
-  graph.AddArc(1, 4);
+  builder.AddArc(1, 4);
   weights.push_back(1.0);
-  graph.AddArc(2, 4);
+  builder.AddArc(2, 4);
   weights.push_back(-3.0);
-  graph.AddArc(3, 4);
+  builder.AddArc(3, 4);
   weights.push_back(0.0);
 
   // Static graph reorders the arcs at Build() time, use permutation to get
   // from the old ordering to the new one.
   std::vector<int32_t> permutation;
-  graph.Build(&permutation);
+  const auto graph = std::move(builder).Build(&permutation);
   util::Permute(permutation, &weights);
 
   // We need a topological order. We can find it by hand on this small graph,
   // e.g., {0, 1, 2, 3, 4}, but we demonstrate how to compute one instead.
   ASSIGN_OR_RETURN(const std::vector<int32_t> topological_order,
-                   util::graph::FastTopologicalSort(graph));
+                   util::graph::FastTopologicalSort(*graph));
 
   operations_research::KShortestPathsOnDagWrapper<util::StaticGraph<>>
-      shortest_paths_on_dag(&graph, &weights, topological_order,
+      shortest_paths_on_dag(graph.get(), &weights, topological_order,
                             /*path_count=*/2);
   const int source = 0;
   shortest_paths_on_dag.RunKShortestPathOnDag({source});

--- a/ortools/graph/samples/dag_multiple_shortest_paths_sequential.cc
+++ b/ortools/graph/samples/dag_multiple_shortest_paths_sequential.cc
@@ -42,29 +42,29 @@ int main(int argc, char** argv) {
   const int n = 10;
   const int source = n;
   const int dest = n + 1;
-  util::StaticGraph<> graph;
+  util::StaticGraph<>::Builder builder;
   // There are 3 types of arcs: (1) source to M, (2) M to dest, and (3) within
   // M. This vector stores all of them, first of type (1), then type (2),
   // then type (3). The arcs are ordered by i in M within each type.
   std::vector<double> weights(3 * n - 1);
 
   for (int i = 0; i < n; ++i) {
-    graph.AddArc(source, i);
+    builder.AddArc(source, i);
     weights[i] = 100.0 + i;
   }
   for (int i = 0; i < n; ++i) {
-    graph.AddArc(i, dest);
+    builder.AddArc(i, dest);
     weights[n + i] = 100.0 + i;
   }
   for (int i = 0; i + 1 < n; ++i) {
-    graph.AddArc(i, i + 1);
+    builder.AddArc(i, i + 1);
     weights[2 * n + i] = 10.0;
   }
 
   // Static graph reorders the arcs at Build() time, use permutation to get from
   // the old ordering to the new one.
   std::vector<int32_t> permutation;
-  graph.Build(&permutation);
+  const auto graph = std::move(builder).Build(&permutation);
   util::Permute(permutation, &weights);
   // [END graph]
 
@@ -79,7 +79,7 @@ int main(int argc, char** argv) {
   topological_order.push_back(dest);
 
   operations_research::KShortestPathsOnDagWrapper<util::StaticGraph<>>
-      shortest_paths_on_dag(&graph, &weights, topological_order,
+      shortest_paths_on_dag(graph.get(), &weights, topological_order,
                             /*path_count=*/2);
   shortest_paths_on_dag.RunKShortestPathOnDag({source});
 

--- a/ortools/graph/samples/dag_shortest_path_one_to_all.cc
+++ b/ortools/graph/samples/dag_shortest_path_one_to_all.cc
@@ -30,32 +30,30 @@
 
 namespace {
 absl::Status Main() {
-  util::StaticGraph<> graph;
+  util::StaticGraph<>::Builder builder;
   std::vector<double> weights;
-  graph.AddArc(0, 2);
+  builder.AddArc(0, 2);
   weights.push_back(5.0);
-  graph.AddArc(0, 3);
+  builder.AddArc(0, 3);
   weights.push_back(4.0);
-  graph.AddArc(1, 3);
+  builder.AddArc(1, 3);
   weights.push_back(1.0);
-  graph.AddArc(2, 4);
+  builder.AddArc(2, 4);
   weights.push_back(-3.0);
-  graph.AddArc(3, 4);
+  builder.AddArc(3, 4);
   weights.push_back(0.0);
 
-  // Static graph reorders the arcs at Build() time, use permutation to get
+  // Static graph reorders the arcs at build time, use permutation to get
   // from the old ordering to the new one.
-  std::vector<int32_t> permutation;
-  graph.Build(&permutation);
-  util::Permute(permutation, &weights);
+  const auto graph = std::move(builder).BuildAndPermute(weights);
 
   // We need a topological order. We can find it by hand on this small graph,
   // e.g., {0, 1, 2, 3, 4}, but we demonstrate how to compute one instead.
   ASSIGN_OR_RETURN(const std::vector<int32_t> topological_order,
-                   util::graph::FastTopologicalSort(graph));
+                   util::graph::FastTopologicalSort(*graph));
 
   operations_research::ShortestPathsOnDagWrapper<util::StaticGraph<>>
-      shortest_path_on_dag(&graph, &weights, topological_order);
+      shortest_path_on_dag(graph.get(), &weights, topological_order);
   const int source = 0;
   shortest_path_on_dag.RunShortestPathOnDag({source});
 

--- a/ortools/graph/samples/dag_shortest_path_sequential.cc
+++ b/ortools/graph/samples/dag_shortest_path_sequential.cc
@@ -45,29 +45,29 @@ int main(int argc, char** argv) {
   const int n = 10;
   const int source = n;
   const int dest = n + 1;
-  util::StaticGraph<> graph;
+  util::StaticGraph<>::Builder builder;
   // There are 3 types of arcs: (1) source to M, (2) M to dest, and (3) within
   // M. This vector stores all of them, first of type (1), then type (2),
   // then type (3). The arcs are ordered by i in M within each type.
   std::vector<double> weights(3 * n - 1);
 
   for (int i = 0; i < n; ++i) {
-    graph.AddArc(source, i);
+    builder.AddArc(source, i);
     weights[i] = 100.0;
   }
   for (int i = 0; i < n; ++i) {
-    graph.AddArc(i, dest);
+    builder.AddArc(i, dest);
     weights[n + i] = 100.0;
   }
   for (int i = 0; i + 1 < n; ++i) {
-    graph.AddArc(i, i + 1);
+    builder.AddArc(i, i + 1);
     weights[2 * n + i] = 1.0;
   }
 
   // Static graph reorders the arcs at Build() time, use permutation to get from
   // the old ordering to the new one.
   std::vector<int32_t> permutation;
-  graph.Build(&permutation);
+  const auto graph = std::move(builder).Build(&permutation);
   util::Permute(permutation, &weights);
   // [END graph]
 
@@ -82,7 +82,7 @@ int main(int argc, char** argv) {
   topological_order.push_back(dest);
 
   operations_research::ShortestPathsOnDagWrapper<util::StaticGraph<>>
-      shortest_path_on_dag(&graph, &weights, topological_order);
+      shortest_path_on_dag(graph.get(), &weights, topological_order);
   shortest_path_on_dag.RunShortestPathOnDag({source});
 
   std::cout << "Initial distance: " << shortest_path_on_dag.LengthTo(dest)

--- a/ortools/graph/samples/dijkstra_all_pairs_shortest_paths.cc
+++ b/ortools/graph/samples/dijkstra_all_pairs_shortest_paths.cc
@@ -30,7 +30,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <iostream>
-#include <limits>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -75,15 +74,15 @@ double Distance(const std::pair<double, double>& node1,
   return std::sqrt(dx * dx + dy * dy);
 }
 
-std::pair<util::StaticGraph<int32_t, int32_t>, std::vector<double>> MakeGraph(
-    const std::vector<std::pair<double, double>>& points,
-    double max_edge_distance) {
-  util::StaticGraph<int32_t, int32_t> graph;
-  CHECK_LE(points.size(),
-           static_cast<size_t>(std::numeric_limits<int32_t>::max()));
+std::pair<std::unique_ptr<util::StaticGraph<int32_t, int32_t>>,
+          std::vector<double>>
+MakeGraph(const std::vector<std::pair<double, double>>& points,
+          double max_edge_distance) {
+  util::StaticGraph<int32_t, int32_t>::Builder builder;
+  CHECK_LE(points.size(), static_cast<size_t>(kint32max));
   const int32_t num_nodes = static_cast<int32_t>(points.size());
   if (num_nodes > 0) {
-    graph.AddNode(num_nodes - 1);
+    builder.AddNode(num_nodes - 1);
   }
   std::vector<double> arcs;
   for (int32_t i = 0; i < num_nodes; ++i) {
@@ -97,17 +96,14 @@ std::pair<util::StaticGraph<int32_t, int32_t>, std::vector<double>> MakeGraph(
       }
       const double dist = Distance(points[i], points[j]);
       if (dist <= max_edge_distance) {
-        graph.AddArc(i, j);
+        builder.AddArc(i, j);
         arcs.push_back(dist);
-        graph.AddArc(j, i);
+        builder.AddArc(j, i);
         arcs.push_back(dist);
       }
     }
   }
-  std::vector<int32_t> permutation;
-  graph.Build(&permutation);
-  util::Permute(permutation, &arcs);
-
+  auto graph = std::move(builder).BuildAndPermute(arcs);
   return {std::move(graph), std::move(arcs)};
 }
 
@@ -158,14 +154,14 @@ int main(int argc, char** argv) {
             << std::endl;
   std::cout << "Max distance for edge: " << max_edge_distance << std::endl;
   std::cout << "Estimated edges: " << expected_edges << std::endl;
-  std::cout << "Actual edges: " << graph.num_arcs() / 2 << std::endl;
+  std::cout << "Actual edges: " << graph->num_arcs() / 2 << std::endl;
   std::cout << "All pairs shortest path distance limit: " << limit << std::endl;
   std::cout << "Upper bound (estimated) on pairs of points within limit: "
             << estimated_connected_pairs << std::endl;
 
   const absl::Time start = absl::Now();
   const std::vector<std::pair<int, int>> all_pairs_within_distance =
-      AllPairsWithinDistance(graph, arc_lengths, limit);
+      AllPairsWithinDistance(*graph, arc_lengths, limit);
   const absl::Duration shortest_path_time = absl::Now() - start;
   // Our problem is undirected, so everything appears twice.
   std::cout << "Actual pairs of points within distance limit: "

--- a/ortools/graph/samples/dijkstra_one_to_all.cc
+++ b/ortools/graph/samples/dijkstra_one_to_all.cc
@@ -30,30 +30,30 @@ int main(int argc, char** argv) {
   InitGoogle(argv[0], &argc, &argv, true);
 
   // Create the graph
-  util::StaticGraph<> graph;
+  util::StaticGraph<>::Builder builder(5, 6);
   std::vector<int> weights;
-  graph.AddArc(0, 1);
+  builder.AddArc(0, 1);
   weights.push_back(2);
-  graph.AddArc(1, 2);
+  builder.AddArc(1, 2);
   weights.push_back(4);
-  graph.AddArc(1, 3);
+  builder.AddArc(1, 3);
   weights.push_back(0);
-  graph.AddArc(2, 3);
+  builder.AddArc(2, 3);
   weights.push_back(6);
-  graph.AddArc(3, 0);
+  builder.AddArc(3, 0);
   weights.push_back(8);
-  graph.AddArc(4, 2);
+  builder.AddArc(4, 2);
   weights.push_back(1);
 
   // Static graph reorders the arcs at Build() time, use permutation to get
   // from the old ordering to the new one.
   std::vector<int32_t> permutation;
-  graph.Build(&permutation);
+  const auto graph = std::move(builder).Build(&permutation);
   util::Permute(permutation, &weights);
 
   // Compute the shortest path to each reachable node.
   operations_research::BoundedDijkstraWrapper<util::StaticGraph<>, int>
-      dijkstra(&graph, &weights);
+      dijkstra(graph.get(), &weights);
   const std::vector<int> reachable_from_zero = dijkstra.RunBoundedDijkstra(
       /*source_node=*/0, /*distance_limit=*/kint32max);
 

--- a/ortools/graph/samples/dijkstra_sequential.cc
+++ b/ortools/graph/samples/dijkstra_sequential.cc
@@ -48,36 +48,36 @@ int main(int argc, char** argv) {
   const int n = 10;
   const int source = n;
   const int dest = n + 1;
-  util::StaticGraph<> graph;
+  util::StaticGraph<>::Builder builder;
   // There are 3 types of arcs: (1) source to M, (2) within M, and (3) M to
   // dest. This vector stores all of them, first of type (1), then type (2),
   // then type (3). The arcs are ordered by i in M within each type.
   std::vector<int> weights(3 * n);
 
   for (int i = 0; i < n; ++i) {
-    graph.AddArc(source, i);
+    builder.AddArc(source, i);
     weights[i] = 100;
   }
   for (int i = 0; i < n; ++i) {
-    graph.AddArc(i, (i + 1) % n);
+    builder.AddArc(i, (i + 1) % n);
     weights[n + i] = 1;
   }
   for (int i = 0; i < n; ++i) {
-    graph.AddArc(i, dest);
+    builder.AddArc(i, dest);
     weights[2 * n + i] = 100;
   }
 
   // Static graph reorders the arcs at Build() time, use permutation to get from
   // the old ordering to the new one.
   std::vector<int32_t> permutation;
-  graph.Build(&permutation);
+  const auto graph = std::move(builder).Build(&permutation);
   util::Permute(permutation, &weights);
   // [END graph]
 
   // [START first-path]
   // A reusable shortest path calculator.
   operations_research::BoundedDijkstraWrapper<util::StaticGraph<>, int>
-      dijkstra(&graph, &weights);
+      dijkstra(graph.get(), &weights);
 
   // This function returns false if there is no path from `source` to `dest`
   // of length at most `distance_limit`. Avoid CHECK when you cannot prove a

--- a/ortools/graph/shortest_paths.h
+++ b/ortools/graph/shortest_paths.h
@@ -79,6 +79,7 @@
 #include "ortools/base/adjustable_priority_queue.h"
 #include "ortools/base/threadpool.h"
 #include "ortools/base/timer.h"
+#include "ortools/base/types.h"
 
 namespace operations_research {
 
@@ -87,8 +88,7 @@ namespace operations_research {
 // precision should be acceptable in practice.
 typedef uint32_t PathDistance;
 
-const PathDistance kDisconnectedPathDistance =
-    std::numeric_limits<uint32_t>::max();
+const PathDistance kDisconnectedPathDistance = kuint32max;
 
 namespace internal {
 template <class NodeIndex, NodeIndex kNilNode>

--- a/ortools/graph/shortest_paths_test.cc
+++ b/ortools/graph/shortest_paths_test.cc
@@ -220,15 +220,15 @@ void TestShortestPathsFromGraph(
     const PathDistance arc_lengths[],
     const typename GraphType::NodeIndex expected_paths[],
     const PathDistance expected_distances[]) {
-  GraphType graph(num_nodes, num_arcs);
+  typename GraphType::Builder builder(num_nodes, num_arcs);
   std::vector<PathDistance> lengths(num_arcs);
   for (int i = 0; i < num_arcs; ++i) {
-    lengths[graph.AddArc(arcs[i][0], arcs[i][1])] = arc_lengths[i];
+    lengths[builder.AddArc(arcs[i][0], arcs[i][1])] = arc_lengths[i];
   }
   std::vector<typename GraphType::ArcIndex> permutation;
-  graph.Build(&permutation);
+  const auto graph = std::move(builder).Build(&permutation);
   util::Permute(permutation, &lengths);
-  TestShortestPathsFromGraph(graph, lengths, expected_paths,
+  TestShortestPathsFromGraph(*graph, lengths, expected_paths,
                              expected_distances);
 }
 
@@ -389,7 +389,7 @@ TYPED_TEST(GraphShortestPathsTest, DISABLED_LargeRandomShortestPaths) {
   const int max_distance = 50;
   const PathDistance kConnectionArcLength = 300;
   std::mt19937 randomizer(12345);
-  TypeParam graph(kSize, kSize + kSize * kDegree);
+  typename TypeParam::Builder builder(kSize, kSize + kSize * kDegree);
   std::vector<PathDistance> lengths;
   for (int i = 0; i < kSize; ++i) {
     const typename TypeParam::NodeIndex tail(
@@ -399,45 +399,48 @@ TYPED_TEST(GraphShortestPathsTest, DISABLED_LargeRandomShortestPaths) {
           absl::Uniform(randomizer, 0, kSize));
       const PathDistance length =
           1 + absl::Uniform(randomizer, 0, max_distance);
-      graph.AddArc(tail, head);
+      builder.AddArc(tail, head);
       lengths.push_back(length);
     }
   }
   typename TypeParam::NodeIndex prev_index = TypeParam::kNilNode;
   typename TypeParam::NodeIndex first_index = TypeParam::kNilNode;
-  for (const typename TypeParam::NodeIndex node_index : graph.AllNodes()) {
-    if (prev_index != TypeParam::kNilNode) {
-      graph.AddArc(prev_index, node_index);
-      lengths.push_back(kConnectionArcLength);
-    } else {
-      first_index = node_index;
+  {
+    const auto graph1 = typename TypeParam::Builder(builder).Build(nullptr);
+    for (const typename TypeParam::NodeIndex node_index : graph1->AllNodes()) {
+      if (prev_index != TypeParam::kNilNode) {
+        builder.AddArc(prev_index, node_index);
+        lengths.push_back(kConnectionArcLength);
+      } else {
+        first_index = node_index;
+      }
+      prev_index = node_index;
     }
-    prev_index = node_index;
   }
-  graph.AddArc(prev_index, first_index);
+  builder.AddArc(prev_index, first_index);
   lengths.push_back(kConnectionArcLength);
   std::vector<typename TypeParam::ArcIndex> permutation;
-  graph.Build(&permutation);
+  const auto graph = std::move(builder).Build(&permutation);
   util::Permute(permutation, &lengths);
   std::vector<std::vector<typename TypeParam::NodeIndex>> components;
-  ::FindStronglyConnectedComponents(graph.num_nodes(), graph, &components);
+  ::FindStronglyConnectedComponents(graph->num_nodes(), *graph, &components);
   CHECK_EQ(1, components.size());
   CHECK_EQ(kSize, components[0].size());
   const int kSourceSize = 10;
-  const int source_size = std::min(graph.num_nodes(), kSourceSize);
+  const int source_size = std::min(graph->num_nodes(), kSourceSize);
   std::vector<typename TypeParam::NodeIndex> sources(source_size, 0);
   for (int i = 0; i < source_size; ++i) {
-    sources[i] = absl::Uniform(randomizer, 0, graph.num_nodes());
+    sources[i] = absl::Uniform(randomizer, 0, graph->num_nodes());
   }
   const int kThreads = 10;
   auto container =
       GenericPathContainer<TypeParam>::BuildInMemoryCompactPathContainer();
   ComputeManyToManyShortestPathsWithMultipleThreads(
-      graph, lengths, sources, sources, kThreads, &container);
+      *graph, lengths, sources, sources, kThreads, &container);
   auto distance_container =
       GenericPathContainer<TypeParam>::BuildPathDistanceContainer();
   ComputeManyToManyShortestPathsWithMultipleThreads(
-      graph, lengths, sources, sources, kThreads, &distance_container);
+      *graph, lengths, sources, sources, kThreads, &distance_container);
   for (int tail = 0; tail < sources.size(); ++tail) {
     for (int head = 0; head < sources.size(); ++head) {
       EXPECT_NE(TypeParam::kNilNode, container.GetPenultimateNodeInPath(

--- a/ortools/graph/solve_flow_model.cc
+++ b/ortools/graph/solve_flow_model.cc
@@ -25,6 +25,7 @@
 #include <functional>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/flags/flag.h"
@@ -196,16 +197,16 @@ void SolveMinCostFlow(const FlowModelProto& flow_model, double* loading_time,
   }
 
   // Build the graph.
-  Graph graph(num_nodes, flow_model.arcs_size());
+  Graph::Builder builder(num_nodes, flow_model.arcs_size());
   for (int i = 0; i < flow_model.arcs_size(); ++i) {
-    graph.AddArc(flow_model.arcs(i).tail(), flow_model.arcs(i).head());
+    builder.AddArc(flow_model.arcs(i).tail(), flow_model.arcs(i).head());
   }
   std::vector<Graph::ArcIndex> permutation;
-  graph.Build(&permutation);
-  absl::PrintF("%d,", graph.num_nodes());
-  absl::PrintF("%d,", graph.num_arcs());
+  const auto graph = std::move(builder).Build(&permutation);
+  absl::PrintF("%d,", graph->num_nodes());
+  absl::PrintF("%d,", graph->num_arcs());
 
-  GenericMinCostFlow<Graph> min_cost_flow(&graph);
+  GenericMinCostFlow<Graph> min_cost_flow(graph.get());
   for (int i = 0; i < flow_model.arcs_size(); ++i) {
     const Graph::ArcIndex image = i < permutation.size() ? permutation[i] : i;
     min_cost_flow.SetArcUnitCost(image, flow_model.arcs(i).unit_cost());
@@ -231,27 +232,28 @@ void SolveMinCostFlow(const FlowModelProto& flow_model, double* loading_time,
 
 // Loads a FlowModelProto proto into the MaxFlow class and solves it.
 template <typename GraphType>
-void SolveMaxFlow(
-    const FlowModelProto& flow_model, double* loading_time,
-    double* solving_time,
-    std::function<void(GraphType* graph)> configure_graph_options = nullptr) {
+void SolveMaxFlow(const FlowModelProto& flow_model, double* loading_time,
+                  double* solving_time,
+                  std::function<void(typename GraphType::Builder* graph)>
+                      configure_graph_options = nullptr) {
   WallTimer timer;
   timer.Start();
 
   // Build the graph.
-  GraphType graph(flow_model.nodes_size(), flow_model.arcs_size());
+  typename GraphType::Builder graph_builder(flow_model.nodes_size(),
+                                            flow_model.arcs_size());
   for (int i = 0; i < flow_model.arcs_size(); ++i) {
-    graph.AddArc(flow_model.arcs(i).tail(), flow_model.arcs(i).head());
+    graph_builder.AddArc(flow_model.arcs(i).tail(), flow_model.arcs(i).head());
   }
   std::vector<typename GraphType::ArcIndex> permutation;
 
   if (configure_graph_options != nullptr) {
-    configure_graph_options(&graph);
+    configure_graph_options(&graph_builder);
   }
-  graph.Build(&permutation);
+  const auto graph = std::move(graph_builder).Build(&permutation);
 
-  absl::PrintF("%d,", graph.num_nodes());
-  absl::PrintF("%d,", graph.num_arcs());
+  absl::PrintF("%d,", graph->num_nodes());
+  absl::PrintF("%d,", graph->num_arcs());
 
   // Find source & sink.
   typename GraphType::NodeIndex source = -1;
@@ -269,7 +271,7 @@ void SolveMaxFlow(
   CHECK_NE(sink, -1);
 
   // Create the max flow instance and set the arc capacities.
-  GenericMaxFlow<GraphType> max_flow(&graph, source, sink);
+  GenericMaxFlow<GraphType> max_flow(graph.get(), source, sink);
   for (int i = 0; i < flow_model.arcs_size(); ++i) {
     const typename GraphType::ArcIndex image =
         i < permutation.size() ? permutation[i] : i;
@@ -374,10 +376,10 @@ int main(int argc, char** argv) {
         if (absl::GetFlag(FLAGS_use_flow_graph)) {
           SolveMaxFlow<util::FlowGraph<>>(
               proto, &loading_time, &solving_time,
-              [](util::FlowGraph<>* graph) {
-                graph->SetDetectReverse(
+              [](util::FlowGraph<>::Builder* builder) {
+                builder->SetDetectReverse(
                     absl::GetFlag(FLAGS_detect_reverse_arcs));
-                graph->SetSortByHead(absl::GetFlag(FLAGS_sort_heads));
+                builder->SetSortByHead(absl::GetFlag(FLAGS_sort_heads));
               });
         } else {
           SolveMaxFlow<util::ReverseArcStaticGraph<>>(proto, &loading_time,

--- a/ortools/graph_base/BUILD.bazel
+++ b/ortools/graph_base/BUILD.bazel
@@ -39,6 +39,7 @@ cc_library(
         ":iterators",
         "//ortools/base:constant_divisor",
         "@abseil-cpp//absl/base:core_headers",
+        "@abseil-cpp//absl/base:nullability",
         "@abseil-cpp//absl/debugging:leak_check",
         "@abseil-cpp//absl/log:check",
         "@abseil-cpp//absl/types:span",
@@ -52,7 +53,6 @@ cc_library(
     hdrs = ["random_graph.h"],
     deps = [
         ":graph",
-        "//ortools/base:types",
         "@abseil-cpp//absl/container:flat_hash_set",
         "@abseil-cpp//absl/log:check",
         "@abseil-cpp//absl/memory",
@@ -67,6 +67,7 @@ cc_library(
     deps = [
         "//ortools/base:numbers",
         "//ortools/util:filelineiter",
+        "@abseil-cpp//absl/log:check",
         "@abseil-cpp//absl/status",
         "@abseil-cpp//absl/status:statusor",
         "@abseil-cpp//absl/strings",

--- a/ortools/graph_base/flow_graph.h
+++ b/ortools/graph_base/flow_graph.h
@@ -22,6 +22,7 @@
 #include "absl/log/check.h"
 #include "absl/types/span.h"
 #include "ortools/base/stl_util.h"
+#include "ortools/base/unique_array.h"
 #include "ortools/graph_base/graph.h"
 #include "ortools/graph_base/iterators.h"
 
@@ -63,23 +64,15 @@ class FlowGraph : public BaseGraph<FlowGraph<NodeIndexType, ArcIndexType>,
   using Base::num_nodes_;
 
  public:
-  FlowGraph() = default;
-
-  FlowGraph(NodeIndexType num_nodes, ArcIndexType arc_capacity) {
-    this->Reserve(num_nodes, arc_capacity);
-    this->FreezeCapacities();
-    this->AddNode(num_nodes - 1);
-  }
+  class Builder;
 
   NodeIndexType Head(ArcIndexType arc) const {
-    DCHECK(is_built_);
     DCHECK_GE(arc, 0);
     DCHECK_LT(arc, num_arcs_);
     return heads_[arc];
   }
 
   NodeIndexType Tail(ArcIndexType arc) const {
-    DCHECK(is_built_);
     DCHECK_GE(arc, 0);
     DCHECK_LT(arc, num_arcs_);
 
@@ -91,9 +84,8 @@ class FlowGraph : public BaseGraph<FlowGraph<NodeIndexType, ArcIndexType>,
   }
 
   // Each arc has a reverse.
-  // If not added by the client, we have created one, see Build().
+  // If not added by the client, we have created one during Build().
   ArcIndexType OppositeArc(ArcIndexType arc) const {
-    DCHECK(is_built_);
     DCHECK_GE(arc, 0);
     DCHECK_LT(arc, num_arcs_);
     return reverse_[arc];
@@ -105,7 +97,6 @@ class FlowGraph : public BaseGraph<FlowGraph<NodeIndexType, ArcIndexType>,
   }
   util::IntegerRange<ArcIndexType> OutgoingArcsStartingFrom(
       NodeIndexType node, ArcIndexType from) const {
-    DCHECK(is_built_);
     DCHECK_GE(node, 0);
     DCHECK_LT(node, num_nodes_);
     DCHECK_GE(from, start_[node]);
@@ -131,81 +122,20 @@ class FlowGraph : public BaseGraph<FlowGraph<NodeIndexType, ArcIndexType>,
     return {&heads_[b], size};
   }
 
-  void ReserveArcs(ArcIndexType bound) override {
-    Base::ReserveArcs(bound);
-    tmp_tails_.reserve(bound);
-    tmp_heads_.reserve(bound);
-  }
-
-  void AddNode(NodeIndexType node) {
-    num_nodes_ = std::max(num_nodes_, node + 1);
-  }
-
-  ArcIndexType AddArc(NodeIndexType tail, NodeIndexType head) {
-    AddNode(tail > head ? tail : head);
-    tmp_tails_.push_back(tail);
-    tmp_heads_.push_back(head);
-    return num_arcs_++;
-  }
-
-  void Build() { Build(nullptr); }
-  void Build(std::vector<ArcIndexType>* permutation) final;
-
-  // This influence what Build() does. If true, we will detect already existing
-  // pairs of (arc, reverse_arc) and only construct new reverse arc for the one
-  // that we couldn't match. Otherwise, we will construct a new reverse arc for
-  // each input arcs.
-  void SetDetectReverse(bool value) { option_detect_reverse_ = value; }
-
-  // This influence what Build() does. If true, the order of each outgoing arc
-  // will be sorted by their head. Otherwise, it will be in the original order
-  // with the newly created reverse arc afterwards.
-  void SetSortByHead(bool value) { option_sort_by_head_ = value; }
-
  private:
-  // Computes the permutation that would stable_sort input, and fill start_
-  // to correspond to the beginning of each section of identical elements.
-  // This assumes input only contains element in [0, num_nodes_).
-  void FillPermutationAndStart(absl::Span<const NodeIndexType> input,
-                               absl::Span<ArcIndexType> perm);
+  friend class Builder;
 
-  // These are similar but tie-break identical element by "second_criteria".
-  // We have two versions. It seems filling the reverse permutation instead is
-  // slighthly faster and require less memory.
-  void FillPermutationAndStart(absl::Span<const NodeIndexType> first_criteria,
-                               absl::Span<const NodeIndexType> second_criteria,
-                               absl::Span<ArcIndexType> perm);
-  void FillReversePermutationAndStart(
-      absl::Span<const NodeIndexType> first_criteria,
-      absl::Span<const NodeIndexType> second_criteria,
-      absl::Span<ArcIndexType> reverse_perm);
-
-  // Internal helpers for the Fill*() functions above.
-  void InitializeStart(absl::Span<const NodeIndexType> input);
-  void RestoreStart();
-
-  // Different build options.
-  bool option_detect_reverse_ = true;
-  bool option_sort_by_head_ = false;
-
-  // Starts at false and set to true on Build(). This is mainly used in
-  // DCHECKs() to guarantee that the graph is just built once, and no new arcs
-  // are added afterwards.
-  bool is_built_ = false;
-
-  // This is just used before Build() to store the AddArc() data.
-  std::vector<NodeIndexType> tmp_tails_;
-  std::vector<NodeIndexType> tmp_heads_;
+  FlowGraph() = default;
 
   // First outgoing arc for a node.
   // Indexed by NodeIndexType + a sentinel start_[num_nodes_] = num_arcs_.
-  std::unique_ptr<ArcIndexType[]> start_;
+  gtl::UniqueArray<ArcIndexType> start_;
 
-  // Indexed by ArcIndexType an of size num_arcs_.
+  // Indexed by ArcIndexType and of size num_arcs_.
   // Head for an arc.
-  std::unique_ptr<NodeIndexType[]> heads_;
+  gtl::UniqueArray<NodeIndexType> heads_;
   // Reverse arc for an arc.
-  std::unique_ptr<ArcIndexType[]> reverse_;
+  gtl::UniqueArray<ArcIndexType> reverse_;
 };
 
 namespace internal {
@@ -224,65 +154,158 @@ void PermuteInto(absl::Span<const Key> permutation,
 }  // namespace internal
 
 template <typename NodeIndexType, typename ArcIndexType>
-void FlowGraph<NodeIndexType, ArcIndexType>::InitializeStart(
-    absl::Span<const NodeIndexType> input) {
-  // Computes the number of each elements.
-  std::fill(start_.get(), start_.get() + num_nodes_, 0);
-  start_[num_nodes_] = input.size();  // sentinel.
+class FlowGraph<NodeIndexType, ArcIndexType>::Builder
+    : public internal::GraphBuilderBase<Builder, FlowGraph, NodeIndexType,
+                                        ArcIndexType> {
+ public:
+  Builder() = default;
+  Builder(NodeIndexType num_nodes, ArcIndexType num_arcs)
+      : num_nodes_(num_nodes) {
+    ReserveArcs(num_arcs);
+  }
 
-  for (const NodeIndexType node : input) start_[node]++;
+  void ReserveArcs(ArcIndexType bound) & {
+    tmp_tails_.reserve(bound);
+    tmp_heads_.reserve(bound);
+  }
+
+  void AddNode(NodeIndexType node) & {
+    num_nodes_ = std::max(num_nodes_, node + 1);
+  }
+
+  ArcIndexType AddArc(NodeIndexType tail, NodeIndexType head) & {
+    AddNode(tail > head ? tail : head);
+    tmp_tails_.push_back(tail);
+    tmp_heads_.push_back(head);
+    return num_arcs_++;
+  }
+
+  // If true, we will detect already existing pairs of (arc, reverse_arc) and
+  // only construct new reverse arc for the one that we couldn't match.
+  // Otherwise, we will construct a new reverse arc for each input arcs.
+  void SetDetectReverse(bool value) & { option_detect_reverse_ = value; }
+  Builder&& SetDetectReverse(bool value) && {
+    SetDetectReverse(value);
+    return std::move(*this);
+  }
+
+  // If true, the order of each outgoing arc will be sorted by their head.
+  // Otherwise, it will be in the original order with the newly created
+  // reverse arc afterwards.
+  void SetSortByHead(bool value) & { option_sort_by_head_ = value; }
+  Builder&& SetSortByHead(bool value) && {
+    SetSortByHead(value);
+    return std::move(*this);
+  }
+
+  std::unique_ptr<FlowGraph> Build(std::vector<ArcIndexType>* permutation) &&;
+
+  NodeIndexType num_nodes() const { return num_nodes_; }
+  ArcIndexType num_arcs() const { return num_arcs_; }
+
+ private:
+  void FillReversePermutationAndStart(
+      absl::Span<const NodeIndexType> first_criteria,
+      absl::Span<const NodeIndexType> second_criteria,
+      absl::Span<ArcIndexType> reverse_perm,
+      absl::Span<ArcIndexType> start) const;
+
+  // Computes the permutation that would stable_sort input, and fill start
+  // to correspond to the beginning of each section of identical elements.
+  // This assumes input only contains element in [0, num_nodes_).
+  void FillPermutationAndStart(absl::Span<const NodeIndexType> input,
+                               absl::Span<ArcIndexType> perm,
+                               absl::Span<ArcIndexType> start) const;
+
+  // These are similar but tie-break identical element by "second_criteria".
+  // We have two versions. It seems filling the reverse permutation instead is
+  // slightly faster and require less memory.
+  void FillPermutationAndStart(absl::Span<const NodeIndexType> first_criteria,
+                               absl::Span<const NodeIndexType> second_criteria,
+                               absl::Span<ArcIndexType> perm,
+                               absl::Span<ArcIndexType> start) const;
+
+  // Internal helpers for the Fill*() functions above.
+  void InitializeStart(absl::Span<const NodeIndexType> input,
+                       absl::Span<ArcIndexType> start) const;
+  void RestoreStart(absl::Span<ArcIndexType> start) const;
+
+  bool option_detect_reverse_ = true;
+  bool option_sort_by_head_ = false;
+
+  NodeIndexType num_nodes_ = 0;
+  ArcIndexType num_arcs_ = 0;
+
+  // Stores the AddArc() data.
+  std::vector<NodeIndexType> tmp_tails_;
+  std::vector<NodeIndexType> tmp_heads_;
+};
+
+template <typename NodeIndexType, typename ArcIndexType>
+void FlowGraph<NodeIndexType, ArcIndexType>::Builder::InitializeStart(
+    absl::Span<const NodeIndexType> input,
+    absl::Span<ArcIndexType> start) const {
+  // Computes the number of each elements.
+  std::fill(start.data(), start.data() + num_nodes_, 0);
+  start[num_nodes_] = input.size();  // sentinel.
+
+  for (const NodeIndexType node : input) start[node]++;
 
   // Compute the cumulative sums (shifted one element to the right).
   int sum = 0;
   for (int i = 0; i < num_nodes_; ++i) {
-    int temp = start_[i];
-    start_[i] = sum;
+    int temp = start[i];
+    start[i] = sum;
     sum += temp;
   }
   DCHECK_EQ(sum, input.size());
 }
 
 template <typename NodeIndexType, typename ArcIndexType>
-void FlowGraph<NodeIndexType, ArcIndexType>::RestoreStart() {
+void FlowGraph<NodeIndexType, ArcIndexType>::Builder::RestoreStart(
+    absl::Span<ArcIndexType> start) const {
   // Restore in start[i] the index of the first arc with tail >= i.
   for (int i = num_nodes_; --i > 0;) {
-    start_[i] = start_[i - 1];
+    start[i] = start[i - 1];
   }
-  start_[0] = 0;
+  start[0] = 0;
 }
 
 template <typename NodeIndexType, typename ArcIndexType>
-void FlowGraph<NodeIndexType, ArcIndexType>::FillPermutationAndStart(
-    absl::Span<const NodeIndexType> input, absl::Span<ArcIndexType> perm) {
+void FlowGraph<NodeIndexType, ArcIndexType>::Builder::FillPermutationAndStart(
+    absl::Span<const NodeIndexType> input, absl::Span<ArcIndexType> perm,
+    absl::Span<ArcIndexType> start) const {
   DCHECK_EQ(input.size(), perm.size());
-  InitializeStart(input);
+  InitializeStart(input, start);
 
   // Computes the permutation.
   // Note that this temporarily alters the start_ vector.
   for (int i = 0; i < input.size(); ++i) {
-    perm[i] = start_[input[i]]++;
+    perm[i] = start[input[i]]++;
   }
 
-  RestoreStart();
+  RestoreStart(start);
 }
 
 template <typename NodeIndexType, typename ArcIndexType>
-void FlowGraph<NodeIndexType, ArcIndexType>::FillPermutationAndStart(
+void FlowGraph<NodeIndexType, ArcIndexType>::Builder::FillPermutationAndStart(
     absl::Span<const NodeIndexType> first_criteria,
     absl::Span<const NodeIndexType> second_criteria,
-    absl::Span<ArcIndexType> perm) {
+    absl::Span<ArcIndexType> perm, absl::Span<ArcIndexType> start) const {
   // First sort by second_criteria.
-  FillPermutationAndStart(second_criteria, absl::MakeSpan(perm));
+  FillPermutationAndStart(second_criteria, perm, start);
 
   // Create a temporary permuted version of first_criteria.
-  const auto tmp_storage = std::make_unique<ArcIndexType[]>(num_arcs_);
-  const auto tmp = absl::MakeSpan(tmp_storage.get(), num_arcs_);
+  const auto tmp_storage = gtl::MakeUniqueArray<ArcIndexType>(num_arcs_);
+  const auto tmp = absl::MakeSpan(tmp_storage.data(), num_arcs_);
   internal::PermuteInto<ArcIndexType, NodeIndexType>(perm, first_criteria, tmp);
 
   // Now sort by permuted first_criteria.
-  const auto second_perm_storage = std::make_unique<ArcIndexType[]>(num_arcs_);
-  const auto second_perm = absl::MakeSpan(second_perm_storage.get(), num_arcs_);
-  FillPermutationAndStart(tmp, second_perm);
+  const auto second_perm_storage =
+      gtl::MakeUniqueArray<ArcIndexType>(num_arcs_);
+  const auto second_perm =
+      absl::MakeSpan(second_perm_storage.data(), num_arcs_);
+  FillPermutationAndStart(tmp, second_perm, start);
 
   // Update the final permutation. This guarantee that for the same
   // first_criteria, the second_criteria will be used.
@@ -292,35 +315,33 @@ void FlowGraph<NodeIndexType, ArcIndexType>::FillPermutationAndStart(
 }
 
 template <typename NodeIndexType, typename ArcIndexType>
-void FlowGraph<NodeIndexType, ArcIndexType>::FillReversePermutationAndStart(
-    absl::Span<const NodeIndexType> first_criteria,
-    absl::Span<const NodeIndexType> second_criteria,
-    absl::Span<ArcIndexType> reverse_perm) {
+void FlowGraph<NodeIndexType, ArcIndexType>::Builder::
+    FillReversePermutationAndStart(
+        absl::Span<const NodeIndexType> first_criteria,
+        absl::Span<const NodeIndexType> second_criteria,
+        absl::Span<ArcIndexType> reverse_perm,
+        absl::Span<ArcIndexType> start) const {
   // Compute the reverse perm according to the second criteria.
-  InitializeStart(second_criteria);
-  const auto r_perm_storage = std::make_unique<ArcIndexType[]>(num_arcs_);
-  const auto r_perm = absl::MakeSpan(r_perm_storage.get(), num_arcs_);
-  auto* start = start_.get();
+  InitializeStart(second_criteria, start);
+  const auto r_perm_storage = gtl::MakeUniqueArray<ArcIndexType>(num_arcs_);
+  const auto r_perm = absl::MakeSpan(r_perm_storage.data(), num_arcs_);
   for (int i = 0; i < second_criteria.size(); ++i) {
     r_perm[start[second_criteria[i]]++] = i;
   }
 
   // Now radix-sort by the first criteria and combine the two permutations.
-  InitializeStart(first_criteria);
+  InitializeStart(first_criteria, start);
   for (const int i : r_perm) {
     reverse_perm[start[first_criteria[i]]++] = i;
   }
-  RestoreStart();
+  RestoreStart(start);
 }
 
 template <typename NodeIndexType, typename ArcIndexType>
-void FlowGraph<NodeIndexType, ArcIndexType>::Build(
-    std::vector<ArcIndexType>* permutation) {
-  DCHECK(!is_built_);
-  if (is_built_) return;
-  is_built_ = true;
-
-  start_ = std::make_unique<ArcIndexType[]>(num_nodes_ + 1);
+std::unique_ptr<FlowGraph<NodeIndexType, ArcIndexType>>
+FlowGraph<NodeIndexType, ArcIndexType>::Builder::Build(
+    std::vector<ArcIndexType>* permutation) && {
+  auto start = gtl::MakeUniqueArray<ArcIndexType>(num_nodes_ + 1);
   std::vector<ArcIndexType> perm(num_arcs_);
 
   const int kNoExplicitReverseArc = -1;
@@ -343,7 +364,8 @@ void FlowGraph<NodeIndexType, ArcIndexType>::Build(
     // a kind of radix sort by computing the degree of each node.
     auto reverse_perm = absl::MakeSpan(perm);  // we reuse space
     FillReversePermutationAndStart(tmp_tails_, tmp_heads_,
-                                   absl::MakeSpan(reverse_perm));
+                                   absl::MakeSpan(reverse_perm),
+                                   absl::MakeSpan(start));
 
     // Identify arc pairs that are reverse of each other and fill reverse for
     // them. The others position will stay at -1.
@@ -433,24 +455,34 @@ void FlowGraph<NodeIndexType, ArcIndexType>::Build(
   // TODO(user): For now we only support sorting, or all new reverse after
   // and keep the original arc order.
   if (option_sort_by_head_) {
-    FillPermutationAndStart(tmp_tails_, tmp_heads_, absl::MakeSpan(perm));
+    FillPermutationAndStart(tmp_tails_, tmp_heads_, absl::MakeSpan(perm),
+                            absl::MakeSpan(start));
   } else {
-    FillPermutationAndStart(tmp_tails_, absl::MakeSpan(perm));
+    FillPermutationAndStart(tmp_tails_, absl::MakeSpan(perm),
+                            absl::MakeSpan(start));
   }
 
+  auto graph = absl::WrapUnique(new FlowGraph());
+  graph->const_capacities_ = true;
+  graph->num_nodes_ = num_nodes_;
+  graph->num_arcs_ = num_arcs_;
+  graph->node_capacity_ = num_nodes_;
+  graph->arc_capacity_ = num_arcs_;
+  graph->start_ = std::move(start);
+
   // Create the final heads_.
-  heads_ = std::make_unique<NodeIndexType[]>(num_arcs_);
+  graph->heads_ = gtl::MakeUniqueArray<NodeIndexType>(num_arcs_);
   internal::PermuteInto<ArcIndexType, NodeIndexType>(
-      perm, tmp_heads_, absl::MakeSpan(heads_.get(), num_arcs_));
+      perm, tmp_heads_, absl::MakeSpan(graph->heads_.data(), num_arcs_));
 
   // No longer needed.
   gtl::STLClearObject(&tmp_tails_);
   gtl::STLClearObject(&tmp_heads_);
 
   // We now create reverse_, this needs the permutation on both sides.
-  reverse_ = std::make_unique<ArcIndexType[]>(num_arcs_);
+  graph->reverse_ = gtl::MakeUniqueArray<ArcIndexType>(num_arcs_);
   for (int i = 0; i < num_arcs_; ++i) {
-    reverse_[perm[i]] = perm[reverse[i]];
+    graph->reverse_[perm[i]] = perm[reverse[i]];
   }
 
   if (permutation != nullptr) {
@@ -461,10 +493,7 @@ void FlowGraph<NodeIndexType, ArcIndexType>::Build(
     }
     permutation->swap(perm);
   }
-
-  node_capacity_ = num_nodes_;
-  arc_capacity_ = num_arcs_;
-  this->FreezeCapacities();
+  return std::move(graph);
 }
 
 }  // namespace util

--- a/ortools/graph_base/graph.h
+++ b/ortools/graph_base/graph.h
@@ -37,7 +37,8 @@
 //
 // Provided implementations:
 //   - ListGraph<> for the simplest api. Also aliased to util::Graph.
-//   - StaticGraph<> for performance, but require calling Build(), see below
+//   - StaticGraph<> for performance, but requires building before usage, see
+//     below
 //   - CompleteGraph<> if you need a fully connected graph
 //   - CompleteBipartiteGraph<> if you need a fully connected bipartite graph
 //   - ReverseArcListGraph<> to add reverse arcs to ListGraph<>
@@ -75,20 +76,17 @@
 //
 // Note on iteration efficiency: When re-indexing the arcs it is not possible to
 // have both the outgoing arcs and the incoming ones form a consecutive range.
+// It is however possible to do so for the outgoing arcs and the opposite
+// incoming arcs. It is why the OutgoingOrOppositeIncomingArcs() and
+// OutgoingArcs() iterations are more efficient than the IncomingArcs() one.
 //
 // Iterators are invalidated by any operation that changes the graph (e.g.
 // `AddArc()`).
 //
-// It is however possible to do so for the outgoing arcs and the opposite
-// incoming arcs. It is why the OutgoingOrOppositeIncomingArcs() and
-// OutgoingArcs() iterations are more efficient than the IncomingArcs() one.
-// TODO(b/385094969): Once we no longer use `Next()/Ok()` for iterators, we can
-// get rid of `limit_`, which will make iteration much more efficient.
-//
 // If you know the graph size in advance, this already set the number of nodes,
 // reserve space for the arcs and check in DEBUG mode that you don't go over the
 // bounds:
-//   Graph graph(num_nodes, arc_capacity);
+//   ListGraph<> graph(num_nodes, arc_capacity);
 //
 // Storing and using node annotations:
 //   vector<bool> is_visited(graph.num_nodes(), false);
@@ -110,31 +108,45 @@
 //
 // More efficient version:
 //   typedef StaticGraph<> Graph;
-//   Graph graph(num_nodes, arc_capacity);  // Optional, but help memory usage.
+//   // Note: providing the arc capacity is optional, but helps memory usage.
+//   Graph::Builder graph_builder(num_nodes, arc_capacity);
 //   vector<int> weights;
 //   weights.reserve(arc_capacity);  // Optional, but help memory usage.
 //   for (...) {
-//     graph.AddArc(tail, head);
+//     graph_builder.AddArc(tail, head);
 //     weights.push_back(arc_weight);
 //   }
 //   ...
-//   vector<Graph::ArcIndex> permutation;
-//   graph.Build(&permutation);  // A static graph must be Build() before usage.
-//   Permute(permutation, &weights);  // Build() may permute the arc index.
+//   // Build() may permute the arc indices:
+//   const Graph graph = std::move(graph_builder).BuildAndPermute(weights);
 //   ...
+//
+//  Note on the permutation:
+//  - you can permute more than one vector at construction:
+//      std::vector<int> colors, normals;
+//      const Graph graph =
+//          std::move(graph_builder).BuildAndPermute(colors, normals);
+//  - you can also get the permutation explicitly with `Build()` and use it
+//    later:
+//      std::vector<int> permutation;
+//      const Graph graph = std::move(graph_builder).Build(&permutation);
+//      ...
 //
 // Encoding an undirected graph: If you don't need arc annotation, then the best
 // is to add two arcs for each edge (one in each direction) to a directed graph.
 // Otherwise you can do the following.
 //
 //   typedef ReverseArc... Graph;
-//   Graph graph;
+//   Graph::Builder graph_builder;
 //   for (...) {
-//     graph.AddArc(tail, head);  // or graph.AddArc(head, tail) but not both.
+//     graph_builder.AddArc(tail, head);  // or graph.AddArc(head, tail) but not
+//                                        // both.
 //     edge_annotations.push_back(value);
 //   }
+//   const Graph graph =
+//       std::move(graph_builder).BuildAndPermute(edge_annotations);
 //   ...
-//   for (const Graph::NodeIndex node : graph.AllNodes()) {
+//   for (const Graph::NodeIndex node : graph->AllNodes()) {
 //     for (const Graph::ArcIndex arc :
 //          graph.OutgoingOrOppositeIncomingArcs(node)) {
 //       destination = graph.Head(arc);
@@ -165,12 +177,17 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <initializer_list>
 #include <iterator>
 #include <limits>
+#include <memory>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "absl/base/attributes.h"
+#include "absl/base/macros.h"
+#include "absl/base/nullability.h"
 #include "absl/debugging/leak_check.h"
 #include "absl/log/check.h"
 #include "absl/types/span.h"
@@ -187,6 +204,113 @@ class SVector;
 template <typename IndexT, typename T>
 class Vector;
 
+// A base class for graph builders, that adds common functionality to all graph
+// builders.
+template <typename BuilderImpl, typename GraphImpl, typename NodeIndexType,
+          typename ArcIndexType>
+class GraphBuilderBase {
+ public:
+  // Builds the graph and permutes the given arc-indexed arrays so that they
+  // correspond to the arc indices of the built graph.
+  template <typename... ArcPropertyArray>
+  std::unique_ptr<GraphImpl> BuildAndPermute(
+      ArcPropertyArray&... arc_properties) &&;
+
+  // Builds the graph and returns it. If `permutation` is not nullptr, it is
+  // filled with the arc permutation if the graph implementation reorders arcs.
+  GraphImpl BuildGraph(
+      std::vector<ArcIndexType>* absl_nullable permutation) && {
+    return std::move(
+        *static_cast<BuilderImpl&&>(std::move(*this)).Build(permutation));
+  }
+
+  // Same as `BuildAndPermute()`, but returns a value.
+  template <typename... ArcPropertyArray>
+  GraphImpl BuildGraphAndPermute(ArcPropertyArray&... arc_properties) && {
+    return std::move(*std::move(*this).BuildAndPermute(arc_properties...));
+  }
+
+  void Reserve(NodeIndexType node_capacity, ArcIndexType arc_capacity) {
+    static_cast<BuilderImpl&>(*this).ReserveArcs(arc_capacity);
+    static_cast<BuilderImpl&>(*this).ReserveNodes(node_capacity);
+  }
+
+  // Reserving does nothing by default.
+  void ReserveNodes(NodeIndexType bound) {}
+  void ReserveArcs(ArcIndexType bound) {}
+
+  // The number of arcs added by the user. Might not be the same as the number
+  // of arcs in the built graph for some graph implementations (e.g.
+  // `FlowGraph`).
+  ArcIndexType num_arcs() const;
+
+  // The number of nodes added by the user. Might not be the same as the number
+  // of nodes in the built graph for some graph implementations.
+  NodeIndexType num_nodes();
+};
+
+// A graph builder for graphs that don't need building (e.g. `ListGraph`).
+// Simply forwards mutable calls to the underlying graph.
+// TODO(b/501313028): Remove once migration is over.
+template <typename Impl, typename NodeIndexType, typename ArcIndexType,
+          bool build_permutes_arcs>
+class MutableGraphBuilder
+    : public GraphBuilderBase<
+          MutableGraphBuilder<Impl, NodeIndexType, ArcIndexType,
+                              build_permutes_arcs>,
+          Impl, NodeIndexType, ArcIndexType> {
+  using Base =
+      GraphBuilderBase<MutableGraphBuilder<Impl, NodeIndexType, ArcIndexType,
+                                           build_permutes_arcs>,
+                       Impl, NodeIndexType, ArcIndexType>;
+
+ public:
+  static constexpr bool kBuildPermutesArcs = build_permutes_arcs;
+
+  MutableGraphBuilder() : graph_(std::make_unique<Impl>()) {}
+  MutableGraphBuilder(NodeIndexType num_nodes, ArcIndexType arc_capacity)
+      : graph_(std::make_unique<Impl>(num_nodes, arc_capacity)) {}
+
+  // TODO(b/501313028): This should be `= default` when we no longer mutate
+  // the graph.
+  MutableGraphBuilder(const MutableGraphBuilder& other) {
+    graph_ = std::make_unique<Impl>(*other.graph_);
+  }
+  MutableGraphBuilder& operator=(const MutableGraphBuilder& other) {
+    if (this == &other) return *this;
+    graph_ = std::make_unique<Impl>(*other.graph_);
+    return *this;
+  }
+  MutableGraphBuilder(MutableGraphBuilder&&) = default;
+  MutableGraphBuilder& operator=(MutableGraphBuilder&&) = default;
+
+  std::unique_ptr<Impl> Build(
+      std::vector<ArcIndexType>* absl_nullable permutation) && {
+    graph_->Build(permutation);
+    return std::move(graph_);
+  }
+
+  void AddNode(NodeIndexType node) { graph_->AddNode(node); }
+
+  ArcIndexType AddArc(NodeIndexType tail, NodeIndexType head) {
+    return graph_->AddArc(tail, head);
+  }
+
+  void ReserveNodes(NodeIndexType bound) { graph_->ReserveNodes(bound); }
+
+  void ReserveArcs(ArcIndexType bound) { graph_->ReserveArcs(bound); }
+
+  void FreezeCapacities() { graph_->FreezeCapacities(); }
+
+  NodeIndexType node_capacity() const { return graph_->node_capacity(); }
+  ArcIndexType arc_capacity() const { return graph_->arc_capacity(); }
+
+  ArcIndexType num_arcs() const { return graph_->num_arcs(); }
+  NodeIndexType num_nodes() const { return graph_->num_nodes(); }
+
+ protected:
+  std::unique_ptr<Impl> graph_;
+};
 }  // namespace internal
 
 // Base class of all Graphs implemented here. The default value for the graph
@@ -223,10 +347,13 @@ class BaseGraph  //
 
   virtual ~BaseGraph() = default;
 
-  // Returns the number of valid nodes in the graph. Prefer using num_nodes():
-  // the size() API is here to make Graph and vector<vector<int>> more alike.
+  // Returns the number of valid nodes in the graph.
   NodeIndexType num_nodes() const { return num_nodes_; }
-  NodeIndexType size() const { return num_nodes_; }  // Prefer num_nodes().
+
+  [[deprecated("Use num_nodes() instead")]] ABSL_REFACTOR_INLINE NodeIndexType
+  size() const {
+    return num_nodes();
+  }
 
   // Returns the number of valid arcs in the graph.
   ArcIndexType num_arcs() const { return num_arcs_; }
@@ -300,7 +427,7 @@ class BaseGraph  //
   //
   // Note that some implementations become immutable after calling Build().
   // By default, Build() is a no-op.
-  virtual void Build(std::vector<ArcIndexType>* permutation) {
+  virtual void Build(std::vector<ArcIndexType>* absl_nullable permutation) {
     if (permutation != nullptr) permutation->clear();
   }
   void Build() { Build(nullptr); }
@@ -318,9 +445,18 @@ class BaseGraph  //
   NodeIndexType node_capacity_;
   ArcIndexType num_arcs_;
   ArcIndexType arc_capacity_;
+  // TODO(b/501313028): This is only relevant for mutable graphs.
   bool const_capacities_;
 };
 
+// Provide a `size` overload so that `Graph` and `std::vector<std::vector<int>>`
+// are compatible.
+template <typename Impl, typename NodeIndexType, typename ArcIndexType,
+          bool HasNegativeReverseArcs>
+constexpr auto size(const BaseGraph<Impl, NodeIndexType, ArcIndexType,
+                                    HasNegativeReverseArcs>& graph) {
+  return graph.num_nodes();
+}
 // An iterator that wraps an arc iterator and retrieves a property of the arc.
 // The property to retrieve is specified by a `Graph` member function taking an
 // `ArcIndex` parameter. For example, `ArcHeadIterator` retrieves the head of an
@@ -621,7 +757,9 @@ class SVector {
 
 // Graph traits, to allow algorithms to manipulate graphs as adjacency lists.
 // This works with any graph type, and any object that has:
-// - a size() method returning the number of nodes.
+// - an ADL-compatible `size()` method returning the number of nodes. This
+//   includes any object with a `size()` method (e.g. `std::vector`), C-style
+//   arrays, ...
 // - an operator[] method taking a node index and returning a range of neighbour
 //   node indices.
 // One common example is using `std::vector<std::vector<int>>` to represent
@@ -629,9 +767,14 @@ class SVector {
 template <typename Graph>
 struct GraphTraits {
  private:
+  static constexpr auto num_nodes(const Graph& graph) {
+    using std::size;
+    return size(graph);
+  }
+
   // The type of the range returned by `operator[]`.
   using NeighborRangeType = std::decay_t<
-      decltype(std::declval<Graph>()[std::declval<Graph>().size()])>;
+      decltype(std::declval<Graph>()[num_nodes(std::declval<Graph>())])>;
 
  public:
   // The index type for nodes of the graph.
@@ -670,6 +813,8 @@ class ListGraph : public BaseGraph<ListGraph<NodeIndexType, ArcIndexType>,
   using Base::num_nodes_;
 
  public:
+  using Builder = internal::MutableGraphBuilder<ListGraph, NodeIndexType,
+                                                ArcIndexType, false>;
   using Base::IsArcValid;
   ListGraph() = default;
 
@@ -778,6 +923,9 @@ class StaticGraph : public BaseGraph<StaticGraph<NodeIndexType, ArcIndexType>,
   using Base::num_nodes_;
 
  public:
+  using Builder = internal::MutableGraphBuilder<StaticGraph, NodeIndexType,
+                                                ArcIndexType, true>;
+
   using Base::IsArcValid;
   StaticGraph() : is_built_(false), arc_in_order_(true), last_tail_seen_(0) {}
   StaticGraph(NodeIndexType num_nodes, ArcIndexType arc_capacity)
@@ -789,6 +937,7 @@ class StaticGraph : public BaseGraph<StaticGraph<NodeIndexType, ArcIndexType>,
     }
   }
 
+  // TODO(b/501313028): Use `GraphFromArcs()` instead.
   // Shortcut to directly create a finalized graph, i.e. Build() is called.
   template <class ArcContainer>  // e.g. vector<pair<int, int>>.
   static StaticGraph FromArcs(NodeIndexType num_nodes,
@@ -821,7 +970,7 @@ class StaticGraph : public BaseGraph<StaticGraph<NodeIndexType, ArcIndexType>,
   void AddNode(NodeIndexType node);
   ArcIndexType AddArc(NodeIndexType tail, NodeIndexType head);
 
-  void Build(std::vector<ArcIndexType>* permutation) final;
+  void Build(std::vector<ArcIndexType>* absl_nullable permutation) final;
   void Build() { Build(nullptr); }
   bool IsBuilt() const final { return is_built_; }
 
@@ -865,6 +1014,9 @@ class ReverseArcListGraph
   using Base::num_nodes_;
 
  public:
+  using Builder =
+      internal::MutableGraphBuilder<ReverseArcListGraph, NodeIndexType,
+                                    ArcIndexType, false>;
   using Base::IsArcValid;
   ReverseArcListGraph() = default;
   ReverseArcListGraph(NodeIndexType num_nodes, ArcIndexType arc_capacity) {
@@ -1001,6 +1153,9 @@ class ReverseArcStaticGraph
   using Base::num_nodes_;
 
  public:
+  using Builder =
+      internal::MutableGraphBuilder<ReverseArcStaticGraph, NodeIndexType,
+                                    ArcIndexType, true>;
   using Base::IsArcValid;
   ReverseArcStaticGraph() : is_built_(false) {}
   ReverseArcStaticGraph(NodeIndexType num_nodes, ArcIndexType arc_capacity)
@@ -1083,7 +1238,7 @@ class ReverseArcStaticGraph
   void AddNode(NodeIndexType node);
   ArcIndexType AddArc(NodeIndexType tail, NodeIndexType head);
 
-  void Build(std::vector<ArcIndexType>* permutation) final;
+  void Build(std::vector<ArcIndexType>* absl_nullable permutation) final;
   void Build() { Build(nullptr); }
   bool IsBuilt() const final { return is_built_; }
 
@@ -1131,12 +1286,30 @@ void Permute(const IntVector& permutation, Array* array_to_permute) {
       typename std::iterator_traits<decltype(std::begin(array))>::value_type;
   std::vector<ElementType> temp(size);
   auto array_begin = std::begin(array);
-  std::copy_n(array_begin, size, temp.begin());
+  std::move(array_begin, array_begin + size, temp.begin());
   for (size_t i = 0; i < permutation.size(); ++i) {
-    *(array_begin + static_cast<size_t>(permutation[i])) = temp[i];
+    *(array_begin + static_cast<size_t>(permutation[i])) = std::move(temp[i]);
   }
 }
-
+namespace internal {
+template <typename BuilderImpl, typename GraphImpl, typename NodeIndexType,
+          typename ArcIndexType>
+template <typename... ArcPropertyArray>
+std::unique_ptr<GraphImpl> GraphBuilderBase<
+    BuilderImpl, GraphImpl, NodeIndexType,
+    ArcIndexType>::BuildAndPermute(ArcPropertyArray&... arc_properties) && {
+  if constexpr (BuilderImpl::kBuildPermutesArcs) {
+    std::vector<ArcIndexType> permutation;
+    auto graph =
+        static_cast<BuilderImpl&&>(std::move(*this)).Build(&permutation);
+    (Permute(permutation, &arc_properties), ...);
+    return graph;
+  } else {
+    // Optimization: avoid permuting with an identity permutation.
+    return static_cast<BuilderImpl&&>(std::move(*this)).Build(nullptr);
+  }
+}
+}  // namespace internal
 // BaseGraph implementation ----------------------------------------------------
 
 template <typename Impl, typename NodeIndexType, typename ArcIndexType,
@@ -1385,10 +1558,9 @@ template <class ArcContainer>
 StaticGraph<NodeIndexType, ArcIndexType>
 StaticGraph<NodeIndexType, ArcIndexType>::FromArcs(NodeIndexType num_nodes,
                                                    const ArcContainer& arcs) {
-  StaticGraph g(num_nodes, arcs.size());
-  for (const auto& [from, to] : arcs) g.AddArc(from, to);
-  g.Build();
-  return g;
+  StaticGraph::Builder builder(num_nodes, arcs.size());
+  for (const auto& [from, to] : arcs) builder.AddArc(from, to);
+  return std::move(builder).BuildGraph(nullptr);
 }
 
 template <typename NodeIndexType, typename ArcIndexType>
@@ -2060,6 +2232,17 @@ CompleteBipartiteGraph<NodeIndexType, ArcIndexType>::operator[](
 
 // Defining the simplest Graph interface as Graph for convenience.
 typedef ListGraph<> Graph;
+
+// Creates a graph from a container of arcs.
+template <typename GraphT,
+          typename ArcContainer = std::initializer_list<std::pair<
+              typename GraphT::NodeIndex, typename GraphT::NodeIndex>>>
+GraphT GraphFromArcs(typename GraphT::NodeIndex num_nodes,
+                     const ArcContainer& arcs) {
+  typename GraphT::Builder builder(num_nodes, arcs.size());
+  for (const auto& [from, to] : arcs) builder.AddArc(from, to);
+  return std::move(builder).BuildGraph(nullptr);
+}
 
 }  // namespace util
 

--- a/ortools/graph_base/graph_generator.h
+++ b/ortools/graph_base/graph_generator.h
@@ -14,13 +14,13 @@
 #ifndef UTIL_GRAPH_GRAPH_GENERATOR_H_
 #define UTIL_GRAPH_GRAPH_GENERATOR_H_
 
+#include <utility>
+
 // Generates a complete undirected graph with `num_nodes` nodes.
 //
 // A complete graph is a graph in which all pairs of distinct nodes are
 // connected by an edge.
 // The graph is represented using the provided `Graph` template.
-// If the chosen graph type requires a call to `Build()`, the user is expected
-// to perform this call, possibly after tweaking the graph.
 //
 // Consider using `CompleteGraph` (util/graph/graph.h) instead of this function
 // in production code, as it uses constant memory to store the graph. Instead,
@@ -36,16 +36,16 @@
 template <typename Graph>
 Graph GenerateCompleteUndirectedGraph(
     const typename Graph::NodeIndex num_nodes) {
-  Graph graph;
-  graph.Reserve(num_nodes, num_nodes * (num_nodes - 1));
-  graph.AddNode(num_nodes - 1);  // Only for degenerate cases with no arcs.
+  typename Graph::Builder builder;
+  builder.Reserve(num_nodes, num_nodes * (num_nodes - 1));
+  builder.AddNode(num_nodes - 1);  // Only for degenerate cases with no arcs.
   for (typename Graph::NodeIndex src = 0; src < num_nodes; ++src) {
     for (typename Graph::NodeIndex dst = src + 1; dst < num_nodes; ++dst) {
-      graph.AddArc(src, dst);
-      graph.AddArc(dst, src);
+      builder.AddArc(src, dst);
+      builder.AddArc(dst, src);
     }
   }
-  return graph;
+  return std::move(*std::move(builder).Build(nullptr));
 }
 
 // Generates a complete undirected bipartite graph with `num_nodes_1` and
@@ -54,8 +54,6 @@ Graph GenerateCompleteUndirectedGraph(
 // A complete bipartite graph is a graph in which all pairs of distinct nodes,
 // one in each part, are connected by an edge.
 // The graph is represented using the provided `Graph` template.
-// If the chosen graph type requires a call to `Build()`, the user is expected
-// to perform this call, possibly after tweaking the graph.
 //
 // Args:
 //   num_nodes_1: The number of nodes in the first part of the graph.
@@ -67,16 +65,16 @@ template <typename Graph>
 Graph GenerateCompleteUndirectedBipartiteGraph(
     const typename Graph::NodeIndex num_nodes_1,
     const typename Graph::NodeIndex num_nodes_2) {
-  Graph graph;
-  graph.Reserve(num_nodes_1 + num_nodes_2, 2 * num_nodes_1 * num_nodes_2);
-  graph.AddNode(num_nodes_1 + num_nodes_2 - 1);  // Only for degenerate cases.
+  typename Graph::Builder builder;
+  builder.Reserve(num_nodes_1 + num_nodes_2, 2 * num_nodes_1 * num_nodes_2);
+  builder.AddNode(num_nodes_1 + num_nodes_2 - 1);  // Only for degenerate cases.
   for (typename Graph::NodeIndex src = 0; src < num_nodes_1; ++src) {
     for (typename Graph::NodeIndex dst = 0; dst < num_nodes_2; ++dst) {
-      graph.AddArc(src, num_nodes_1 + dst);
-      graph.AddArc(num_nodes_1 + dst, src);
+      builder.AddArc(src, num_nodes_1 + dst);
+      builder.AddArc(num_nodes_1 + dst, src);
     }
   }
-  return graph;
+  return std::move(*std::move(builder).Build(nullptr));
 }
 
 // Generates a complete directed bipartite graph with `num_nodes_1` and
@@ -86,8 +84,6 @@ Graph GenerateCompleteUndirectedBipartiteGraph(
 // one in each part, are connected by an edge. Edges are directed from the first
 // part towards the second part.
 // The graph is represented using the provided `Graph` template.
-// If the chosen graph type requires a call to `Build()`, the user is expected
-// to perform this call, possibly after tweaking the graph.
 //
 // Consider using `CompleteBipartiteGraph` (util/graph/graph.h) instead of this
 // function in production code, as it uses constant memory to store the graph.
@@ -105,15 +101,15 @@ template <typename Graph>
 Graph GenerateCompleteDirectedBipartiteGraph(
     const typename Graph::NodeIndex num_nodes_1,
     const typename Graph::NodeIndex num_nodes_2) {
-  Graph graph;
-  graph.Reserve(num_nodes_1 + num_nodes_2, num_nodes_1 * num_nodes_2);
-  graph.AddNode(num_nodes_1 + num_nodes_2 - 1);  // Only for degenerate cases.
+  typename Graph::Builder builder;
+  builder.Reserve(num_nodes_1 + num_nodes_2, num_nodes_1 * num_nodes_2);
+  builder.AddNode(num_nodes_1 + num_nodes_2 - 1);  // Only for degenerate cases.
   for (typename Graph::NodeIndex src = 0; src < num_nodes_1; ++src) {
     for (typename Graph::NodeIndex dst = 0; dst < num_nodes_2; ++dst) {
-      graph.AddArc(src, num_nodes_1 + dst);
+      builder.AddArc(src, num_nodes_1 + dst);
     }
   }
-  return graph;
+  return std::move(*std::move(builder).Build(nullptr));
 }
 
 #endif  // UTIL_GRAPH_GRAPH_GENERATOR_H_

--- a/ortools/graph_base/graph_generator_test.cc
+++ b/ortools/graph_base/graph_generator_test.cc
@@ -44,7 +44,6 @@ TYPED_TEST_SUITE(GenerateCompleteUndirectedGraphTest,
 
 TYPED_TEST(GenerateCompleteUndirectedGraphTest, SimpleGraph) {
   TypeParam graph = GenerateCompleteUndirectedGraph<TypeParam>(3);
-  graph.Build();
 
   EXPECT_EQ(graph.num_nodes(), 3);
   EXPECT_EQ(graph.num_arcs(), 6);
@@ -58,7 +57,6 @@ TYPED_TEST(GenerateCompleteUndirectedGraphTest, SimpleGraph) {
 
 TYPED_TEST(GenerateCompleteUndirectedGraphTest, SmallestGraph) {
   TypeParam graph = GenerateCompleteUndirectedGraph<TypeParam>(1);
-  graph.Build();
 
   EXPECT_EQ(graph.num_nodes(), 1);
   EXPECT_EQ(graph.num_arcs(), 0);
@@ -75,7 +73,6 @@ TYPED_TEST_SUITE(GenerateCompleteUndirectedBipartiteGraphTest,
 
 TYPED_TEST(GenerateCompleteUndirectedBipartiteGraphTest, SimpleGraph) {
   TypeParam graph = GenerateCompleteUndirectedBipartiteGraph<TypeParam>(2, 3);
-  graph.Build();
 
   EXPECT_EQ(graph.num_nodes(), 5);
   EXPECT_EQ(graph.num_arcs(), 12);
@@ -96,7 +93,6 @@ TYPED_TEST_SUITE(GenerateCompleteDirectedBipartiteGraphTest,
 
 TYPED_TEST(GenerateCompleteDirectedBipartiteGraphTest, SimpleGraph) {
   TypeParam graph = GenerateCompleteDirectedBipartiteGraph<TypeParam>(2, 3);
-  graph.Build();
 
   EXPECT_EQ(graph.num_nodes(), 5);
   EXPECT_EQ(graph.num_arcs(), 6);
@@ -109,7 +105,6 @@ TYPED_TEST(GenerateCompleteDirectedBipartiteGraphTest, SimpleGraph) {
 
 TYPED_TEST(GenerateCompleteDirectedBipartiteGraphTest, SimplSmallestGraphLeft) {
   TypeParam graph = GenerateCompleteDirectedBipartiteGraph<TypeParam>(1, 0);
-  graph.Build();
 
   EXPECT_EQ(graph.num_nodes(), 1);
   EXPECT_EQ(graph.num_arcs(), 0);
@@ -119,7 +114,6 @@ TYPED_TEST(GenerateCompleteDirectedBipartiteGraphTest, SimplSmallestGraphLeft) {
 TYPED_TEST(GenerateCompleteDirectedBipartiteGraphTest,
            SimplSmallestGraphRight) {
   TypeParam graph = GenerateCompleteDirectedBipartiteGraph<TypeParam>(0, 1);
-  graph.Build();
 
   EXPECT_EQ(graph.num_nodes(), 1);
   EXPECT_EQ(graph.num_arcs(), 0);

--- a/ortools/graph_base/graph_test.cc
+++ b/ortools/graph_base/graph_test.cc
@@ -43,6 +43,7 @@ using testing::AllOf;
 using testing::ElementsAre;
 using testing::Field;
 using testing::Pair;
+using testing::Pointee;
 using testing::UnorderedElementsAre;
 
 DEFINE_STRONG_INT_TYPE(StrongNodeId, int32_t);
@@ -262,29 +263,22 @@ void ConstructAndCheckGraph(
     bool test_permutation) {
   using NodeIndex = typename GraphType::NodeIndex;
   using ArcIndex = typename GraphType::ArcIndex;
-  std::unique_ptr<GraphType> graph;
-  if (reserve) {
-    graph.reset(new GraphType(num_nodes, num_arcs));
-  } else {
-    graph.reset(new GraphType());
-  }
+  auto builder = reserve ? typename GraphType::Builder(num_nodes, num_arcs)
+                         : typename GraphType::Builder();
   std::vector<std::vector<NodeIndex>> verifier(static_cast<size_t>(num_nodes));
 
   for (ArcIndex i(0); i < num_arcs; ++i) {
     NodeIndex head = heads[static_cast<size_t>(i)];
     NodeIndex tail = tails[static_cast<size_t>(i)];
-    EXPECT_EQ(i, graph->AddArc(tail, head));
+    EXPECT_EQ(i, builder.AddArc(tail, head));
     verifier[static_cast<size_t>(tail)].push_back(head);
   }
   std::vector<typename GraphType::ArcIndex> permutation;
-  if (test_permutation) {
-    graph->Build(&permutation);
-  } else {
-    graph->Build();
-  }
+  const auto graph =
+      std::move(builder).Build(test_permutation ? &permutation : nullptr);
 
   EXPECT_EQ(num_nodes, graph->num_nodes());
-  EXPECT_EQ(num_nodes, graph->size());
+  EXPECT_EQ(num_nodes, size(*graph));
   EXPECT_EQ(num_arcs, graph->num_arcs());
   CheckOutgoingArcIterator(*graph, verifier);
   CheckOutgoingHeadIterator(*graph, verifier);
@@ -751,40 +745,39 @@ TYPED_TEST_SUITE(GenericGraphInterfaceTest, GraphType);
 TYPED_TEST(GenericGraphInterfaceTest, EmptyGraph) {
   using NodeIndex = typename TypeParam::NodeIndex;
   using ArcIndex = typename TypeParam::ArcIndex;
-  TypeParam graph;
-  graph.Build();
-  EXPECT_EQ(NodeIndex(0), graph.num_nodes());
-  EXPECT_EQ(NodeIndex(0), graph.size());
-  EXPECT_EQ(ArcIndex(0), graph.num_arcs());
+  const auto graph = typename TypeParam::Builder().Build(nullptr);
+  EXPECT_EQ(NodeIndex(0), graph->num_nodes());
+  EXPECT_EQ(NodeIndex(0), size(*graph));
+  EXPECT_EQ(ArcIndex(0), graph->num_arcs());
 }
 
 TYPED_TEST(GenericGraphInterfaceTest, EmptyGraphAlternateSyntax) {
   using NodeIndex = typename TypeParam::NodeIndex;
   using ArcIndex = typename TypeParam::ArcIndex;
-  TypeParam graph(NodeIndex(0), ArcIndex(0));
-  graph.Build();
-  EXPECT_EQ(NodeIndex(0), graph.num_nodes());
-  EXPECT_EQ(NodeIndex(0), graph.size());
-  EXPECT_EQ(ArcIndex(0), graph.num_arcs());
+  const auto graph =
+      typename TypeParam::Builder(NodeIndex(0), ArcIndex(0)).Build(nullptr);
+  EXPECT_EQ(NodeIndex(0), graph->num_nodes());
+  EXPECT_EQ(NodeIndex(0), size(*graph));
+  EXPECT_EQ(ArcIndex(0), graph->num_arcs());
 }
 
 TYPED_TEST(GenericGraphInterfaceTest, GraphWithNodesButNoArc) {
   using NodeIndex = typename TypeParam::NodeIndex;
   using ArcIndex = typename TypeParam::ArcIndex;
   const NodeIndex kNodes(1000);
-  TypeParam graph(kNodes, ArcIndex(0));
-  graph.Build();
-  EXPECT_EQ(kNodes, graph.num_nodes());
-  EXPECT_EQ(kNodes, graph.size());
-  EXPECT_EQ(ArcIndex(0), graph.num_arcs());
+  const auto graph =
+      typename TypeParam::Builder(kNodes, ArcIndex(0)).Build(nullptr);
+  EXPECT_EQ(kNodes, graph->num_nodes());
+  EXPECT_EQ(kNodes, size(*graph));
+  EXPECT_EQ(ArcIndex(0), graph->num_arcs());
   int count = 0;
-  for (const NodeIndex node : graph.AllNodes()) {
-    for ([[maybe_unused]] const ArcIndex arc : graph.OutgoingArcs(node)) {
+  for (const NodeIndex node : graph->AllNodes()) {
+    for ([[maybe_unused]] const ArcIndex arc : graph->OutgoingArcs(node)) {
       ++count;
     }
   }
   EXPECT_EQ(0, count);
-  for ([[maybe_unused]] const ArcIndex arc : graph.AllForwardArcs()) {
+  for ([[maybe_unused]] const ArcIndex arc : graph->AllForwardArcs()) {
     ++count;
   }
   EXPECT_EQ(0, count);
@@ -841,32 +834,33 @@ TYPED_TEST(GenericGraphInterfaceTest, BuildWithOrderedArc) {
 
 TYPED_TEST(GenericGraphInterfaceTest, PastTheEndIterators) {
   using NodeIndex = typename TypeParam::NodeIndex;
-  TypeParam graph;
-  graph.AddArc(NodeIndex(0), NodeIndex(1));
-  graph.AddArc(NodeIndex(0), NodeIndex(2));
-  graph.AddArc(NodeIndex(0), NodeIndex(3));
-  graph.AddArc(NodeIndex(3), NodeIndex(4));
-  graph.AddArc(NodeIndex(1), NodeIndex(4));
-  graph.Build();
+  typename TypeParam::Builder builder;
+  builder.AddArc(NodeIndex(0), NodeIndex(1));
+  builder.AddArc(NodeIndex(0), NodeIndex(2));
+  builder.AddArc(NodeIndex(0), NodeIndex(3));
+  builder.AddArc(NodeIndex(3), NodeIndex(4));
+  builder.AddArc(NodeIndex(1), NodeIndex(4));
+  const auto graph = std::move(builder).Build(nullptr);
   for (NodeIndex i(0); i < NodeIndex(4); ++i) {
-    EXPECT_EQ(graph.OutgoingArcsStartingFrom(i, TypeParam::kNilArc).end(),
-              graph.OutgoingArcs(i).end());
+    EXPECT_EQ(graph->OutgoingArcsStartingFrom(i, TypeParam::kNilArc).end(),
+              graph->OutgoingArcs(i).end());
     if constexpr (TypeParam::kHasNegativeReverseArcs) {
-      EXPECT_EQ(graph.IncomingArcsStartingFrom(i, TypeParam::kNilArc).end(),
-                graph.IncomingArcs(i).end());
+      EXPECT_EQ(graph->IncomingArcsStartingFrom(i, TypeParam::kNilArc).end(),
+                graph->IncomingArcs(i).end());
       EXPECT_EQ(
-          graph.OppositeIncomingArcsStartingFrom(i, TypeParam::kNilArc).end(),
-          graph.OppositeIncomingArcs(i).end());
-      EXPECT_EQ(
-          graph
-              .OutgoingOrOppositeIncomingArcsStartingFrom(i, TypeParam::kNilArc)
-              .end(),
-          typename TypeParam::OutgoingOrOppositeIncomingArcIterator(
-              graph, i, TypeParam::kNilArc));
+          graph->OppositeIncomingArcsStartingFrom(i, TypeParam::kNilArc).end(),
+          graph->OppositeIncomingArcs(i).end());
+      EXPECT_EQ(graph
+                    ->OutgoingOrOppositeIncomingArcsStartingFrom(
+                        i, TypeParam::kNilArc)
+                    .end(),
+                typename TypeParam::OutgoingOrOppositeIncomingArcIterator(
+                    *graph, i, TypeParam::kNilArc));
     }
   }
 }
 
+// TODO(b/501313028): Remove once graphs are always built.
 TEST(StaticGraphTest, HeadAndTailBeforeAndAfterBuild) {
   for (const bool poll_in_the_middle_of_construction : {false, true}) {
     for (const bool build : {false, true}) {
@@ -921,7 +915,7 @@ TEST(StaticGraphTest, FromArcs) {
   const std::vector<std::pair<int, int>> arcs = {{1, 2}, {1, 0}};
   StaticGraph<> graph = StaticGraph<>::FromArcs(3, arcs);
   EXPECT_EQ(3, graph.num_nodes());
-  EXPECT_EQ(3, graph.size());
+  EXPECT_EQ(3, size(graph));
   EXPECT_EQ(2, graph.num_arcs());
   std::vector<std::pair<int, int>> read_arcs;
   for (const auto arc : graph.AllForwardArcs()) {
@@ -933,7 +927,7 @@ TEST(StaticGraphTest, FromArcs) {
 TEST(CompleteGraphTest, EmptyGraph) {
   CompleteGraph<> graph(0);
   EXPECT_EQ(0, graph.num_nodes());
-  EXPECT_EQ(0, graph.size());
+  EXPECT_EQ(0, size(graph));
   EXPECT_EQ(0, graph.num_arcs());
   for (const auto arc : graph.AllForwardArcs()) {
     EXPECT_TRUE(false);
@@ -944,7 +938,7 @@ TEST(CompleteGraphTest, EmptyGraph) {
 TEST(CompleteGraphTest, OneNodeGraph) {
   CompleteGraph<> graph(1);
   EXPECT_EQ(1, graph.num_nodes());
-  EXPECT_EQ(1, graph.size());
+  EXPECT_EQ(1, size(graph));
   EXPECT_EQ(1, graph.num_arcs());
   EXPECT_EQ(graph.Head(0), 0);
   EXPECT_EQ(graph.Tail(0), 0);
@@ -954,7 +948,7 @@ TEST(CompleteGraphTest, NonEmptyGraph) {
   static const int kNumNodes = 5;
   CompleteGraph<> graph(kNumNodes);
   EXPECT_EQ(kNumNodes, graph.num_nodes());
-  EXPECT_EQ(kNumNodes, graph.size());
+  EXPECT_EQ(kNumNodes, size(graph));
   EXPECT_EQ(kNumNodes * kNumNodes, graph.num_arcs());
   int count = 0;
   for (const auto arc : graph.AllForwardArcs()) {
@@ -984,7 +978,7 @@ TEST(CompleteGraphTest, NonEmptyGraph) {
 TEST(CompleteBipartiteGraphTest, EmptyGraph) {
   CompleteBipartiteGraph<> graph(0, 0);
   EXPECT_EQ(0, graph.num_nodes());
-  EXPECT_EQ(0, graph.size());
+  EXPECT_EQ(0, size(graph));
   EXPECT_EQ(0, graph.num_arcs());
   EXPECT_TRUE(graph.AllForwardArcs().empty());
 }
@@ -992,7 +986,7 @@ TEST(CompleteBipartiteGraphTest, EmptyGraph) {
 TEST(CompleteBipartiteGraphTest, OneRightNodeGraph) {
   CompleteBipartiteGraph<> graph(3, 1);
   EXPECT_EQ(4, graph.num_nodes());
-  EXPECT_EQ(4, graph.size());
+  EXPECT_EQ(4, size(graph));
   EXPECT_EQ(3, graph.num_arcs());
   EXPECT_EQ(graph.Head(0), 3);
   EXPECT_EQ(graph.Head(1), 3);
@@ -1007,7 +1001,7 @@ TEST(CompleteBipartiteGraphTest, NonEmptyGraph) {
   static const int kNumLeftNodes = 3;
   CompleteBipartiteGraph<> graph(kNumLeftNodes, kNumRightNodes);
   EXPECT_EQ(kNumLeftNodes + kNumRightNodes, graph.num_nodes());
-  EXPECT_EQ(graph.num_nodes(), graph.size());
+  EXPECT_EQ(graph.num_nodes(), size(graph));
   EXPECT_EQ(kNumLeftNodes * kNumRightNodes, graph.num_arcs());
   int count = 0;
   for (const auto arc : graph.AllForwardArcs()) {
@@ -1046,7 +1040,7 @@ TEST(CompleteBipartiteGraphTest, Overflow) {
   constexpr NodeIndex kNumNodes = std::numeric_limits<NodeIndex>::max() / 2;
   Graph graph(kNumNodes, kNumNodes);
   EXPECT_EQ(2 * kNumNodes, graph.num_nodes());
-  EXPECT_EQ(graph.num_nodes(), graph.size());
+  EXPECT_EQ(graph.num_nodes(), size(graph));
   EXPECT_EQ(kNumNodes * kNumNodes, graph.num_arcs());
   constexpr uint64_t kLeft = kNumNodes - 3;
   constexpr uint64_t kRight = kNumNodes + kNumNodes - 2;
@@ -1086,6 +1080,47 @@ TEST(Permute, StrongVector) {
   EXPECT_THAT(array, ElementsAre(4, 6, 5));
 }
 
+class TestGraphBuilder
+    : public internal::GraphBuilderBase<TestGraphBuilder, ListGraph<int, int>,
+                                        int, int> {
+ public:
+  static constexpr bool kBuildPermutesArcs = true;
+
+  explicit TestGraphBuilder(std::vector<int> permutation)
+      : permutation_(std::move(permutation)) {}
+
+  std::unique_ptr<ListGraph<int, int>> Build(std::vector<int>* permutation) && {
+    *permutation = std::move(permutation_);
+    return nullptr;
+  }
+
+ private:
+  std::vector<int> permutation_;
+};
+
+TEST(BuildAndPermuteTest, Works) {
+  TestGraphBuilder builder({0, 2, 1});
+  int array[] = {4, 5, 6};
+  std::vector<bool> bool_vector = {true, false, true};
+  util_intops::StrongVector<StrongArcId, int> strong_vector = {4, 5, 6};
+  std::unique_ptr<int> unique_ptr_array[] = {std::make_unique<int>(4),
+                                             std::make_unique<int>(5),
+                                             std::make_unique<int>(6)};
+  auto graph = std::move(builder).BuildAndPermute(
+      array, bool_vector, strong_vector, unique_ptr_array);
+  EXPECT_THAT(array, ElementsAre(4, 6, 5));
+  EXPECT_THAT(bool_vector, ElementsAre(true, true, false));
+  EXPECT_THAT(strong_vector, ElementsAre(4, 6, 5));
+  EXPECT_THAT(unique_ptr_array,
+              ElementsAre(Pointee(4), Pointee(6), Pointee(5)));
+}
+
+template <typename Graph>
+class BMGraphBuilder : public Graph::Builder {
+  using Base = Graph::Builder;
+  using Base::Base;
+};
+
 template <typename GraphType, bool reserve>
 static void BM_RandomArcs(benchmark::State& state) {
   const int kRandomSeed = 0;
@@ -1093,16 +1128,16 @@ static void BM_RandomArcs(benchmark::State& state) {
   const int kArcs = 5 * kNodes;
   int items_processed = 0;
   for (auto _ : state) {
-    GraphType graph;
+    BMGraphBuilder<GraphType> builder;
     if (reserve) {
-      graph.Reserve(kNodes, kArcs);
+      builder.Reserve(kNodes, kArcs);
     }
     std::mt19937 randomizer(kRandomSeed);
     for (int i = 0; i < kArcs; ++i) {
-      graph.AddArc(absl::Uniform<int32_t>(randomizer, 0, kNodes),
-                   absl::Uniform<int32_t>(randomizer, 0, kNodes));
+      builder.AddArc(absl::Uniform<int32_t>(randomizer, 0, kNodes),
+                     absl::Uniform<int32_t>(randomizer, 0, kNodes));
     }
-    graph.Build();
+    const auto graph = std::move(builder).Build(nullptr);
     items_processed += kArcs;
   }
   state.SetItemsProcessed(items_processed);
@@ -1116,17 +1151,17 @@ static void BM_OrderedArcs(benchmark::State& state) {
   const int kArcs = kDegree * kNodes;
   int items_processed = 0;
   for (auto _ : state) {
-    GraphType graph;
+    BMGraphBuilder<GraphType> builder;
     if (reserve) {
-      graph.Reserve(kNodes, kArcs);
+      builder.Reserve(kNodes, kArcs);
     }
     std::mt19937 randomizer(kRandomSeed);
     for (int i = 0; i < kNodes; ++i) {
       for (int j = 0; j < kDegree; ++j) {
-        graph.AddArc(i, absl::Uniform<int32_t>(randomizer, 0, kNodes));
+        builder.AddArc(i, absl::Uniform<int32_t>(randomizer, 0, kNodes));
       }
     }
-    graph.Build();
+    const auto graph = std::move(builder).Build(nullptr);
     items_processed += kArcs;
   }
   state.SetItemsProcessed(items_processed);
@@ -1142,14 +1177,14 @@ static void BM_RandomArcsBeforeBuild(benchmark::State& state) {
   const int kArcs = 5 * kNodes;
   int items_processed = 0;
   for (auto _ : state) {
-    GraphType graph;
+    BMGraphBuilder<GraphType> builder;
     if (reserve) {
-      graph.Reserve(kNodes, kArcs);
+      builder.Reserve(kNodes, kArcs);
     }
     std::mt19937 randomizer(kRandomSeed);
     for (int i = 0; i < kArcs; ++i) {
-      graph.AddArc(absl::Uniform<int32_t>(randomizer, 0, kNodes),
-                   absl::Uniform<int32_t>(randomizer, 0, kNodes));
+      builder.AddArc(absl::Uniform<int32_t>(randomizer, 0, kNodes),
+                     absl::Uniform<int32_t>(randomizer, 0, kNodes));
     }
     items_processed += kArcs;
   }
@@ -1159,18 +1194,25 @@ static void BM_RandomArcsBeforeBuild(benchmark::State& state) {
 // A basic vector<vector<>> graph implementation that many people uses. It is
 // quite slower and use more memory than a static graph, except maybe during
 // construction.
-class VectorVectorGraph {
+using VectorVectorGraph = std::vector<std::vector<int32_t>>;
+
+template <>
+class BMGraphBuilder<VectorVectorGraph> {
  public:
-  VectorVectorGraph() = default;
+  BMGraphBuilder() : graph_(std::make_unique<VectorVectorGraph>()) {}
+
   void Reserve(int32_t num_nodes, int32_t num_arcs) {
-    // We could only reserve the space, but AddArc() need to be smarter then.
-    graph_.resize(num_nodes);
+    graph_->resize(num_nodes);
   }
-  void Build() {}
-  void AddArc(int32_t tail, int32_t head) { graph_[tail].push_back(head); }
+
+  void AddArc(int32_t tail, int32_t head) { (*graph_)[tail].push_back(head); }
+
+  std::unique_ptr<VectorVectorGraph> Build(nullptr_t) && {
+    return std::move(graph_);
+  }
 
  private:
-  std::vector<std::vector<int32_t>> graph_;
+  std::unique_ptr<VectorVectorGraph> graph_;
 };
 
 #define RESERVE true
@@ -1202,23 +1244,23 @@ BENCHMARK_TEMPLATE2(BM_RandomArcs, ReverseArcStaticGraph<>, NO_RESERVE);
 #undef NO_RESERVE
 
 template <typename GraphType>
-void BuildGraphForIterationsBenchmarks(GraphType* graph) {
+GraphType BuildGraphForIterationsBenchmarks() {
   const int kRandomSeed = 0;
   const int kNodes = 10 * 1000 * 1000;
   const int kArcs = 5 * kNodes;
-  graph->Reserve(kNodes, kArcs);
+  typename GraphType::Builder builder;
+  builder.Reserve(kNodes, kArcs);
   std::mt19937 randomizer(kRandomSeed);
   for (int i = 0; i < kArcs; ++i) {
-    graph->AddArc(absl::Uniform<int32_t>(randomizer, 0, kNodes),
-                  absl::Uniform<int32_t>(randomizer, 0, kNodes));
+    builder.AddArc(absl::Uniform<int32_t>(randomizer, 0, kNodes),
+                   absl::Uniform<int32_t>(randomizer, 0, kNodes));
   }
-  graph->Build();
+  return std::move(builder).BuildGraph(nullptr);
 }
 
 template <typename GraphType>
 static void BM_OutgoingIterations(benchmark::State& state) {
-  GraphType graph;
-  BuildGraphForIterationsBenchmarks(&graph);
+  const auto graph = BuildGraphForIterationsBenchmarks<GraphType>();
   int64_t num_arcs = 0;
   int64_t some_work = 0;
   for (auto _ : state) {
@@ -1240,8 +1282,7 @@ BENCHMARK_TEMPLATE(BM_OutgoingIterations, ReverseArcStaticGraph<>);
 
 template <typename GraphType>
 static void BM_IncomingIterations(benchmark::State& state) {
-  GraphType graph;
-  BuildGraphForIterationsBenchmarks(&graph);
+  const auto graph = BuildGraphForIterationsBenchmarks<GraphType>();
   int64_t num_arcs = 0;
   int64_t some_work = 0;
   for (auto _ : state) {
@@ -1261,8 +1302,7 @@ BENCHMARK_TEMPLATE(BM_IncomingIterations, ReverseArcStaticGraph<>);
 
 template <typename GraphType>
 static void BM_OppositeIncomingIterations(benchmark::State& state) {
-  GraphType graph;
-  BuildGraphForIterationsBenchmarks(&graph);
+  const auto graph = BuildGraphForIterationsBenchmarks<GraphType>();
   int64_t num_arcs = 0;
   int64_t some_work = 0;
   for (auto _ : state) {
@@ -1282,8 +1322,7 @@ BENCHMARK_TEMPLATE(BM_OppositeIncomingIterations, ReverseArcStaticGraph<>);
 
 template <typename GraphType>
 static void BM_OutgoingOrOppositeIncomingIterations(benchmark::State& state) {
-  GraphType graph;
-  BuildGraphForIterationsBenchmarks(&graph);
+  const auto graph = BuildGraphForIterationsBenchmarks<GraphType>();
   int64_t num_arcs = 0;
   for (auto _ : state) {
     for (int node = 0; node < graph.num_nodes(); ++node) {
@@ -1306,8 +1345,7 @@ BENCHMARK_TEMPLATE(BM_OutgoingOrOppositeIncomingIterations,
 template <typename GraphType>
 static void BM_OutgoingOrOppositeIncomingIterationsTwoLoops(
     benchmark::State& state) {
-  GraphType graph;
-  BuildGraphForIterationsBenchmarks(&graph);
+  const auto graph = BuildGraphForIterationsBenchmarks<GraphType>();
   for (auto _ : state) {
     for (int node = 0; node < graph.num_nodes(); ++node) {
       const auto work = [&graph](int arc) {
@@ -1331,8 +1369,7 @@ BENCHMARK_TEMPLATE(BM_OutgoingOrOppositeIncomingIterationsTwoLoops,
 
 template <typename GraphType>
 static void BM_IntegralTypeCopy(benchmark::State& state) {
-  GraphType graph;
-  BuildGraphForIterationsBenchmarks(&graph);
+  const auto graph = BuildGraphForIterationsBenchmarks<GraphType>();
 
   for (auto s : state) {
     GraphType copied;

--- a/ortools/graph_base/random_graph.cc
+++ b/ortools/graph_base/random_graph.cc
@@ -24,76 +24,58 @@
 #include "absl/memory/memory.h"
 #include "absl/random/bit_gen_ref.h"
 #include "absl/random/random.h"
-#include "ortools/base/types.h"
+#include "ortools/graph_base/graph.h"
 
 namespace util {
 
 namespace {
-// This function initializes the graph used by GenerateRandomMultiGraph() and
-// GenerateRandomMultiGraph(), given their arguments.
-// See the .h for documentation on those arguments.
-std::unique_ptr<StaticGraph<>> CreateGraphMaybeReserved(int num_nodes,
-                                                        int num_arcs,
-                                                        bool finalized,
-                                                        absl::BitGenRef gen) {
-  std::unique_ptr<StaticGraph<>> graph;
-  // We either "reserve" the number of nodes and arcs or not, depending on
-  // randomness and on the "finalized" bit (if false, we can't assume that the
-  // user won't add some nodes or arcs after we return the graph, so we can't
-  // cap those).
-  if (finalized && absl::Bernoulli(gen, 1.0 / 2)) {
-    graph = std::make_unique<StaticGraph<>>(num_nodes, num_arcs);
-  } else {
-    graph = std::make_unique<StaticGraph<>>();
-    graph->AddNode(num_nodes - 1);
-  }
-  return graph;
+// Creates a builder and reserves arcs, but does not freeze capacity to allow
+// for growth.
+StaticGraph<>::Builder CreateBuilder(int num_nodes, int num_arcs) {
+  StaticGraph<>::Builder builder;
+  builder.Reserve(num_nodes, num_arcs);
+  builder.AddNode(num_nodes - 1);
+  return builder;
 }
 }  // namespace
 
-std::unique_ptr<StaticGraph<>> GenerateRandomMultiGraph(int num_nodes,
-                                                        int num_arcs,
-                                                        bool finalized,
-                                                        absl::BitGenRef gen) {
-  std::unique_ptr<StaticGraph<>> graph =
-      CreateGraphMaybeReserved(num_nodes, num_arcs, finalized, gen);
+StaticGraph<>::Builder GenerateRandomMultiGraph(int num_nodes, int num_arcs,
+                                                absl::BitGenRef gen) {
+  StaticGraph<>::Builder builder = CreateBuilder(num_nodes, num_arcs);
   if (num_nodes != 0) {
     CHECK_GT(num_nodes, 0);
     CHECK_GE(num_arcs, 0);
-    graph->AddNode(num_nodes - 1);
+    builder.AddNode(num_nodes - 1);
     for (int a = 0; a < num_arcs; ++a) {
-      graph->AddArc(absl::Uniform(gen, 0, num_nodes),
-                    absl::Uniform(gen, 0, num_nodes));
+      builder.AddArc(absl::Uniform(gen, 0, num_nodes),
+                     absl::Uniform(gen, 0, num_nodes));
     }
   } else {
     CHECK_EQ(num_arcs, 0);
   }
-  if (finalized) graph->Build();
-  return graph;
+  return builder;
 }
 
 namespace {
 // Parameterized method to generate both directed and undirected simple graphs.
-std::unique_ptr<StaticGraph<>> GenerateRandomSimpleGraph(int num_nodes,
-                                                         int num_arcs,
-                                                         bool finalized,
-                                                         bool directed,
-                                                         absl::BitGenRef gen) {
+StaticGraph<>::Builder GenerateRandomSimpleGraph(int num_nodes, int num_arcs,
+                                                 bool directed,
+                                                 absl::BitGenRef gen) {
   CHECK_GE(num_nodes, 0);
   // For an undirected graph, the number of arcs should be even: a->b and b->a.
   CHECK(directed || (num_arcs % 2 == 0));
   const int64_t max_num_arcs =
       static_cast<int64_t>(num_nodes) * (num_nodes - 1);
   CHECK_LE(num_arcs, max_num_arcs);
-  std::unique_ptr<StaticGraph<>> graph =
-      CreateGraphMaybeReserved(num_nodes, num_arcs, finalized, gen);
+  StaticGraph<>::Builder builder = CreateBuilder(num_nodes, num_arcs);
 
   // If the number of arcs is greater than half the possible arcs of the graph,
   // we generate the inverse graph and convert non-arcs to arcs.
   if (num_arcs > max_num_arcs / 2) {
     std::unique_ptr<StaticGraph<>> inverse_graph =
-        GenerateRandomSimpleGraph(num_nodes, max_num_arcs - num_arcs,
-                                  /*finalized=*/true, directed, gen);
+        GenerateRandomSimpleGraph(num_nodes, max_num_arcs - num_arcs, directed,
+                                  gen)
+            .Build(nullptr);
     std::vector<bool> node_mask(num_nodes, false);
     for (int from = 0; from < num_nodes; ++from) {
       for (const int to : (*inverse_graph)[from]) {
@@ -103,12 +85,11 @@ std::unique_ptr<StaticGraph<>> GenerateRandomSimpleGraph(int num_nodes,
         if (node_mask[to]) {
           node_mask[to] = false;  // So that the mask is reset to all false.
         } else if (to != from) {
-          graph->AddArc(from, to);
+          builder.AddArc(from, to);
         }
       }
     }
-    if (finalized) graph->Build();
-    return graph;
+    return builder;
   }
 
   // We use a trivial algorithm: pick an arc at random, uniformly, and add it to
@@ -133,7 +114,7 @@ std::unique_ptr<StaticGraph<>> GenerateRandomSimpleGraph(int num_nodes,
   // the expected number of iterations (which is less than 0.69 * max_num_arcs).
   int64_t num_iterations = 0;
   const int64_t max_num_iterations = 1000 + max_num_arcs;
-  while (graph->num_arcs() < num_arcs) {
+  while (builder.num_arcs() < num_arcs) {
     ++num_iterations;
     CHECK_LE(num_iterations, max_num_iterations)
         << "The random number generator supplied to GenerateRandomSimpleGraph()"
@@ -143,30 +124,30 @@ std::unique_ptr<StaticGraph<>> GenerateRandomSimpleGraph(int num_nodes,
     if (tail == head) continue;
     if (directed) {
       if (!arc_set.insert({tail, head}).second) continue;
-      graph->AddArc(tail, head);
+      builder.AddArc(tail, head);
     } else {  // undirected
       const std::pair<int, int> arc = {
           std::min(tail, head),
           std::max(tail, head)};  // Canonic edge representative.
       if (!arc_set.insert(arc).second) continue;
-      graph->AddArc(tail, head);
-      graph->AddArc(head, tail);
+      builder.AddArc(tail, head);
+      builder.AddArc(head, tail);
     }
   }
-  if (finalized) graph->Build();
-  return graph;
+  return builder;
 }
 }  // namespace
 
-std::unique_ptr<StaticGraph<>> GenerateRandomDirectedSimpleGraph(
-    int num_nodes, int num_arcs, bool finalized, absl::BitGenRef gen) {
-  return GenerateRandomSimpleGraph(num_nodes, num_arcs, finalized,
+StaticGraph<>::Builder GenerateRandomDirectedSimpleGraph(int num_nodes,
+                                                         int num_arcs,
+                                                         absl::BitGenRef gen) {
+  return GenerateRandomSimpleGraph(num_nodes, num_arcs,
                                    /*directed=*/true, gen);
 }
 
-std::unique_ptr<StaticGraph<>> GenerateRandomUndirectedSimpleGraph(
-    int num_nodes, int num_edges, bool finalized, absl::BitGenRef gen) {
-  return GenerateRandomSimpleGraph(num_nodes, 2 * num_edges, finalized,
+StaticGraph<>::Builder GenerateRandomUndirectedSimpleGraph(
+    int num_nodes, int num_edges, absl::BitGenRef gen) {
+  return GenerateRandomSimpleGraph(num_nodes, 2 * num_edges,
                                    /*directed=*/false, gen);
 }
 

--- a/ortools/graph_base/random_graph.h
+++ b/ortools/graph_base/random_graph.h
@@ -17,8 +17,6 @@
 #ifndef UTIL_GRAPH_RANDOM_GRAPH_H_
 #define UTIL_GRAPH_RANDOM_GRAPH_H_
 
-#include <memory>
-
 #include "absl/random/bit_gen_ref.h"
 #include "ortools/graph_base/graph.h"
 
@@ -27,24 +25,23 @@ namespace util {
 // Generates a random graph where multi-arcs and self-arcs are allowed (and
 // therefore expected): exactly "num_arcs" are generated, each from a node
 // picked uniformly at random to another node picked uniformly at random.
-// Calls Build() on the graph iff "finalized" is true.
-std::unique_ptr<StaticGraph<>> GenerateRandomMultiGraph(int num_nodes,
-                                                        int num_arcs,
-                                                        bool finalized,
-                                                        absl::BitGenRef gen);
+StaticGraph<>::Builder GenerateRandomMultiGraph(int num_nodes, int num_arcs,
+                                                absl::BitGenRef gen);
 
 // Like GenerateRandomMultiGraph(), but with neither multi-arcs nor self-arcs:
 // the generated graph will have exactly num_arcs arcs. It will be picked
 // uniformly at random from the set of all simple graphs with that number of
 // nodes and arcs.
-std::unique_ptr<StaticGraph<>> GenerateRandomDirectedSimpleGraph(
-    int num_nodes, int num_arcs, bool finalized, absl::BitGenRef gen);
+StaticGraph<>::Builder GenerateRandomDirectedSimpleGraph(int num_nodes,
+                                                         int num_arcs,
+                                                         absl::BitGenRef gen);
 
 // Like GenerateRandomDirectedSimpleGraph(), but where an undirected edge is
 // represented by two arcs: a->b and b->a. As a result, the amount of arcs in
 // the generated graph is 2*num_edges.
-std::unique_ptr<StaticGraph<>> GenerateRandomUndirectedSimpleGraph(
-    int num_nodes, int num_edges, bool finalized, absl::BitGenRef gen);
+StaticGraph<>::Builder GenerateRandomUndirectedSimpleGraph(int num_nodes,
+                                                           int num_edges,
+                                                           absl::BitGenRef gen);
 
 }  // namespace util
 

--- a/ortools/graph_base/test_util.h
+++ b/ortools/graph_base/test_util.h
@@ -36,15 +36,15 @@ namespace util {
 template <class Graph>
 std::unique_ptr<Graph> Create2DGridGraph(int64_t width, int64_t height) {
   const int64_t num_arcs = 2L * ((width - 1) * height + width * (height - 1));
-  auto graph = std::make_unique<Graph>(/*num_nodes=*/width * height,
-                                       /*arc_capacity=*/num_arcs);
+  typename Graph::Builder builder(/*num_nodes=*/width * height,
+                                  /*arc_capacity=*/num_arcs);
   // Add horizontal edges.
   for (int i = 0; i < height; ++i) {
     for (int j = 1; j < width; ++j) {
       const int left = i * width + (j - 1);
       const int right = i * width + j;
-      graph->AddArc(left, right);
-      graph->AddArc(right, left);
+      builder.AddArc(left, right);
+      builder.AddArc(right, left);
     }
   }
   // Add vertical edges.
@@ -52,12 +52,11 @@ std::unique_ptr<Graph> Create2DGridGraph(int64_t width, int64_t height) {
     for (int j = 0; j < width; ++j) {
       const int up = (i - 1) * width + j;
       const int down = i * width + j;
-      graph->AddArc(up, down);
-      graph->AddArc(down, up);
+      builder.AddArc(up, down);
+      builder.AddArc(down, up);
     }
   }
-  graph->Build();
-  return graph;
+  return std::move(builder).Build(nullptr);
 }
 
 }  // namespace util

--- a/ortools/graph_base/util.h
+++ b/ortools/graph_base/util.h
@@ -231,22 +231,22 @@ bool GraphIsSymmetric(const Graph& graph) {
   typedef typename Graph::NodeIndex NodeIndex;
   typedef typename Graph::ArcIndex ArcIndex;
   // Create a reverse copy of the graph.
-  StaticGraph<NodeIndex, ArcIndex> reverse_graph(graph.num_nodes(),
-                                                 graph.num_arcs());
+  typename StaticGraph<NodeIndex, ArcIndex>::Builder builder(graph.num_nodes(),
+                                                             graph.num_arcs());
   for (const NodeIndex node : graph.AllNodes()) {
     for (const ArcIndex arc : graph.OutgoingArcs(node)) {
-      reverse_graph.AddArc(graph.Head(arc), node);
+      builder.AddArc(graph.Head(arc), node);
     }
   }
-  reverse_graph.Build();
+  const auto reverse_graph = std::move(builder).Build(nullptr);
   // Compare the graph to its reverse, one adjacency list at a time.
   std::vector<ArcIndex> count(graph.num_nodes(), 0);
   for (const NodeIndex node : graph.AllNodes()) {
     for (const ArcIndex arc : graph.OutgoingArcs(node)) {
       ++count[graph.Head(arc)];
     }
-    for (const ArcIndex arc : reverse_graph.OutgoingArcs(node)) {
-      if (--count[reverse_graph.Head(arc)] < 0) return false;
+    for (const ArcIndex arc : reverse_graph->OutgoingArcs(node)) {
+      if (--count[reverse_graph->Head(arc)] < 0) return false;
     }
     for (const ArcIndex arc : graph.OutgoingArcs(node)) {
       if (count[graph.Head(arc)] != 0) return false;
@@ -273,15 +273,13 @@ bool GraphIsWeaklyConnected(const Graph& graph) {
 
 template <class Graph>
 std::unique_ptr<Graph> CopyGraph(const Graph& graph) {
-  std::unique_ptr<Graph> new_graph(
-      new Graph(graph.num_nodes(), graph.num_arcs()));
+  typename Graph::Builder builder(graph.num_nodes(), graph.num_arcs());
   for (const auto node : graph.AllNodes()) {
     for (const auto arc : graph.OutgoingArcs(node)) {
-      new_graph->AddArc(node, graph.Head(arc));
+      builder.AddArc(node, graph.Head(arc));
     }
   }
-  new_graph->Build();
-  return new_graph;
+  return std::move(builder).Build(nullptr);
 }
 
 template <class Graph>
@@ -290,17 +288,15 @@ std::unique_ptr<Graph> RemapGraph(const Graph& old_graph,
   DCHECK(IsValidPermutation(new_node_index)) << "Invalid permutation";
   const int num_nodes = old_graph.num_nodes();
   CHECK_EQ(new_node_index.size(), num_nodes);
-  std::unique_ptr<Graph> new_graph(new Graph(num_nodes, old_graph.num_arcs()));
+  typename Graph::Builder builder(num_nodes, old_graph.num_arcs());
   typedef typename Graph::NodeIndex NodeIndex;
   typedef typename Graph::ArcIndex ArcIndex;
   for (const NodeIndex node : old_graph.AllNodes()) {
     for (const ArcIndex arc : old_graph.OutgoingArcs(node)) {
-      new_graph->AddArc(new_node_index[node],
-                        new_node_index[old_graph.Head(arc)]);
+      builder.AddArc(new_node_index[node], new_node_index[old_graph.Head(arc)]);
     }
   }
-  new_graph->Build();
-  return new_graph;
+  return std::move(builder).Build(nullptr);
 }
 
 template <class Graph>
@@ -325,21 +321,20 @@ std::unique_ptr<Graph> GetSubgraphOfNodes(const Graph& old_graph,
   // NOTE(user): there might seem to be a bit of duplication with RemapGraph(),
   // but there is a key difference: the loop below only iterates on "nodes",
   // which could be much smaller than all the graph's nodes.
-  std::unique_ptr<Graph> new_graph(new Graph(nodes.size(), num_arcs));
+  typename Graph::Builder builder(nodes.size(), num_arcs);
   for (NodeIndex new_tail = 0; new_tail < nodes.size(); ++new_tail) {
     const NodeIndex old_tail = nodes[new_tail];
     for (const ArcIndex arc : old_graph.OutgoingArcs(old_tail)) {
       const NodeIndex new_head = new_node_index[old_graph.Head(arc)];
-      if (new_head != -1) new_graph->AddArc(new_tail, new_head);
+      if (new_head != -1) builder.AddArc(new_tail, new_head);
     }
   }
-  new_graph->Build();
-  return new_graph;
+  return std::move(builder).Build(nullptr);
 }
 
 template <class Graph>
 std::unique_ptr<Graph> RemoveSelfArcsAndDuplicateArcs(const Graph& graph) {
-  std::unique_ptr<Graph> g(new Graph(graph.num_nodes(), graph.num_arcs()));
+  typename Graph::Builder builder(graph.num_nodes(), graph.num_arcs());
   typedef typename Graph::ArcIndex ArcIndex;
   typedef typename Graph::NodeIndex NodeIndex;
   std::vector<bool> tmp_node_mask(graph.num_nodes(), false);
@@ -348,15 +343,14 @@ std::unique_ptr<Graph> RemoveSelfArcsAndDuplicateArcs(const Graph& graph) {
       const NodeIndex head = graph.Head(arc);
       if (head != tail && !tmp_node_mask[head]) {
         tmp_node_mask[head] = true;
-        g->AddArc(tail, head);
+        builder.AddArc(tail, head);
       }
     }
     for (const ArcIndex arc : graph.OutgoingArcs(tail)) {
       tmp_node_mask[graph.Head(arc)] = false;
     }
   }
-  g->Build();
-  return g;
+  return std::move(builder).Build(nullptr);
 }
 
 template <class Graph>


### PR DESCRIPTION
* Add a BaseGraph::Builder class that simply forwards mutable calls (AddNode AddArc, Reserve, Build) to the underlying class.
* Update clients that use XXXStaticGraph, or a template graph to use Builder. Users who directly use ListGraph do not need to be changed if they do not call Build. If they do, remove the unnecessery call to Build.
* Move mutable functions from BaseGraph to XXXGraph::Builder.