### PR TITLE
tools: remove pkg_resources from check_python_deps.py

### DIFF
--- a/tools/check_python_deps.py
+++ b/tools/check_python_deps.py
@@ -33,9 +33,6 @@ Follow this link for installing instructions :
 https://pypi.python.org/pypi/setuptools
 make sure you use \"""" + sys.executable + """\" during the installation""")
 
-from pkg_resources import \
-    parse_version  # pylint: disable=g-import-not-at-top,unused-import
-
 required_ortools_version = "VVVV"
 required_protobuf_version = "PROTOBUF_TAG"
 


### PR DESCRIPTION
<!--
Thank you for submitting a PR!

Please make sure you are targeting the main branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->

Continuation of https://github.com/google/or-tools/pull/5032. Note that the error is not unique to alpine; it affects any environment with setuptools newer than v82.0.0 (see <https://setuptools.pypa.io/en/latest/deprecated/pkg_resources.html>).
