### PR TITLE
[ci] Use fastbuild by default for ci

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -38,7 +38,7 @@ build --enable_platform_specific_config
 # Options for Linux.
 ###############################################################################
 
-build:linux --cxxopt=-std=c++20 --host_cxxopt=-std=c++20
+build:linux --per_file_copt=^//or-tools/.*\.cc$@-std=c++20
 build:linux --cxxopt=-Wno-sign-compare --host_cxxopt=-Wno-sign-compare
 build:linux --cxxopt=-Wno-range-loop-construct --host_cxxopt=-Wno-range-loop-construct
 
@@ -49,7 +49,7 @@ build:linux --cxxopt=-Wno-range-loop-construct --host_cxxopt=-Wno-range-loop-con
 # Sets the default Apple platform to macOS.
 build --apple_platform_type=macos
 build:macos --features=-supports_dynamic_linker
-build:macos --cxxopt=-std=c++20 --host_cxxopt=-std=c++20
+build:macos --per_file_copt=^//or-tools/.*\.cc$@-std=c++20
 build:macos --cxxopt=-Wno-sign-compare --host_cxxopt=-Wno-sign-compare
 build:macos --cxxopt=-Wno-dangling-field --host_cxxopt=-Wno-dangling-field
 build:macos --cxxopt=-Wno-range-loop-construct --host_cxxopt=-Wno-range-loop-construct
@@ -60,7 +60,7 @@ build:macos --cxxopt=-Wno-nullability-completeness --host_cxxopt=-Wno-nullabilit
 # Options for Windows.
 ###############################################################################
 
-build:windows --cxxopt=/std:c++20 --host_cxxopt=/std:c++20
+build:windows --per_file_copt=^//or-tools/.*\.cc$@/std:c++20
 # Enable preprocessor conformance mode needed to correctly support __VA_OPT__
 build:windows --cxxopt=/Zc:preprocessor --host_cxxopt=/Zc:preprocessor
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -38,7 +38,7 @@ build --enable_platform_specific_config
 # Options for Linux.
 ###############################################################################
 
-build:linux --per_file_copt=^//or-tools/.*\.cc$@-std=c++20
+build:linux --cxxopt=-std=c++20 --host_cxxopt=-std=c++20
 build:linux --cxxopt=-Wno-sign-compare --host_cxxopt=-Wno-sign-compare
 build:linux --cxxopt=-Wno-range-loop-construct --host_cxxopt=-Wno-range-loop-construct
 
@@ -49,7 +49,7 @@ build:linux --cxxopt=-Wno-range-loop-construct --host_cxxopt=-Wno-range-loop-con
 # Sets the default Apple platform to macOS.
 build --apple_platform_type=macos
 build:macos --features=-supports_dynamic_linker
-build:macos --per_file_copt=^//or-tools/.*\.cc$@-std=c++20
+build:macos --cxxopt=-std=c++20 --host_cxxopt=-std=c++20
 build:macos --cxxopt=-Wno-sign-compare --host_cxxopt=-Wno-sign-compare
 build:macos --cxxopt=-Wno-dangling-field --host_cxxopt=-Wno-dangling-field
 build:macos --cxxopt=-Wno-range-loop-construct --host_cxxopt=-Wno-range-loop-construct
@@ -60,7 +60,7 @@ build:macos --cxxopt=-Wno-nullability-completeness --host_cxxopt=-Wno-nullabilit
 # Options for Windows.
 ###############################################################################
 
-build:windows --per_file_copt=^//or-tools/.*\.cc$@/std:c++20
+build:windows --cxxopt=/std:c++20 --host_cxxopt=/std:c++20
 # Enable preprocessor conformance mode needed to correctly support __VA_OPT__
 build:windows --cxxopt=/Zc:preprocessor --host_cxxopt=/Zc:preprocessor
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -78,11 +78,6 @@ build:windows --enable_runfiles
 # All build options also apply to test as described by the "Option precedence"
 # section in https://bazel.build/run/bazelrc#bazelrc-syntax-semantics.
 
-# Note for anybody considering using --compilation_mode=opt in CI, it builds
-# most files twice, one PIC version for shared libraries in tests, and one
-# non-PIC version for binaries.
-build:ci --copt=-O1
-
 # Show as many errors as possible.
 build:ci --keep_going
 
@@ -95,9 +90,8 @@ build:ci --test_tag_filters=-noci
 # Print information only about tests executed
 build:ci --test_summary=short
 
-# Attempt to work around intermittent issue while trying to fetch remote blob.
-# See e.g. https://github.com/bazelbuild/bazel/issues/18694.
-build:ci --remote_default_exec_properties=cache-silo-key=CleverPeafowl
+# Use GCS Bucket as a remote cache by default.
+build:ci --remote_cache=https://storage.googleapis.com/or-tools-github-remote-caching --google_default_credentials
 
 ###############################################################################
 # Options for asan.

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -45,7 +45,7 @@ jobs:
         python-version: ${{env.PYTHON_VERSION}}
     - uses: bazel-contrib/setup-bazel@0.19.0
     - name: Build
-      run: bazel test --config=ci --remote_cache=https://storage.googleapis.com/or-tools-github-remote-caching --google_default_credentials //ortools/...
+      run: bazel test --config=ci //ortools/...
       shell: bash
 ###############################################################################
   CMake:


### PR DESCRIPTION
Do not explicitly set `-O1` as by `--compilation_mode` defaults to `fast_build` which is what we want. It also removes some warnings on Windows that complain about overridden options (`cl : Command line warning D9025 : overriding '/Od' with '/O1'`).