### PR TITLE
Make vendoring pybind11_abseil optional

### DIFF
--- a/cmake/python.cmake
+++ b/cmake/python.cmake
@@ -15,6 +15,15 @@ if(NOT BUILD_PYTHON)
   return()
 endif()
 
+# When ON (the upstream default), the pybind11_abseil Python module is staged
+# next to the ortools package and bundled into the wheel so that a bare
+# `pip install ortools` is self-contained. Distributions that ship
+# pybind11_abseil as a separate runtime package (e.g. Debian)
+# must turn this OFF to avoid shipping a second copy of
+# pybind11_abseil/status.*.cpython-*.so.
+option(VENDOR_PYBIND11_ABSEIL
+  "Stage the pybind11_abseil Python module into the ortools wheel" ON)
+
 # Use latest UseSWIG module (3.14) and Python3 module (3.18)
 cmake_minimum_required(VERSION 3.18)
 
@@ -311,7 +320,9 @@ file(GENERATE
   OUTPUT ${PYTHON_PROJECT_DIR}/__init__.py
   INPUT ${PROJECT_BINARY_DIR}/python/__init__.py.in)
 
-file(GENERATE OUTPUT ${PYTHON_PROJECT_DIR}/../pybind11_abseil/__init__.py CONTENT "")
+if(VENDOR_PYBIND11_ABSEIL)
+  file(GENERATE OUTPUT ${PYTHON_PROJECT_DIR}/../pybind11_abseil/__init__.py CONTENT "")
+endif()
 file(GENERATE OUTPUT ${PYTHON_PROJECT_DIR}/algorithms/__init__.py CONTENT "")
 file(GENERATE OUTPUT ${PYTHON_PROJECT_DIR}/algorithms/python/__init__.py CONTENT "")
 file(GENERATE OUTPUT ${PYTHON_PROJECT_DIR}/bop/__init__.py CONTENT "")
@@ -706,7 +717,7 @@ add_custom_command(
    $<IF:$<BOOL:${BUILD_MATH_OPT}>,copy,true>
    $<TARGET_FILE:math_opt_io_pybind11> ${PYTHON_PROJECT}/math_opt/io/python
   COMMAND ${CMAKE_COMMAND} -E
-   $<IF:$<BOOL:${BUILD_MATH_OPT}>,copy,true>
+   $<IF:$<BOOL:${VENDOR_PYBIND11_ABSEIL}>,copy,true>
    $<TARGET_FILE:status_py_extension_stub> ${PYTHON_PROJECT}/../pybind11_abseil
   COMMAND ${CMAKE_COMMAND} -E
    $<IF:$<TARGET_EXISTS:pdlp_pybind11>,copy,true>


### PR DESCRIPTION
## Summary

Adds a new CMake option **`VENDOR_PYBIND11_ABSEIL`** (default `ON`) that guards the two staging actions in [`cmake/python.cmake`](cmake/python.cmake) that place the `pybind11_abseil` Python module next to the `ortools` package and bundle it into the wheel.

With the option left `ON`, a bare `pip install ortools` remains fully self‑contained — no behaviour change for the upstream wheels/builds.

Setting `-DVENDOR_PYBIND11_ABSEIL=OFF` lets downstream packagers that already ship `pybind11_abseil` as a separate runtime dependency (e.g. Debian, which provides `python3-pybind11-abseil`) skip the duplicate copy of `pybind11_abseil/status.*.cpython-*.so` that would cause a file conflict.

## Why

Distros that maintain `pybind11_abseil` themselves cannot consume the vendored copy without either colliding with their own package layout or shipping a redundant `.so`. Today the only way to suppress that staging is to patch `cmake/python.cmake`; this turns it into a supported, documented knob instead.

## Changes

Only `cmake/python.cmake`:

```cmake
option(VENDOR_PYBIND11_ABSEIL
  "Stage the pybind11_abseil Python module into the ortools wheel" ON)
```

## Compatibility

Default value is `ON`, so existing CI/wheel builds are byte-for-byte unaffected. The opt-out is purely additive for distribution builders who choose to flip it off.
