### PR TITLE
python: declare free-threading support in graph modules

### DIFF
--- a/ortools/graph/python/linear_sum_assignment.cc
+++ b/ortools/graph/python/linear_sum_assignment.cc
@@ -20,7 +20,7 @@ using ::operations_research::SimpleLinearSumAssignment;
 using NodeIndex = ::operations_research::SimpleLinearSumAssignment::NodeIndex;
 using ::pybind11::arg;
 
-PYBIND11_MODULE(linear_sum_assignment, m) {
+PYBIND11_MODULE(linear_sum_assignment, m, pybind11::mod_gil_not_used()) {
   pybind11::class_<SimpleLinearSumAssignment> slsa(m,
                                                    "SimpleLinearSumAssignment");
   slsa.def(pybind11::init<>());

--- a/ortools/graph/python/max_flow.cc
+++ b/ortools/graph/python/max_flow.cc
@@ -22,7 +22,7 @@
 using ::operations_research::SimpleMaxFlow;
 using ::pybind11::arg;
 
-PYBIND11_MODULE(max_flow, m) {
+PYBIND11_MODULE(max_flow, m, pybind11::mod_gil_not_used()) {
   pybind11::class_<SimpleMaxFlow> smf(m, "SimpleMaxFlow");
   smf.def(pybind11::init<>());
   smf.def("add_arc_with_capacity", &SimpleMaxFlow::AddArcWithCapacity,

--- a/ortools/graph/python/min_cost_flow.cc
+++ b/ortools/graph/python/min_cost_flow.cc
@@ -21,7 +21,7 @@ using ::operations_research::MinCostFlowBase;
 using ::operations_research::SimpleMinCostFlow;
 using ::pybind11::arg;
 
-PYBIND11_MODULE(min_cost_flow, m) {
+PYBIND11_MODULE(min_cost_flow, m, pybind11::mod_gil_not_used()) {
   pybind11::class_<SimpleMinCostFlow> smcf(m, "SimpleMinCostFlow");
   smcf.def(pybind11::init<>());
   smcf.def("add_arc_with_capacity_and_unit_cost",


### PR DESCRIPTION
Adds `pybind11::mod_gil_not_used()` to the three `ortools.graph.python` modules (`min_cost_flow`, `max_flow`, `linear_sum_assignment`).

OR-Tools has shipped free-threaded (cp313t/cp314t) Linux wheels since 9.12, but because no extension module declares `Py_mod_gil_not_used`, importing e.g. `ortools.graph.python.min_cost_flow` on a free-threaded interpreter emits a `RuntimeWarning` and re-enables the GIL process-wide, which defeats the purpose of the free-threaded build.

These three modules are stateless pybind11 bindings around `SimpleMinCostFlow` / `SimpleMaxFlow` / `SimpleLinearSumAssignment`, which hold all state per instance with no global/static mutable state.

Motivation: [k-means-constrained](https://github.com/joshlk/k-means-constrained) uses `SimpleMinCostFlow` and is adding free-threaded (3.14t) wheels for true multi-threaded solving; this declaration is what currently blocks the GIL staying disabled.