### PR TITLE
cmake: use consistent export names

### DIFF
--- a/cmake/cpp.cmake
+++ b/cmake/cpp.cmake
@@ -337,7 +337,7 @@ function(ortools_cxx_library)
   )
   if(NOT LIBRARY_NO_INSTALL)
     install(TARGETS ${LIBRARY_NAME}
-      EXPORT ortoolsTargets
+      EXPORT ${PROJECT_NAME}Targets
       INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
       ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
       LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -418,7 +418,7 @@ function(ortools_cxx_binary)
   endif()
   if(NOT BINARY_NO_INSTALL)
     install(TARGETS ${BINARY_NAME}
-      EXPORT ortoolsTargets
+      EXPORT ${PROJECT_NAME}Targets
       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     )
   endif()


### PR DESCRIPTION
The `install(EXPORT)` call under Install rules expects `${PROJECT_NAME}Targets`.

<!--
Thank you for submitting a PR!

Please make sure you are targeting the main branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->
