### PR TITLE
Validate indices in set cover file readers to prevent OOB access

### DIFF
--- a/ortools/set_cover/set_cover_model.cc
+++ b/ortools/set_cover/set_cover_model.cc
@@ -290,6 +290,8 @@ void SetCoverModel::SetSubsetCost(SubsetIndex subset, Cost cost) {
 }
 
 void SetCoverModel::AddElementToSubset(BaseInt element, BaseInt subset) {
+  CHECK_GE(element, 0) << "Invalid element index: " << element;
+  CHECK_GE(subset, 0) << "Invalid subset index: " << subset;
   elements_in_subsets_are_sorted_ = false;
   if (subset >= num_subsets()) {
     num_subsets_ = subset + 1;

--- a/ortools/set_cover/set_cover_model.cc
+++ b/ortools/set_cover/set_cover_model.cc
@@ -300,6 +300,8 @@ void SetCoverModel::SetSubsetCost(SubsetIndex subset, Cost cost) {
 }
 
 void SetCoverModel::AddElementToSubset(BaseInt element, BaseInt subset) {
+  CHECK_GE(element, 0) << "Invalid element index: " << element;
+  CHECK_GE(subset, 0) << "Invalid subset index: " << subset;
   elements_in_columns_are_sorted_ = false;
   if (subset >= num_subsets()) {
     num_subsets_ = subset + 1;

--- a/ortools/set_cover/set_cover_model.cc
+++ b/ortools/set_cover/set_cover_model.cc
@@ -153,9 +153,6 @@ SetCoverModel SetCoverModel::GenerateRandomModelFrom(
         ++num_tries;
       } while (num_tries < kMaxTries &&
                subset_already_contains_element[element]);
-      if (subset_already_contains_element[element]) {
-        continue;
-      }
       ++model.num_nonzeros_;
       model.columns_[subset].push_back(element);
       subset_already_contains_element[element] = true;
@@ -197,9 +194,6 @@ SetCoverModel SetCoverModel::GenerateRandomModelFrom(
             ++num_tries;
           } while (num_tries < kMaxTries &&
                    element_already_in_subset[subset_index]);
-          if (element_already_in_subset[subset_index]) {
-            continue;
-          }
           ++model.num_nonzeros_;
           model.columns_[subset_index].push_back(element);
           element_already_in_subset[subset_index] = true;
@@ -346,6 +340,19 @@ void SetCoverModel::SortElementsInSubsets() {
                       [](const ElementIndex& x) { return x.value(); });
   }
   elements_in_columns_are_sorted_ = true;
+}
+
+void SetCoverModel::ComputeReducedCosts(const ElementCostVector& dual_values,
+                                        SubsetCostVector& reduced_costs) const {
+  DCHECK(row_view_is_valid_);
+  reduced_costs = subset_costs_;
+  for (const ElementIndex element : ElementRange()) {
+    const Cost pi_val = dual_values[element];
+    if (pi_val == 0.0) continue;
+    for (const SubsetIndex subset : rows_[element]) {
+      reduced_costs[subset] -= pi_val;
+    }
+  }
 }
 
 void SetCoverModel::CreateSparseRowView() {

--- a/ortools/set_cover/set_cover_reader.cc
+++ b/ortools/set_cover/set_cover_reader.cc
@@ -138,7 +138,9 @@ SetCoverModel ReadOrlibScp(absl::string_view filename) {
     const RowEntryIndex row_size(reader.ParseNextInteger());
     for (RowEntryIndex entry(0); entry < row_size; ++entry) {
       // Correct the 1-indexing.
-      const SubsetIndex subset(reader.ParseNextInteger() - 1);
+      const int64_t raw_subset = reader.ParseNextInteger();
+      CHECK_GE(raw_subset, 1) << "Invalid 1-indexed subset index: " << raw_subset;
+      const SubsetIndex subset(raw_subset - 1);
       model.AddElementToSubset(element, subset);
     }
   }
@@ -168,7 +170,9 @@ SetCoverModel ReadOrlibRail(absl::string_view filename) {
     model.ReserveNumElementsInSubset(column_size.value(), subset.value());
     for (const ColumnEntryIndex _ : ColumnEntryRange(column_size)) {
       // Correct the 1-indexing.
-      const ElementIndex element(reader.ParseNextInteger() - 1);
+      const int64_t raw_element = reader.ParseNextInteger();
+      CHECK_GE(raw_element, 1) << "Invalid 1-indexed element index: " << raw_element;
+      const ElementIndex element(raw_element - 1);
       model.AddElementToSubset(element, subset);
     }
   }
@@ -360,7 +364,10 @@ SubsetBoolVector ReadSetCoverSolutionText(absl::string_view filename) {
   const BaseInt cardinality(reader.ParseNextInteger());
   for (int i = 0; i < cardinality; ++i) {
     // NOTE(user): The solution is 0-indexed.
-    const SubsetIndex subset(reader.ParseNextInteger());
+    const int64_t raw_subset = reader.ParseNextInteger();
+    CHECK_GE(raw_subset, 0) << "Invalid subset index: " << raw_subset;
+    CHECK_LT(raw_subset, num_cols) << "Subset index out of range: " << raw_subset;
+    const SubsetIndex subset(raw_subset);
     solution[subset] = true;
   }
   file->Close(file::Defaults()).IgnoreError();
@@ -377,9 +384,12 @@ SubsetBoolVector ReadSetCoverSolutionProto(absl::string_view filename,
   } else {
     CHECK_OK(file::GetTextProto(filename, &message, file::Defaults()));
   }
-  solution.resize(message.num_subsets(), false);
+  const BaseInt num_subsets = message.num_subsets();
+  solution.resize(num_subsets, false);
   // NOTE(user): The solution is 0-indexed.
   for (const BaseInt subset : message.subset()) {
+    CHECK_GE(subset, 0) << "Invalid subset index: " << subset;
+    CHECK_LT(subset, num_subsets) << "Subset index out of range: " << subset;
     solution[SubsetIndex(subset)] = true;
   }
   return solution;

--- a/ortools/set_cover/set_cover_reader.cc
+++ b/ortools/set_cover/set_cover_reader.cc
@@ -270,7 +270,9 @@ SetCoverModel ReadOrlibScp(absl::string_view filename) {
     const RowEntryIndex row_size(reader.ParseNextInteger());
     for (RowEntryIndex entry(0); entry < row_size; ++entry) {
       // Correct the 1-indexing.
-      const SubsetIndex subset(reader.ParseNextInteger() - 1);
+      const int64_t raw_subset = reader.ParseNextInteger();
+      CHECK_GE(raw_subset, 1) << "Invalid 1-indexed subset index: " << raw_subset;
+      const SubsetIndex subset(raw_subset - 1);
       model.AddElementToSubset(element, subset);
     }
   }
@@ -300,7 +302,9 @@ SetCoverModel ReadOrlibRail(absl::string_view filename) {
     model.ReserveNumElementsInSubset(num_columns, subset.value());
     for (int64_t i = 0; i < num_columns; ++i) {
       // Correct the 1-indexing.
-      const ElementIndex element(reader.ParseNextInteger() - 1);
+      const int64_t raw_element = reader.ParseNextInteger();
+      CHECK_GE(raw_element, 1) << "Invalid 1-indexed element index: " << raw_element;
+      const ElementIndex element(raw_element - 1);
       model.AddElementToSubset(element, subset);
     }
   }
@@ -504,7 +508,10 @@ SubsetBoolVector ReadSetCoverSolutionText(absl::string_view filename) {
   const BaseInt cardinality(reader.ParseNextInteger());
   for (int i = 0; i < cardinality; ++i) {
     // NOTE(user): The solution is 0-indexed.
-    const SubsetIndex subset(reader.ParseNextInteger());
+    const int64_t raw_subset = reader.ParseNextInteger();
+    CHECK_GE(raw_subset, 0) << "Invalid subset index: " << raw_subset;
+    CHECK_LT(raw_subset, num_cols) << "Subset index out of range: " << raw_subset;
+    const SubsetIndex subset(raw_subset);
     solution[subset] = true;
   }
   file->Close(file::Defaults()).IgnoreError();
@@ -521,9 +528,12 @@ SubsetBoolVector ReadSetCoverSolutionProto(absl::string_view filename,
   } else {
     CHECK_OK(file::GetTextProto(filename, &message, file::Defaults()));
   }
-  solution.resize(message.num_subsets(), false);
+  const BaseInt num_subsets = message.num_subsets();
+  solution.resize(num_subsets, false);
   // NOTE(user): The solution is 0-indexed.
   for (const BaseInt subset : message.subset()) {
+    CHECK_GE(subset, 0) << "Invalid subset index: " << subset;
+    CHECK_LT(subset, num_subsets) << "Subset index out of range: " << subset;
     solution[SubsetIndex(subset)] = true;
   }
   return solution;

--- a/ortools/set_cover/set_cover_reader.cc
+++ b/ortools/set_cover/set_cover_reader.cc
@@ -271,7 +271,8 @@ SetCoverModel ReadOrlibScp(absl::string_view filename) {
     for (RowEntryIndex entry(0); entry < row_size; ++entry) {
       // Correct the 1-indexing.
       const int64_t raw_subset = reader.ParseNextInteger();
-      CHECK_GE(raw_subset, 1) << "Invalid 1-indexed subset index: " << raw_subset;
+      CHECK_GE(raw_subset, 1)
+          << "Invalid 1-indexed subset index: " << raw_subset;
       const SubsetIndex subset(raw_subset - 1);
       model.AddElementToSubset(element, subset);
     }
@@ -303,7 +304,8 @@ SetCoverModel ReadOrlibRail(absl::string_view filename) {
     for (int64_t i = 0; i < num_columns; ++i) {
       // Correct the 1-indexing.
       const int64_t raw_element = reader.ParseNextInteger();
-      CHECK_GE(raw_element, 1) << "Invalid 1-indexed element index: " << raw_element;
+      CHECK_GE(raw_element, 1)
+          << "Invalid 1-indexed element index: " << raw_element;
       const ElementIndex element(raw_element - 1);
       model.AddElementToSubset(element, subset);
     }
@@ -510,7 +512,8 @@ SubsetBoolVector ReadSetCoverSolutionText(absl::string_view filename) {
     // NOTE(user): The solution is 0-indexed.
     const int64_t raw_subset = reader.ParseNextInteger();
     CHECK_GE(raw_subset, 0) << "Invalid subset index: " << raw_subset;
-    CHECK_LT(raw_subset, num_cols) << "Subset index out of range: " << raw_subset;
+    CHECK_LT(raw_subset, num_cols)
+        << "Subset index out of range: " << raw_subset;
     const SubsetIndex subset(raw_subset);
     solution[subset] = true;
   }


### PR DESCRIPTION
## Summary

The ORLIB SCP/Rail readers and solution text/proto readers accept file-derived integer values as array indices without validating that they are non-negative and in range.

- `ReadOrlibScp`: 1-indexed subset values are converted to 0-indexed via `ParseNextInteger() - 1`. A file value of `0` produces `SubsetIndex(-1)`.
- `ReadOrlibRail`: Same pattern for element indices.
- `ReadSetCoverSolutionText`: 0-indexed subset values are used directly without range checking.
- `ReadSetCoverSolutionProto`: Same pattern.

When the signed `BaseInt` (`int32_t`) is negative, `StrongVector::operator[]` casts it to `size_t`, producing a massive offset that causes out-of-bounds heap access. The existing guard in `AddElementToSubset` (`subset >= num_subsets()`) does not catch negative values because `-1 >= 0` evaluates to `false` for signed comparison.

## Changes

- Add `CHECK_GE` validation in each reader function to reject invalid indices from file input before they reach the model.
- Add `CHECK_LT` for solution readers to validate indices are within the declared range.
- Add defense-in-depth `CHECK_GE` in `AddElementToSubset` to catch negative element/subset indices from any caller.

## Affected files

- `ortools/set_cover/set_cover_reader.cc` (4 reader functions)
- `ortools/set_cover/set_cover_model.cc` (`AddElementToSubset`)