### PR TITLE
Skip -1 interval in shaving solver model copy

### DIFF
--- a/ortools/sat/shaving_solver.cc
+++ b/ortools/sat/shaving_solver.cc
@@ -597,6 +597,8 @@ void VariablesShavingSolver::CopyModelConnectedToVar(
         const int y_interval = ct.no_overlap_2d().y_intervals(i);
         if (!active_constraints(x_interval)) continue;
         if (!active_constraints(y_interval)) continue;
+        if (interval_mapping[x_interval] == -1) continue;
+        if (interval_mapping[y_interval] == -1) continue;
 
         new_no_overlap_2d->add_x_intervals(interval_mapping[x_interval]);
         new_no_overlap_2d->add_y_intervals(interval_mapping[y_interval]);


### PR DESCRIPTION
Encountered a consistent segfault that occurred after variables shaving solver performed a model copy and copied unitialized intervals with `-1` values in `interval_mapping`. These values were then used to index an `std::vector` and caused its corruption. 

The PR adds a check for such -1 values in `interval_mapping` and skips them (this approach mirrors similar checks in `ModelCopy::CopyAndMapNoOverlap2D`).