### PR TITLE
Fix formatting in scheduling docs for interval variables

### DIFF
--- a/ortools/sat/docs/scheduling.md
+++ b/ortools/sat/docs/scheduling.md
@@ -14,8 +14,8 @@ exclusivity between tasks, and temporal relations between tasks.
 ## Interval variables
 
 Intervals are constraints containing three constant of affine expressions
-(start, size, and end). Creating an interval constraint will enforce that `start
-+ size == end`.
+(start, size, and end). Creating an interval constraint will enforce that
+`start + size == end`.
 
 The more general API uses three expressions to define the interval. If the size
 is fixed, a simpler API uses the start expression and the fixed size.


### PR DESCRIPTION
### What / Why

Just a very small formatting fix!

A line break was causing part of a single tick code expression to be interpreted as a markdown bullet point. See the preview of the diff.