### PR TITLE
[ENH] set_cover Python: expose the lower bound accessors directly

### DIFF
--- a/ortools/set_cover/python/set_cover.cc
+++ b/ortools/set_cover/python/set_cover.cc
@@ -291,6 +291,9 @@ PYBIND11_MODULE(set_cover, m) {
             *invariant.model() = model;
           })
       .def("cost", &SetCoverInvariant::cost)
+      .def("lower_bound", &SetCoverInvariant::LowerBound)
+      .def("cost_or_lower_bound", &SetCoverInvariant::CostOrLowerBound)
+      .def("is_cost_consistent", &SetCoverInvariant::is_cost_consistent)
       .def("num_uncovered_elements", &SetCoverInvariant::num_uncovered_elements)
       .def("is_selected",
            [](SetCoverInvariant& invariant) -> std::vector<bool> {

--- a/ortools/set_cover/python/set_cover_test.py
+++ b/ortools/set_cover/python/set_cover_test.py
@@ -222,6 +222,33 @@ class SetCoverTest(absltest.TestCase):
             inv.check_consistency(set_cover.consistency_level.FREE_AND_UNCOVERED)
         )
 
+    def test_dual_ascent_lower_bound(self):
+        model = create_knights_cover_model(8, 8)
+        self.assertTrue(model.compute_feasibility())
+
+        primal = set_cover.SetCoverInvariant(model)
+        self.assertTrue(set_cover.GreedySolutionOptimizer(primal).optimize())
+        upper_bound = primal.cost()
+
+        dual = set_cover.SetCoverInvariant(model)
+        self.assertTrue(set_cover.DualAscentOptimizer(dual).optimize())
+        lower_bound = dual.lower_bound()
+
+        # The dual ascent bound is a valid lower bound on the optimum, so it
+        # cannot exceed the cost of any feasible cover.
+        self.assertGreaterEqual(lower_bound, 0.0)
+        self.assertLessEqual(lower_bound, upper_bound)
+
+    def test_cost_or_lower_bound(self):
+        model = create_knights_cover_model(4, 4)
+        inv = set_cover.SetCoverInvariant(model)
+
+        self.assertTrue(set_cover.GreedySolutionOptimizer(inv).optimize())
+        if inv.is_cost_consistent():
+            self.assertEqual(inv.cost_or_lower_bound(), inv.cost())
+        else:
+            self.assertEqual(inv.cost_or_lower_bound(), inv.lower_bound())
+
     # TODO(user): KnightsCoverGreedyAndTabu, KnightsCoverGreedyRandomClear,
     # KnightsCoverElementDegreeRandomClear, KnightsCoverRandomClearMip,
     # KnightsCoverMip


### PR DESCRIPTION

*Edited 2026-09-05: shortened, the cross-reference to #5122 dropped so this PR stands on its own, and the limits of the existing workaround spelled out. Code unchanged. Re-built and re-run against `main` @ `5a1b660` on 2026-09-05, and provided cost estimate of the existing workaround.*

### What

`SetCoverInvariant` has `LowerBound()`, `CostOrLowerBound()` and `is_cost_consistent()` in C++. None of the three are bound in `ortools/set_cover/python/set_cover.cc`. This adds them next to the existing `cost` binding (plus two tests).

`DualAscentOptimizer` writes its dual bound onto the invariant through
`ReportLowerBound()`. From Python, the only way to read it today is:

```python
bound = inv.export_solution_as_proto().cost_lower_bound
```

That path has two problems.
i) It walks every subset in the model and copies the selected ones into a proto in order to hand back one double, so costing a full pass over the model every time by reading a gap inside. Measured on `main` @ `5a1b660` with this PR applied, one read costs about 28 ns per subset: 0.8 ms at 3,000 subsets (`scpb1`), 28 ms at 1,000,000 subsets, against 0.9 µs for `inv.lower_bound()`. And `ExportSolutionAsProto()` writes the raw `lower_bound_`, while `SetCoverSolutionResponse` has no field for this consistency flag.

A Python caller therefore cannot tell whether that number is a live bound or a stale
one, and `CostOrLowerBound()`, which branches on that flag, cannot be
reconstructed from Python.

With the bindings:

```python
gap = (inv.cost() - inv.lower_bound()) / inv.cost()
```

`is_cost_consistent()` is included for the same reason: `ReportLowerBound()` is called with `is_cost_consistent=false`. After a `DualAscentOptimizer` run on `scpb1`, for example, `cost()` is 75, `lower_bound()` is 45, `is_cost_consistent()` is `False` and `cost_or_lower_bound()` is 45; the proto shows only the 75 and the 45.

Three `.def()` lines and two tests. No new dependency, no build change.

### Verification

`bazel test //ortools/set_cover/python:set_cover_test` passes on Linux (Bazel 8.7.0,
x86_64) against `main` @ `5a1b660` (2026-09-05). `clang-format` clean against the repo `.clang-format`; `black` clean at the file's existing line width.

CLA signed. Drafted with Claude; built, run and reviewed by me.
