### PR TITLE
Fix signature of supports for CPSAT Optimizer

### DIFF
--- a/ortools/julia/ORTools.jl/src/moi_wrapper/CPSat_wrapper.jl
+++ b/ortools/julia/ORTools.jl/src/moi_wrapper/CPSat_wrapper.jl
@@ -157,7 +157,7 @@ function MOI.get(optimizer::CPSATOptimizer, param::MOI.RawOptimizerAttribute)
     return getfield!(optimizer.parameters, Symbol(param.name))
 end
 
-MOI.supports(model::Optimizer, param::MOI.RawOptimizerAttribute) = true
+MOI.supports(model::CPSATOptimizer, param::MOI.RawOptimizerAttribute) = true
 
 
 """


### PR DESCRIPTION
There is a warning because the method is exactly the same as:
https://github.com/google/or-tools/blob/79e340fd50e1cae499bd6c9035486cf06c8261a5/ortools/julia/ORTools.jl/src/moi_wrapper/MathOpt_wrapper.jl#L930
All the other methods of the file have correctly use `::CPSATOptimizer`, it just seems this one was forgotten.