### PR TITLE
linear_solver: use glop instead of cbc in pywraplp_test.py

### DIFF
--- a/ortools/linear_solver/python/pywraplp_test.py
+++ b/ortools/linear_solver/python/pywraplp_test.py
@@ -47,7 +47,7 @@ class PyWrapLp(unittest.TestCase):
     def test_proto(self):
         input_proto = linear_solver_pb2.MPModelProto()
         text_format.Merge(TEXT_MODEL, input_proto)
-        solver = pywraplp.Solver.CreateSolver("CBC")
+        solver = pywraplp.Solver.CreateSolver("GLOP")
         if not solver:
             return
         # For now, create the model from the proto by parsing the proto

--- a/ortools/linear_solver/python/pywraplp_test.py
+++ b/ortools/linear_solver/python/pywraplp_test.py
@@ -55,11 +55,12 @@ class PyWrapLp(unittest.TestCase):
         self.assertEqual(error, "")
         solver.Solve()
         # Fill solution
-        solution = solver.FillSolutionResponseProto()
+        solution = linear_solver_pb2.MPSolutionResponse()
+        solver.FillSolutionResponseProto(solution)
         self.assertEqual(solution.objective_value, 3.0)
         self.assertEqual(solution.variable_value[0], 1.0)
         self.assertEqual(solution.variable_value[1], 1.0)
-        self.assertEqual(solution.best_objective_bound, 3.0)
+        self.assertEqual(solution.best_objective_bound, 0.0)
 
     def test_external_api(self):
         solver = pywraplp.Solver.CreateSolver("GLOP")


### PR DESCRIPTION
1. Bazel do not have python swig support i.e. pywraplp is not build

2. Presubmit.yml CI build without COINOR support to save time
2.1. pywraplp test use CBC solver to test  `solver.FillSolutionResponseProto()` so test is "disable"
https://github.com/google/or-tools/blob/3bf21b5678d7acd6e682ea8329617351630117cf/ortools/linear_solver/python/pywraplp_test.py#L50-L58

3. Contrary to `amd64_<os>_cmake_python.yml` job which fail as expected
trace:
```
267/585 Test #267: python_linear_solver_pywraplp_test ..................................................***Failed    0.28 sec
============================= test session starts ==============================
platform linux -- Python 3.10.21, pytest-9.1.1, pluggy-1.6.0
rootdir: /home/runner/work/or-tools/or-tools
collected 2 items

../../../ortools/linear_solver/python/pywraplp_test.py .F                [100%]

=================================== FAILURES ===================================
_____________________________ PyWrapLp.test_proto ______________________________

self = <pywraplp_test.PyWrapLp testMethod=test_proto>

    def test_proto(self):
        input_proto = linear_solver_pb2.MPModelProto()
        text_format.Merge(TEXT_MODEL, input_proto)
        solver = pywraplp.Solver.CreateSolver("CBC")
        if not solver:
            return
        # For now, create the model from the proto by parsing the proto
        error = solver.LoadModelFromProto(input_proto)
        self.assertEqual(error, "")
        solver.Solve()
        # Fill solution
>       solution = solver.FillSolutionResponseProto()
E       TypeError: Solver.FillSolutionResponseProto() missing 1 required positional argument: 'response'

../../../ortools/linear_solver/python/pywraplp_test.py:58: TypeError
=========================== short test summary info ============================
FAILED ../../../ortools/linear_solver/python/pywraplp_test.py::PyWrapLp::test_proto - TypeError: Solver.FillSolutionResponseProto() missing 1 required positional argument: 'response'
========================= 1 failed, 1 passed in 0.09s ==========================
```

Using "GLOP" should make the presubmit jobs catching the error too

patch incoming
