### PR TITLE
Support Gurobi 13 dynamic loading

### DIFF
--- a/ortools/linear_solver/BUILD.bazel
+++ b/ortools/linear_solver/BUILD.bazel
@@ -562,6 +562,7 @@ cc_library(
         "not_run:arm",
     ],
     deps = [
+        "//ortools/base:status_macros",
         "//ortools/third_party_solvers:gurobi_environment",
         "@abseil-cpp//absl/flags:flag",
         "@abseil-cpp//absl/log",
@@ -570,6 +571,19 @@ cc_library(
         "@abseil-cpp//absl/status:statusor",
         "@abseil-cpp//absl/strings",
         "@abseil-cpp//absl/strings:str_format",
+    ],
+)
+
+cc_test(
+    name = "gurobi_util_test",
+    srcs = ["gurobi_util_test.cc"],
+    copts = ORTOOLS_TEST_COPTS,
+    linkopts = ORTOOLS_DEFAULT_LINKOPTS,
+    deps = [
+        ":gurobi_util",
+        "//ortools/base:gmock_main",
+        "//ortools/third_party_solvers:gurobi_environment",
+        "@abseil-cpp//absl/cleanup",
     ],
 )
 

--- a/ortools/linear_solver/BUILD.bazel
+++ b/ortools/linear_solver/BUILD.bazel
@@ -562,7 +562,6 @@ cc_library(
         "not_run:arm",
     ],
     deps = [
-        "//ortools/base:status_macros",
         "//ortools/third_party_solvers:gurobi_environment",
         "@abseil-cpp//absl/flags:flag",
         "@abseil-cpp//absl/log",

--- a/ortools/linear_solver/gurobi_interface.cc
+++ b/ortools/linear_solver/gurobi_interface.cc
@@ -684,9 +684,10 @@ void GurobiInterface::Reset() {
   // solver_specific_parameter_string_ at the start of the solve; other
   // parameters set by previous calls are only kept in the Gurobi model.
   //
-  // TODO - b/328604189: Fix logging issue upstream, switch to a different API
-  // for copying parameters, or avoid calling Reset() in more places.
-  CheckedGurobiCall(GRBcopyparams(GRBgetenv(model_), GRBgetenv(old_model)));
+  // TODO - b/328604189: Fix logging issue upstream, or avoid calling Reset() in
+  // more places. GRBcopyparams is not exported by Gurobi 13, so we fall back to
+  // copying changed parameters explicitly.
+  CHECK_OK(CopyGurobiParameters(GRBgetenv(model_), GRBgetenv(old_model)));
 
   CheckedGurobiCall(GRBfreemodel(old_model));
   old_model = nullptr;

--- a/ortools/linear_solver/gurobi_util.cc
+++ b/ortools/linear_solver/gurobi_util.cc
@@ -27,6 +27,24 @@
 #include "ortools/third_party_solvers/gurobi_environment.h"
 
 namespace operations_research {
+namespace {
+
+constexpr int kGurobiOkCode = 0;
+constexpr int kIntParam = 1;
+constexpr int kDoubleParam = 2;
+constexpr int kStringParam = 3;
+
+absl::Status GurobiStatus(const int gurobi_code, GRBenv* const env,
+                          const std::string& operation) {
+  if (gurobi_code == kGurobiOkCode) {
+    return absl::OkStatus();
+  }
+  return absl::InvalidArgumentError(
+      absl::StrCat(operation, " failed with Gurobi error ", gurobi_code, ": ",
+                   GRBgeterrormsg(env)));
+}
+
+}  // namespace
 
 bool GurobiIsCorrectlyInstalled() {
   absl::StatusOr<GRBenv*> status = GetGurobiEnv();
@@ -53,6 +71,74 @@ absl::StatusOr<GRBenv*> GetGurobiEnv() {
   }
 
   return env;
+}
+
+absl::Status CopyGurobiParameters(GRBenv* const dest, GRBenv* const src) {
+  if (GRBcopyparams) {
+    return GurobiStatus(GRBcopyparams(dest, src), src, "GRBcopyparams()");
+  }
+
+  const int num_parameters = GRBgetnumparams(src);
+  for (int i = 0; i < num_parameters; ++i) {
+    char* param_name = nullptr;
+    RETURN_IF_ERROR(GurobiStatus(GRBgetparamname(src, i, &param_name), src,
+                                 "GRBgetparamname()"));
+    const int param_type = GRBgetparamtype(src, param_name);
+    switch (param_type) {
+      case kIntParam: {
+        int current_value;
+        int default_value;
+        int min_value;
+        int max_value;
+        RETURN_IF_ERROR(GurobiStatus(
+            GRBgetintparaminfo(src, param_name, &current_value, &min_value,
+                               &max_value, &default_value),
+            src, absl::StrCat("GRBgetintparaminfo(", param_name, ")")));
+        if (current_value != default_value) {
+          RETURN_IF_ERROR(GurobiStatus(
+              GRBsetintparam(dest, param_name, current_value), dest,
+              absl::StrCat("GRBsetintparam(", param_name, ")")));
+        }
+        break;
+      }
+      case kDoubleParam: {
+        double current_value;
+        double default_value;
+        double min_value;
+        double max_value;
+        RETURN_IF_ERROR(GurobiStatus(
+            GRBgetdblparaminfo(src, param_name, &current_value, &min_value,
+                               &max_value, &default_value),
+            src, absl::StrCat("GRBgetdblparaminfo(", param_name, ")")));
+        if (current_value != default_value) {
+          RETURN_IF_ERROR(GurobiStatus(
+              GRBsetdblparam(dest, param_name, current_value), dest,
+              absl::StrCat("GRBsetdblparam(", param_name, ")")));
+        }
+        break;
+      }
+      case kStringParam: {
+        char current_value[GRB_MAX_STRLEN + 1];
+        char default_value[GRB_MAX_STRLEN + 1];
+        RETURN_IF_ERROR(GurobiStatus(
+            GRBgetstrparaminfo(src, param_name, current_value, default_value),
+            src, absl::StrCat("GRBgetstrparaminfo(", param_name, ")")));
+        // This ensures that strcmp does not go beyond the end of the char array.
+        current_value[GRB_MAX_STRLEN] = '\0';
+        default_value[GRB_MAX_STRLEN] = '\0';
+        if (std::strcmp(current_value, default_value) != 0) {
+          RETURN_IF_ERROR(GurobiStatus(
+              GRBsetstrparam(dest, param_name, current_value), dest,
+              absl::StrCat("GRBsetstrparam(", param_name, ")")));
+        }
+        break;
+      }
+      default:
+        LOG(WARNING) << "Skipping Gurobi parameter '" << param_name
+                     << "' of unknown type " << param_type << ".";
+    }
+  }
+  return absl::OkStatus();
 }
 
 std::string GurobiParamInfoForLogging(GRBenv* grb, bool one_liner_output) {

--- a/ortools/linear_solver/gurobi_util.cc
+++ b/ortools/linear_solver/gurobi_util.cc
@@ -81,8 +81,8 @@ absl::Status CopyGurobiParameters(GRBenv* const dest, GRBenv* const src) {
   const int num_parameters = GRBgetnumparams(src);
   for (int i = 0; i < num_parameters; ++i) {
     char* param_name = nullptr;
-    RETURN_IF_ERROR(GurobiStatus(GRBgetparamname(src, i, &param_name), src,
-                                 "GRBgetparamname()"));
+    ABSL_RETURN_IF_ERROR(GurobiStatus(GRBgetparamname(src, i, &param_name), src,
+                                      "GRBgetparamname()"));
     const int param_type = GRBgetparamtype(src, param_name);
     switch (param_type) {
       case kIntParam: {
@@ -90,12 +90,12 @@ absl::Status CopyGurobiParameters(GRBenv* const dest, GRBenv* const src) {
         int default_value;
         int min_value;
         int max_value;
-        RETURN_IF_ERROR(GurobiStatus(
+        ABSL_RETURN_IF_ERROR(GurobiStatus(
             GRBgetintparaminfo(src, param_name, &current_value, &min_value,
                                &max_value, &default_value),
             src, absl::StrCat("GRBgetintparaminfo(", param_name, ")")));
         if (current_value != default_value) {
-          RETURN_IF_ERROR(GurobiStatus(
+          ABSL_RETURN_IF_ERROR(GurobiStatus(
               GRBsetintparam(dest, param_name, current_value), dest,
               absl::StrCat("GRBsetintparam(", param_name, ")")));
         }
@@ -106,12 +106,12 @@ absl::Status CopyGurobiParameters(GRBenv* const dest, GRBenv* const src) {
         double default_value;
         double min_value;
         double max_value;
-        RETURN_IF_ERROR(GurobiStatus(
+        ABSL_RETURN_IF_ERROR(GurobiStatus(
             GRBgetdblparaminfo(src, param_name, &current_value, &min_value,
                                &max_value, &default_value),
             src, absl::StrCat("GRBgetdblparaminfo(", param_name, ")")));
         if (current_value != default_value) {
-          RETURN_IF_ERROR(GurobiStatus(
+          ABSL_RETURN_IF_ERROR(GurobiStatus(
               GRBsetdblparam(dest, param_name, current_value), dest,
               absl::StrCat("GRBsetdblparam(", param_name, ")")));
         }
@@ -120,14 +120,15 @@ absl::Status CopyGurobiParameters(GRBenv* const dest, GRBenv* const src) {
       case kStringParam: {
         char current_value[GRB_MAX_STRLEN + 1];
         char default_value[GRB_MAX_STRLEN + 1];
-        RETURN_IF_ERROR(GurobiStatus(
+        ABSL_RETURN_IF_ERROR(GurobiStatus(
             GRBgetstrparaminfo(src, param_name, current_value, default_value),
             src, absl::StrCat("GRBgetstrparaminfo(", param_name, ")")));
-        // This ensures that strcmp does not go beyond the end of the char array.
+        // This ensures that strcmp does not go beyond the end of the char
+        // array.
         current_value[GRB_MAX_STRLEN] = '\0';
         default_value[GRB_MAX_STRLEN] = '\0';
         if (std::strcmp(current_value, default_value) != 0) {
-          RETURN_IF_ERROR(GurobiStatus(
+          ABSL_RETURN_IF_ERROR(GurobiStatus(
               GRBsetstrparam(dest, param_name, current_value), dest,
               absl::StrCat("GRBsetstrparam(", param_name, ")")));
         }

--- a/ortools/linear_solver/gurobi_util.h
+++ b/ortools/linear_solver/gurobi_util.h
@@ -17,12 +17,19 @@
 #include <string>
 
 #include "absl/flags/declare.h"
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "ortools/third_party_solvers/gurobi_environment.h"
 
 namespace operations_research {
 
 absl::StatusOr<GRBenv*> GetGurobiEnv();
+
+// Copies all non-default Gurobi parameters from `src` to `dest`. When using the
+// fallback implementation for Gurobi 13, parameters that are non-default on
+// `dest` and default on `src` are not reset. This is intended for freshly
+// created destination environments.
+absl::Status CopyGurobiParameters(GRBenv* dest, GRBenv* src);
 
 // This returns true if the Gurobi shared library is properly loaded (otherwise,
 // tries to find it and load it) and if a Gurobi license can be obtained (it

--- a/ortools/linear_solver/gurobi_util_test.cc
+++ b/ortools/linear_solver/gurobi_util_test.cc
@@ -98,8 +98,7 @@ void RunCopyGurobiParametersTest(const bool force_fallback) {
   }
 
   ExpectTestParameters(dest, /*expected_output_flag=*/0, /*expected_threads=*/1,
-                       /*expected_mip_gap=*/0.123,
-                       "gurobi_util_test_src.log");
+                       /*expected_mip_gap=*/0.123, "gurobi_util_test_src.log");
 }
 
 TEST(GurobiUtilTest, CopyGurobiParametersCopiesChangedParameters) {

--- a/ortools/linear_solver/gurobi_util_test.cc
+++ b/ortools/linear_solver/gurobi_util_test.cc
@@ -1,0 +1,130 @@
+// Copyright 2010-2025 Google LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ortools/linear_solver/gurobi_util.h"
+
+#include <functional>
+
+#include "absl/cleanup/cleanup.h"
+#include "gtest/gtest.h"
+#include "ortools/base/gmock.h"
+#include "ortools/third_party_solvers/gurobi_environment.h"
+
+namespace operations_research {
+namespace {
+
+constexpr int kGurobiOkCode = 0;
+
+void SetTestParameters(GRBenv* const env, const int output_flag,
+                       const int threads, const double mip_gap,
+                       const char* const log_file) {
+  ASSERT_EQ(GRBsetintparam(env, GRB_INT_PAR_OUTPUTFLAG, output_flag),
+            kGurobiOkCode)
+      << GRBgeterrormsg(env);
+  ASSERT_EQ(GRBsetintparam(env, GRB_INT_PAR_THREADS, threads), kGurobiOkCode)
+      << GRBgeterrormsg(env);
+  ASSERT_EQ(GRBsetdblparam(env, GRB_DBL_PAR_MIPGAP, mip_gap), kGurobiOkCode)
+      << GRBgeterrormsg(env);
+  ASSERT_EQ(GRBsetstrparam(env, GRB_STR_PAR_LOGFILE, log_file), kGurobiOkCode)
+      << GRBgeterrormsg(env);
+}
+
+void ExpectTestParameters(GRBenv* const env, const int expected_output_flag,
+                          const int expected_threads,
+                          const double expected_mip_gap,
+                          const char* const expected_log_file) {
+  int output_flag = -1;
+  ASSERT_EQ(GRBgetintparam(env, GRB_INT_PAR_OUTPUTFLAG, &output_flag),
+            kGurobiOkCode)
+      << GRBgeterrormsg(env);
+  EXPECT_EQ(output_flag, expected_output_flag);
+
+  int threads = 0;
+  ASSERT_EQ(GRBgetintparam(env, GRB_INT_PAR_THREADS, &threads), kGurobiOkCode)
+      << GRBgeterrormsg(env);
+  EXPECT_EQ(threads, expected_threads);
+
+  double mip_gap = 0.0;
+  ASSERT_EQ(GRBgetdblparam(env, GRB_DBL_PAR_MIPGAP, &mip_gap), kGurobiOkCode)
+      << GRBgeterrormsg(env);
+  EXPECT_DOUBLE_EQ(mip_gap, expected_mip_gap);
+
+  char log_file[GRB_MAX_STRLEN + 1];
+  ASSERT_EQ(GRBgetstrparam(env, GRB_STR_PAR_LOGFILE, log_file), kGurobiOkCode)
+      << GRBgeterrormsg(env);
+  log_file[GRB_MAX_STRLEN] = '\0';
+  EXPECT_STREQ(log_file, expected_log_file);
+}
+
+void RunCopyGurobiParametersTest(const bool force_fallback) {
+  absl::StatusOr<GRBenv*> src_status = GetGurobiEnv();
+  if (!src_status.ok()) {
+    GTEST_SKIP() << src_status.status();
+  }
+  GRBenv* const src = src_status.value();
+  absl::Cleanup src_cleanup = [src] { GRBfreeenv(src); };
+
+  absl::StatusOr<GRBenv*> dest_status = GetGurobiEnv();
+  if (!dest_status.ok()) {
+    GTEST_SKIP() << dest_status.status();
+  }
+  GRBenv* const dest = dest_status.value();
+  absl::Cleanup dest_cleanup = [dest] { GRBfreeenv(dest); };
+
+  SetTestParameters(src, /*output_flag=*/0, /*threads=*/1, /*mip_gap=*/0.123,
+                    "gurobi_util_test_src.log");
+  SetTestParameters(dest, /*output_flag=*/1, /*threads=*/2, /*mip_gap=*/0.321,
+                    "gurobi_util_test_dest.log");
+
+  if (force_fallback) {
+    const std::function<int(GRBenv*, GRBenv*)> saved_copyparams = GRBcopyparams;
+    GRBcopyparams = nullptr;
+    absl::Cleanup restore_copyparams = [saved_copyparams] {
+      GRBcopyparams = saved_copyparams;
+    };
+    ASSERT_OK(CopyGurobiParameters(dest, src));
+  } else {
+    ASSERT_OK(CopyGurobiParameters(dest, src));
+  }
+
+  ExpectTestParameters(dest, /*expected_output_flag=*/0, /*expected_threads=*/1,
+                       /*expected_mip_gap=*/0.123,
+                       "gurobi_util_test_src.log");
+}
+
+TEST(GurobiUtilTest, CopyGurobiParametersCopiesChangedParameters) {
+  RunCopyGurobiParametersTest(/*force_fallback=*/false);
+}
+
+TEST(GurobiUtilTest, CopyGurobiParametersFallbackCopiesChangedParameters) {
+  RunCopyGurobiParametersTest(/*force_fallback=*/true);
+}
+
+TEST(GurobiUtilTest, LoadGurobiDynamicLibraryCanBeCalledTwice) {
+  const absl::Status first_load = LoadGurobiDynamicLibrary({});
+  if (!first_load.ok()) {
+    GTEST_SKIP() << first_load;
+  }
+  ASSERT_OK(LoadGurobiDynamicLibrary({}));
+
+  int major = -1;
+  int minor = -1;
+  int technical = -1;
+  GRBversion(&major, &minor, &technical);
+  EXPECT_GE(major, 0);
+  EXPECT_GE(minor, 0);
+  EXPECT_GE(technical, 0);
+}
+
+}  // namespace
+}  // namespace operations_research

--- a/ortools/linear_solver/linear_solver.cc
+++ b/ortools/linear_solver/linear_solver.cc
@@ -452,7 +452,7 @@ constexpr
         {MPSolver::PDLP_LINEAR_PROGRAMMING, "pdlp"},
         {MPSolver::CPLEX_MIXED_INTEGER_PROGRAMMING, "cplex"},
         {MPSolver::XPRESS_MIXED_INTEGER_PROGRAMMING, "xpress"},
-    };
+};
 // static
 bool MPSolver::ParseSolverType(absl::string_view solver_id,
                                MPSolver::OptimizationProblemType* type) {

--- a/ortools/lp_data/lp_types.cc
+++ b/ortools/lp_data/lp_types.cc
@@ -247,9 +247,7 @@ std::ostream& operator<<(std::ostream& os, const SolveStatus status) {
   return os;
 }
 
-SolveStatus OptimalSolveStatus() {
-  return {SolveStatus::Optimal{}};
-}
+SolveStatus OptimalSolveStatus() { return {SolveStatus::Optimal{}}; }
 
 SolveStatus PrimalInfeasibleSolveStatus() {
   return {SolveStatus::PrimalInfeasible{}};
@@ -302,9 +300,7 @@ SolveStatus InvalidProblemSolveStatus() {
   return {SolveStatus::InvalidProblem{}};
 }
 
-SolveStatus ImpreciseSolveStatus() {
-  return {SolveStatus::Imprecise{}};
-}
+SolveStatus ImpreciseSolveStatus() { return {SolveStatus::Imprecise{}}; }
 
 ProblemStatus SolveStatus::problem_status() const {
   return std::visit([](const auto& alternative) { return alternative.status; },

--- a/ortools/math_opt/solvers/gurobi/g_gurobi.cc
+++ b/ortools/math_opt/solvers/gurobi/g_gurobi.cc
@@ -152,6 +152,7 @@ void GurobiFreeEnv::operator()(GRBenv* const env) const {
 
 absl::StatusOr<GRBenvUniquePtr> GurobiNewPrimaryEnv(
     const std::optional<GurobiIsvKey>& isv_key) {
+  RETURN_IF_ERROR(LoadGurobiDynamicLibrary({}));
   if (isv_key.has_value()) {
     ABSL_ASSIGN_OR_RETURN(GRBenv* const naked_primary_env,
                           NewPrimaryEnvFromISVKey(*isv_key));
@@ -195,6 +196,7 @@ Gurobi::Gurobi(GRBenvUniquePtr optional_owned_primary_env,
 absl::StatusOr<std::unique_ptr<Gurobi>> Gurobi::New(
     GRBenvUniquePtr optional_owned_primary_env, GRBenv* const primary_env) {
   CHECK(primary_env != nullptr);
+  RETURN_IF_ERROR(LoadGurobiDynamicLibrary({}));
   GRBmodel* model = nullptr;
   const int err = GRBnewmodel(primary_env, &model,
                               /*Pname=*/nullptr,

--- a/ortools/math_opt/solvers/gurobi/g_gurobi.cc
+++ b/ortools/math_opt/solvers/gurobi/g_gurobi.cc
@@ -152,7 +152,7 @@ void GurobiFreeEnv::operator()(GRBenv* const env) const {
 
 absl::StatusOr<GRBenvUniquePtr> GurobiNewPrimaryEnv(
     const std::optional<GurobiIsvKey>& isv_key) {
-  RETURN_IF_ERROR(LoadGurobiDynamicLibrary({}));
+  ABSL_RETURN_IF_ERROR(LoadGurobiDynamicLibrary({}));
   if (isv_key.has_value()) {
     ABSL_ASSIGN_OR_RETURN(GRBenv* const naked_primary_env,
                           NewPrimaryEnvFromISVKey(*isv_key));
@@ -196,7 +196,7 @@ Gurobi::Gurobi(GRBenvUniquePtr optional_owned_primary_env,
 absl::StatusOr<std::unique_ptr<Gurobi>> Gurobi::New(
     GRBenvUniquePtr optional_owned_primary_env, GRBenv* const primary_env) {
   CHECK(primary_env != nullptr);
-  RETURN_IF_ERROR(LoadGurobiDynamicLibrary({}));
+  ABSL_RETURN_IF_ERROR(LoadGurobiDynamicLibrary({}));
   GRBmodel* model = nullptr;
   const int err = GRBnewmodel(primary_env, &model,
                               /*Pname=*/nullptr,

--- a/ortools/third_party_solvers/dynamic_library.h
+++ b/ortools/third_party_solvers/dynamic_library.h
@@ -32,6 +32,10 @@
 class DynamicLibrary {
  public:
   DynamicLibrary() : library_handle_(nullptr) {}
+  DynamicLibrary(const DynamicLibrary&) = delete;
+  DynamicLibrary& operator=(const DynamicLibrary&) = delete;
+  DynamicLibrary(DynamicLibrary&&) = delete;
+  DynamicLibrary& operator=(DynamicLibrary&&) = delete;
 
   ~DynamicLibrary() {
     if (library_handle_ == nullptr) {
@@ -59,6 +63,16 @@ class DynamicLibrary {
 
   template <typename T>
   std::function<T> GetFunction(const char* function_name) {
+    std::function<T> function = TryGetFunction<T>(function_name);
+
+    CHECK(function) << "Error: could not find function "
+                    << std::string(function_name) << " in " << library_name_;
+
+    return function;
+  }
+
+  template <typename T>
+  std::function<T> TryGetFunction(const char* function_name) {
 #if defined(_MSC_VER) || defined(__MINGW32__) || defined(__MINGW64__)
     // On Windows, avoid casting to void*: not supported by MinGW.
     FARPROC function_address =
@@ -67,9 +81,9 @@ class DynamicLibrary {
     const void* function_address = dlsym(library_handle_, function_name);
 #endif  // MinGW.
 
-    CHECK(function_address)
-        << "Error: could not find function " << std::string(function_name)
-        << " in " << library_name_;
+    if (function_address == nullptr) {
+      return nullptr;
+    }
 
     return TypeParser<T>::CreateFunction(function_address);
   }
@@ -82,6 +96,11 @@ class DynamicLibrary {
   template <typename T>
   void GetFunction(std::function<T>* function, const char* function_name) {
     *function = GetFunction<T>(function_name);
+  }
+
+  template <typename T>
+  void TryGetFunction(std::function<T>* function, const char* function_name) {
+    *function = TryGetFunction<T>(function_name);
   }
 
   template <typename T>

--- a/ortools/third_party_solvers/gurobi_environment.cc
+++ b/ortools/third_party_solvers/gurobi_environment.cc
@@ -310,7 +310,7 @@ void LoadGurobiFunctions(DynamicLibrary* gurobi_dynamic_library) {
   gurobi_dynamic_library->GetFunction(&GRBsetdblparam, "GRBsetdblparam");
   gurobi_dynamic_library->GetFunction(&GRBsetstrparam, "GRBsetstrparam");
   gurobi_dynamic_library->GetFunction(&GRBresetparams, "GRBresetparams");
-  gurobi_dynamic_library->GetFunction(&GRBcopyparams, "GRBcopyparams");
+  gurobi_dynamic_library->TryGetFunction(&GRBcopyparams, "GRBcopyparams");
   gurobi_dynamic_library->GetFunction(&GRBloadenv, "GRBloadenv");
   gurobi_dynamic_library->GetFunction(&GRBstartenv, "GRBstartenv");
   gurobi_dynamic_library->GetFunction(&GRBemptyenv, "GRBemptyenv");
@@ -339,7 +339,7 @@ std::vector<std::string> GurobiDynamicLibraryPotentialPaths() {
   std::vector<std::string> potential_paths;
   // clang-format off
   const std::vector<absl::string_view> kGurobiVersions = {
-      "1301", "1300",
+      "1302", "1301", "1300",
       "1203", "1202", "1201", "1200",
       "1103", "1102", "1101", "1100",
       "1003", "1002", "1001", "1000",
@@ -407,7 +407,7 @@ std::vector<std::string> GurobiDynamicLibraryPotentialPaths() {
 #if defined(__GNUC__)
   // clang-format off
   for (const absl::string_view version : {
-      "13.0.1", "13.0.0",
+      "13.0.2", "13.0.1", "13.0.0",
       "12.0.3", "12.0.2", "12.0.1", "12.0.0",
       "11.0.3", "11.0.2", "11.0.1", "11.0.0",
       "10.0.3", "10.0.2", "10.0.1", "10.0.0",
@@ -428,12 +428,15 @@ absl::Status LoadGurobiDynamicLibrary(
     DynamicLibrary gurobi_library;
   };
 
-  static absl::NoDestructor<GurobiLibraryStruct> loaded([&potential_paths]() {
-    GurobiLibraryStruct result;
+  static absl::NoDestructor<GurobiLibraryStruct> loaded;
+  static const bool initialized = [&potential_paths]() {
+    GurobiLibraryStruct& result = *loaded;
+    std::vector<std::string> attempted_paths;
     // Try to load the library from the potential paths.
     for (const absl::string_view path : potential_paths) {
+      attempted_paths.push_back(std::string(path));
       if (result.gurobi_library.TryToLoad(path)) {
-        VLOG(1) << "Found the Gurobi library in '" << path << ".";
+        VLOG(1) << "Found the Gurobi library in '" << path << "'.";
         break;
       }
     }
@@ -443,8 +446,9 @@ absl::Status LoadGurobiDynamicLibrary(
       const std::vector<std::string> canonical_paths =
           GurobiDynamicLibraryPotentialPaths();
       for (const absl::string_view path : canonical_paths) {
+        attempted_paths.push_back(std::string(path));
         if (result.gurobi_library.TryToLoad(path)) {
-          VLOG(1) << "Found the Gurobi library in '" << path << ".";
+          VLOG(1) << "Found the Gurobi library in '" << path << "'.";
           break;
         }
       }
@@ -455,13 +459,14 @@ absl::Status LoadGurobiDynamicLibrary(
       result.gurobi_load_status = absl::OkStatus();
     } else {
       result.gurobi_load_status = absl::NotFoundError(absl::StrCat(
-          "Could not find the Gurobi shared library. Looked in: [",
-          absl::StrJoin(potential_paths, "', '"),
-          "]. If you know where it"
+          "Could not find the Gurobi shared library. Looked in: ['",
+          absl::StrJoin(attempted_paths, "', '"),
+          "']. If you know where it"
           " is, pass the full path to 'LoadGurobiDynamicLibrary()'."));
     }
-    return result;
-  }());
+    return true;
+  }();
+  (void)initialized;
 
   return loaded->gurobi_load_status;
 }

--- a/ortools/third_party_solvers/gurobi_parse_header.py
+++ b/ortools/third_party_solvers/gurobi_parse_header.py
@@ -139,6 +139,14 @@ EXPORTED_FUNCTIONS = frozenset(
     ]
 )
 
+OPTIONAL_FUNCTIONS = frozenset(
+    [
+        # Removed from the Gurobi 13 C API. Keep loading optional while callers
+        # provide a fallback implementation.
+        "GRBcopyparams",
+    ]
+)
+
 # TODO(user): Filter #define too.
 
 
@@ -167,7 +175,8 @@ class GurobiHeaderParser:
 
         self.__header += f"extern std::function<{return_type}({args})> {name};\n"
         self.__define += f"std::function<{return_type}({args})> {name} = nullptr;\n"
-        self.__assign += f"  gurobi_dynamic_library->GetFunction(&{name}, "
+        get_function = "TryGetFunction" if name in OPTIONAL_FUNCTIONS else "GetFunction"
+        self.__assign += f"  gurobi_dynamic_library->{get_function}(&{name}, "
         self.__assign += f'"{name}");\n'
 
     def parse(self, filepath: str) -> None:


### PR DESCRIPTION
## Summary

Adds support for dynamically loading Gurobi 13.

Gurobi 13 no longer exports `GRBcopyparams`, which caused OR-Tools dynamic loading to fail before the solver could be used. This PR makes that symbol optional and adds a fallback implementation that copies non-default parameters explicitly.

Also included:

- Adds Gurobi 13.0.0, 13.0.1, and 13.0.2 library search paths.
- Ensures MathOpt Gurobi code loads the dynamic library before creating Gurobi environments/models.
- Makes `DynamicLibrary` non-copyable and adds optional symbol lookup support.
- Improves the Gurobi dynamic-library load error to report all attempted paths.
- Updates `gurobi_parse_header.py` so optional symbols are generated with `TryGetFunction`.
- Adds tests for parameter copying, fallback copying, and repeated dynamic-library loading.

## Testing

```powershell
bazelisk --nowindows_enable_symlinks build --jobs=2 //ortools/third_party_solvers:gurobi_environment //ortools/linear_solver:gurobi_util_test //ortools/linear_solver:linear_solver_gurobi //ortools/math_opt/solvers:gurobi_solver
bazelisk --nowindows_enable_symlinks test --jobs=2 //ortools/linear_solver:gurobi_util_test --test_output=errors
```