### PR TITLE
Route add_enforced_linear_constraint through the enforced helper setters

### DIFF
--- a/ortools/linear_solver/python/model_builder.py
+++ b/ortools/linear_solver/python/model_builder.py
@@ -172,7 +172,7 @@ def _add_enforced_linear_constraint_to_helper(
         helper.set_enforced_constraint_lower_bound(c.index, bounded_expr.lower_bound)
         helper.set_enforced_constraint_upper_bound(c.index, bounded_expr.upper_bound)
         if name is not None:
-            helper.set_constraint_name(c.index, name)
+            helper.set_enforced_constraint_name(c.index, name)
         return c
 
     raise TypeError(f"invalid type={type(bounded_expr).__name__!r}")
@@ -941,16 +941,24 @@ class Model:
         ct.indicator_variable = ivar
         ct.indicator_value = ivalue
         if name:
-            self.__helper.set_constraint_name(ct.index, name)
+            self.__helper.set_enforced_constraint_name(ct.index, name)
         if mbn.is_a_number(linear_expr):
-            self.__helper.set_constraint_lower_bound(ct.index, lb - linear_expr)
-            self.__helper.set_constraint_upper_bound(ct.index, ub - linear_expr)
+            self.__helper.set_enforced_constraint_lower_bound(
+                ct.index, lb - linear_expr
+            )
+            self.__helper.set_enforced_constraint_upper_bound(
+                ct.index, ub - linear_expr
+            )
         elif isinstance(linear_expr, LinearExpr):
             flat_expr = mbh.FlatExpr(linear_expr)
             # pylint: disable=protected-access
-            self.__helper.set_constraint_lower_bound(ct.index, lb - flat_expr.offset)
-            self.__helper.set_constraint_upper_bound(ct.index, ub - flat_expr.offset)
-            self.__helper.add_terms_to_constraint(
+            self.__helper.set_enforced_constraint_lower_bound(
+                ct.index, lb - flat_expr.offset
+            )
+            self.__helper.set_enforced_constraint_upper_bound(
+                ct.index, ub - flat_expr.offset
+            )
+            self.__helper.add_terms_to_enforced_constraint(
                 ct.index, flat_expr.vars, flat_expr.coeffs
             )
         else:

--- a/ortools/linear_solver/python/model_builder_test.py
+++ b/ortools/linear_solver/python/model_builder_test.py
@@ -1794,6 +1794,109 @@ class ModelBuilderProtoTest(absltest.TestCase):
         model.maximize(x.sum())
         self.assertEqual(str(expected), str(model.export_to_proto()))
 
+    def test_add_enforced_linear_constraint_without_regular_constraint(self):
+        # add_enforced_linear_constraint used to write the indicator constraint
+        # through the regular constraint setters using the enforced index. With
+        # no regular constraint at that index this addressed out-of-range memory
+        # and crashed the interpreter; check it now produces a well-formed
+        # indicator constraint and no spurious regular constraint.
+        expected = linear_solver_pb2.MPModelProto()
+        text_format.Parse(
+            """
+    variable {
+      lower_bound: 0
+      upper_bound: 10
+      is_integer: true
+      name: "x"
+    }
+    variable {
+      lower_bound: 0
+      upper_bound: 1
+      is_integer: true
+      name: "z"
+    }
+    general_constraint {
+      name: "ind"
+      indicator_constraint {
+        var_index: 1
+        var_value: 1
+        constraint {
+          lower_bound: 3
+          upper_bound: 8
+          var_index: 0
+          coefficient: 1
+        }
+      }
+    }
+    """,
+            expected,
+        )
+        model = mb.Model()
+        x = model.new_int_var(0, 10, "x")
+        z = model.new_bool_var("z")
+        model.add_enforced_linear_constraint(x, z, True, lb=3, ub=8, name="ind")
+        self.assertEqual(str(expected), str(model.export_to_proto()))
+
+    def test_add_enforced_linear_constraint_keeps_prior_constraint(self):
+        # With a regular constraint already present at the enforced index, the
+        # misrouted setters silently overwrote that constraint's name, bounds
+        # and terms and left the indicator constraint empty. Check the regular
+        # constraint is untouched and the indicator constraint carries its own
+        # bounds and terms.
+        expected = linear_solver_pb2.MPModelProto()
+        text_format.Parse(
+            """
+    variable {
+      lower_bound: 0
+      upper_bound: 10
+      is_integer: true
+      name: "x"
+    }
+    variable {
+      lower_bound: 0
+      upper_bound: 10
+      is_integer: true
+      name: "y"
+    }
+    variable {
+      lower_bound: 0
+      upper_bound: 1
+      is_integer: true
+      name: "z"
+    }
+    constraint {
+      lower_bound: 0
+      upper_bound: 5
+      name: "reg"
+      var_index: 0
+      var_index: 1
+      coefficient: 1
+      coefficient: 1
+    }
+    general_constraint {
+      name: "ind"
+      indicator_constraint {
+        var_index: 2
+        var_value: 1
+        constraint {
+          lower_bound: 3
+          upper_bound: 8
+          var_index: 0
+          coefficient: 1
+        }
+      }
+    }
+    """,
+            expected,
+        )
+        model = mb.Model()
+        x = model.new_int_var(0, 10, "x")
+        y = model.new_int_var(0, 10, "y")
+        z = model.new_bool_var("z")
+        model.add_linear_constraint(x + y, lb=0, ub=5, name="reg")
+        model.add_enforced_linear_constraint(x, z, True, lb=3, ub=8, name="ind")
+        self.assertEqual(str(expected), str(model.export_to_proto()))
+
 
 class SolverTest(parameterized.TestCase):
     _solvers = (


### PR DESCRIPTION
Fixes #5302

`Model.add_enforced_linear_constraint` and the `BoundedLinearExpression` branch of `_add_enforced_linear_constraint_to_helper` wrote the indicator constraint's name, bounds and terms through the non-enforced helper setters (`set_constraint_name` / `set_constraint_lower_bound` / `set_constraint_upper_bound` / `add_terms_to_constraint`) while passing the enforced constraint's index.

Enforced constraints live in `MPModelProto.general_constraint[i]`, but those setters address `MPModelProto.constraint[i]`. The index spaces are disjoint, so the data landed on an unrelated linear constraint — silently destroying it and leaving the indicator constraint empty — or, when no linear constraint existed at that index, `mutable_constraint(i)` read out of bounds and the process segfaulted (the `DCHECK` is compiled out in the release wheel).

This change routes every setter in the enforced paths through the `set_enforced_*` / `add_terms_to_enforced_constraint` variants, matching the `bool` branch of the same helper (which was already correct) and the Java and C# ports.

Added two regression tests:
- `test_add_enforced_linear_constraint_without_regular_constraint` — an enforced constraint on a model with no prior regular constraint now builds a well-formed `general_constraint` instead of crashing.
- `test_add_enforced_linear_constraint_keeps_prior_constraint` — a prior regular constraint keeps its own name, bounds and terms, and the enforced constraint carries its own, instead of the two being conflated.

Both fail on `main` (the first as a segfault, the second on the corrupted proto) and pass with this change.
