### PR TITLE
Do not redefine absl::SourceLocation when Abseil provides it

### DIFF
--- a/ortools/base/source_location.h
+++ b/ortools/base/source_location.h
@@ -32,6 +32,11 @@
 
 #include "absl/base/config.h"
 
+// Abseil >= LTS 20260526 provides absl::SourceLocation; use it when available.
+#if defined(__has_include) && __has_include("absl/types/source_location.h")
+#include "absl/types/source_location.h"
+#else
+
 namespace absl {
 
 // Class representing a specific location in the source code of a program.
@@ -117,9 +122,15 @@ class SourceLocation {
 
 }  // namespace absl
 
+#endif  // __has_include("absl/types/source_location.h")
+
 // If a function takes an `absl::SourceLocation` parameter, pass this as the
-// argument.
+// argument. Abseil's own SourceLocation has no DoNotInvokeDirectly().
+#if defined(__has_include) && __has_include("absl/types/source_location.h")
+#define ABSL_LOC ::absl::SourceLocation::current()
+#else
 #define ABSL_LOC ::absl::SourceLocation::DoNotInvokeDirectly(__LINE__, __FILE__)
+#endif
 
 // ABSL_LOC_CURRENT_DEFAULT_ARG
 //


### PR DESCRIPTION
Abseil LTS 20260526.0 introduced absl/types/source_location.h, which defines absl::SourceLocation. ortools/base/source_location.h also defines absl::SourceLocation unconditionally, causing 'reference to SourceLocation is ambiguous' build errors (e.g. in ortools/math_opt/cpp/message_callback.h) when building against that Abseil version.

Guard the vendored polyfill with __has_include and use Abseil's absl::SourceLocation when the header is present, mapping ABSL_LOC to absl::SourceLocation::current() in that case.

<!--
Thank you for submitting a PR!

Please make sure you are targeting the main branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->
