### PR TITLE
Make solver randomization platform independent

### DIFF
--- a/ortools/glop/BUILD.bazel
+++ b/ortools/glop/BUILD.bazel
@@ -63,6 +63,7 @@ cc_library(
     deps = [
         "//ortools/lp_data:lp_types",
         "//ortools/util:bitset",
+        "//ortools/util:random_engine",
         "//ortools/util:stats",
         "@abseil-cpp//absl/log:check",
         "@abseil-cpp//absl/random",
@@ -169,6 +170,7 @@ cc_library(
         ":update_row",
         ":variables_info",
         "//ortools/lp_data:lp_types",
+        "//ortools/util:random_engine",
         "//ortools/util:stats",
         "@abseil-cpp//absl/base:core_headers",
         "@abseil-cpp//absl/log",
@@ -219,6 +221,7 @@ cc_library(
         "//ortools/lp_data:scattered_vector",
         "//ortools/lp_data:sparse",
         "//ortools/util:bitset",
+        "//ortools/util:random_engine",
         "//ortools/util:stats",
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/log:check",

--- a/ortools/glop/entering_variable.cc
+++ b/ortools/glop/entering_variable.cc
@@ -27,6 +27,7 @@
 #include "ortools/glop/update_row.h"
 #include "ortools/glop/variables_info.h"
 #include "ortools/lp_data/lp_types.h"
+#include "ortools/util/random_engine.h"
 #include "ortools/util/stats.h"
 
 namespace operations_research {
@@ -216,9 +217,8 @@ ColIndex EnteringVariable::DualChooseEnteringColumn(
   // Break the ties randomly.
   if (!equivalent_entering_choices_.empty()) {
     equivalent_entering_choices_.push_back(entering_col);
-    entering_col =
-        equivalent_entering_choices_[std::uniform_int_distribution<int>(
-            0, equivalent_entering_choices_.size() - 1)(random_)];
+    entering_col = equivalent_entering_choices_[
+        StableUniformIndex(random_, equivalent_entering_choices_.size())];
     IF_STATS_ENABLED(
         stats_.num_perfect_ties.Add(equivalent_entering_choices_.size()));
   }

--- a/ortools/glop/pricing.h
+++ b/ortools/glop/pricing.h
@@ -23,6 +23,7 @@
 #include "absl/random/random.h"
 #include "ortools/lp_data/lp_types.h"
 #include "ortools/util/bitset.h"
+#include "ortools/util/random_engine.h"
 #include "ortools/util/stats.h"
 
 namespace operations_research {
@@ -203,8 +204,8 @@ inline Index DynamicMaximum<Index>::RandomizeIfManyChoices(Index best) {
   equivalent_choices_.push_back(best);
   stats_.random_choices.Add(equivalent_choices_.size());
 
-  return equivalent_choices_[std::uniform_int_distribution<int>(
-      0, equivalent_choices_.size() - 1)(random_)];
+  return equivalent_choices_[
+      StableUniformIndex(random_, equivalent_choices_.size())];
 }
 
 template <typename Index>

--- a/ortools/glop/reduced_costs.cc
+++ b/ortools/glop/reduced_costs.cc
@@ -30,6 +30,7 @@
 #include "ortools/lp_data/scattered_vector.h"
 #include "ortools/lp_data/sparse.h"
 #include "ortools/util/bitset.h"
+#include "ortools/util/random_engine.h"
 #include "ortools/util/stats.h"
 
 namespace operations_research {
@@ -247,8 +248,7 @@ void ReducedCosts::PerturbCosts() {
   cost_perturbations_.AssignToZero(matrix_.num_cols());
   for (ColIndex col(0); col < structural_size; ++col) {
     const Fractional objective = objective_[col];
-    const Fractional magnitude =
-        (1.0 + std::uniform_real_distribution<double>()(random_)) *
+    const Fractional magnitude = (1.0 + StableUniformDouble(random_)) *
         (parameters_.relative_cost_perturbation() * std::abs(objective) +
          parameters_.relative_max_cost_perturbation() * max_cost_magnitude);
     DCHECK_GE(magnitude, 0.0);

--- a/ortools/glop/revised_simplex.cc
+++ b/ortools/glop/revised_simplex.cc
@@ -2153,9 +2153,8 @@ void RevisedSimplex::ChooseLeavingVariableRow(
     // Break the ties randomly.
     if (!equivalent_leaving_choices_.empty()) {
       equivalent_leaving_choices_.push_back(*leaving_row);
-      *leaving_row =
-          equivalent_leaving_choices_[std::uniform_int_distribution<int>(
-              0, equivalent_leaving_choices_.size() - 1)(random_)];
+      *leaving_row = equivalent_leaving_choices_[
+          StableUniformIndex(random_, equivalent_leaving_choices_.size())];
     }
 
     // Since we took care of the bound-flip at the beginning, at this point
@@ -2897,7 +2896,7 @@ AbnormalityStatus RevisedSimplex::PrimalPolish(TimeLimit& time_limit) {
 
     // Pick a random one and remove it from the list.
     const int index =
-        std::uniform_int_distribution<int>(0, candidates.size() - 1)(random_);
+        static_cast<int>(StableUniformIndex(random_, candidates.size()));
     const ColIndex entering_col = candidates[index];
     std::swap(candidates[index], candidates.back());
     candidates.pop_back();
@@ -3050,7 +3049,7 @@ AbnormalityStatus RevisedSimplex::DualPolish(TimeLimit& time_limit) {
 
     // Pick a random one and remove it from the list.
     const int index =
-        std::uniform_int_distribution<int>(0, candidates.size() - 1)(random_);
+        static_cast<int>(StableUniformIndex(random_, candidates.size()));
     const RowIndex leaving_row = candidates[index];
     std::swap(candidates[index], candidates.back());
     candidates.pop_back();

--- a/ortools/sat/BUILD.bazel
+++ b/ortools/sat/BUILD.bazel
@@ -3718,6 +3718,7 @@ cc_library(
         ":integer_base",
         ":util",
         "//ortools/lp_data:lp_types",
+        "//ortools/util:random_engine",
         "//ortools/util:strong_integers",
         "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/log:check",

--- a/ortools/sat/clause.cc
+++ b/ortools/sat/clause.cc
@@ -3108,8 +3108,8 @@ BinaryImplicationGraph::GenerateAtMostOnesWithLargeWeight(
     // TODO(user): Prefer more fractional variables.
     const int max_graph_size = 1024;
     if (fractional_literals.size() > max_graph_size) {
-      std::shuffle(fractional_literals.begin(), fractional_literals.end(),
-                   random_);
+      StableShuffle(fractional_literals.begin(), fractional_literals.end(),
+                    random_);
       fractional_literals.resize(max_graph_size);
     }
 

--- a/ortools/sat/continuous_prober.cc
+++ b/ortools/sat/continuous_prober.cc
@@ -109,10 +109,11 @@ ContinuousProber::ContinuousProber(const CpModelProto& model_proto,
                ShavingStats::kRateWindowSizeMax));
   int_shaving_.limit_update_frequency = ShavingStats::kUpdateFrequency;
 
-  std::shuffle(bool_vars_to_probe_.begin(), bool_vars_to_probe_.end(), random_);
-  std::shuffle(int_vars_to_probe_.begin(), int_vars_to_probe_.end(), random_);
-  std::shuffle(bool_vars_to_shave_.begin(), bool_vars_to_shave_.end(), random_);
-  std::shuffle(int_vars_to_shave_.begin(), int_vars_to_shave_.end(), random_);
+  StableShuffle(bool_vars_to_probe_.begin(), bool_vars_to_probe_.end(), random_);
+  StableShuffle(int_vars_to_probe_.begin(), int_vars_to_probe_.end(), random_);
+  StableShuffle(bool_vars_to_shave_.begin(), bool_vars_to_shave_.end(),
+                random_);
+  StableShuffle(int_vars_to_shave_.begin(), int_vars_to_shave_.end(), random_);
 
   CompactVectorVector<int, int> orbits;
   std::vector<int> var_to_orbit_index;
@@ -147,7 +148,7 @@ void ContinuousProber::CompactAndShuffleBooleanVariables(
     }
   }
   bool_vars.resize(new_size);
-  std::shuffle(bool_vars.begin(), bool_vars.end(), random_);
+  StableShuffle(bool_vars.begin(), bool_vars.end(), random_);
 }
 
 void ContinuousProber::CompactAndShuffleIntegerVariables(
@@ -159,7 +160,7 @@ void ContinuousProber::CompactAndShuffleIntegerVariables(
     }
   }
   int_vars.resize(new_size);
-  std::shuffle(int_vars.begin(), int_vars.end(), random_);
+  StableShuffle(int_vars.begin(), int_vars.end(), random_);
 }
 
 #define RETURN_IF_VALUE(fun)                                           \

--- a/ortools/sat/cp_model_lns.cc
+++ b/ortools/sat/cp_model_lns.cc
@@ -805,11 +805,10 @@ TimePartition PartitionIndicesAroundRandomTimeWindow(
   std::sort(start_end_indices.begin(), start_end_indices.end());
   const int relaxed_size = std::floor(difficulty * start_end_indices.size());
 
-  std::uniform_int_distribution<int> random_var(
-      0, start_end_indices.size() - relaxed_size - 1);
   // TODO(user): Consider relaxing more than one time window
   // intervals. This seems to help with Giza models.
-  const int random_start_index = random_var(random);
+  const int random_start_index = static_cast<int>(StableUniformIndex(
+      random, start_end_indices.size() - relaxed_size));
 
   // We want to minimize the time window relaxed, so we now sort the interval
   // after the first selected intervals by end value.
@@ -1579,7 +1578,7 @@ void GetRandomSubset(double relative_size, std::vector<T>* base,
 
   // TODO(user): we could generate this more efficiently than using random
   // shuffle.
-  std::shuffle(base->begin(), base->end(), random);
+  StableShuffle(base->begin(), base->end(), random);
   const int target_size = std::round(relative_size * base->size());
   base->resize(target_size);
 }
@@ -1612,7 +1611,7 @@ Neighborhood RelaxRandomConstraintsGenerator::Generate(
     for (int c = 0; c < num_active_constraints; ++c) {
       active_constraints[c] = c;
     }
-    std::shuffle(active_constraints.begin(), active_constraints.end(), random);
+    StableShuffle(active_constraints.begin(), active_constraints.end(), random);
 
     const int num_model_vars = helper_.ModelProto().variables_size();
     std::vector<bool> visited_variables_set(num_model_vars, false);
@@ -1692,7 +1691,7 @@ Neighborhood VariableGraphNeighborhoodGenerator::Generate(
       }
       // We always randomize to change the partial subgraph explored
       // afterwards.
-      std::shuffle(random_variables.begin(), random_variables.end(), random);
+      StableShuffle(random_variables.begin(), random_variables.end(), random);
       for (const int var : random_variables) {
         if (relaxed_variables.size() < target_size) {
           visited_variables.push_back(var);
@@ -1882,7 +1881,7 @@ Neighborhood ConstraintGraphNeighborhoodGenerator::Generate(
       random_variables.assign(
           helper_.ConstraintToVar()[constraint_index].begin(),
           helper_.ConstraintToVar()[constraint_index].end());
-      std::shuffle(random_variables.begin(), random_variables.end(), random);
+      StableShuffle(random_variables.begin(), random_variables.end(), random);
       for (const int var : random_variables) {
         if (visited_variables_set[var]) continue;
         visited_variables_set[var] = true;
@@ -3026,8 +3025,8 @@ Neighborhood RoutingFullPathNeighborhoodGenerator::Generate(
 
   // Relax all variables, if possible, of one random path.
   const int path_index = absl::Uniform<int>(random, 0, all_paths.size());
-  std::shuffle(all_paths[path_index].begin(), all_paths[path_index].end(),
-               random);
+  StableShuffle(all_paths[path_index].begin(), all_paths[path_index].end(),
+                random);
   while (relaxed_variables.size() < num_variables_to_relax &&
          !all_paths[path_index].empty()) {
     relaxed_variables.insert(all_paths[path_index].back());
@@ -3036,7 +3035,7 @@ Neighborhood RoutingFullPathNeighborhoodGenerator::Generate(
 
   // Relax more variables until the target is reached.
   if (relaxed_variables.size() < num_variables_to_relax) {
-    std::shuffle(all_path_variables.begin(), all_path_variables.end(), random);
+    StableShuffle(all_path_variables.begin(), all_path_variables.end(), random);
     while (relaxed_variables.size() < num_variables_to_relax) {
       relaxed_variables.insert(all_path_variables.back());
       all_path_variables.pop_back();

--- a/ortools/sat/cp_model_presolve.cc
+++ b/ortools/sat/cp_model_presolve.cc
@@ -4857,7 +4857,7 @@ void CpModelPresolver::FindBigAtMostOneAndLinearOverlap(
 
     // We will just greedily compute a big block with a random order.
     // TODO(user): We could sort by match with the full constraint instead.
-    std::shuffle(linear_cts.begin(), linear_cts.end(), context_->random());
+    StableShuffle(linear_cts.begin(), linear_cts.end(), context_->random());
     for (const int c : linear_cts) {
       const ConstraintProto& ct = context_->Constraint(c);
       const int num_terms = ct.linear().vars().size();
@@ -5076,7 +5076,7 @@ void CpModelPresolver::FindBigVerticalLinearOverlap(
 
     // For determinism.
     std::sort(linear_cts.begin(), linear_cts.end());
-    std::shuffle(linear_cts.begin(), linear_cts.end(), context_->random());
+    StableShuffle(linear_cts.begin(), linear_cts.end(), context_->random());
 
     // Now it is almost the same algo as for FindBigHorizontalLinearOverlap().
     // We greedily compute a "common" rectangle using the first constraint
@@ -6422,7 +6422,7 @@ void CpModelPresolver::PresolveToFixPoint() {
   // In September 2019, experiment on the flatzinc problems shows no changes in
   // the results. We should actually count the number of rules triggered.
   if (context_->params().permute_presolve_constraint_order()) {
-    std::shuffle(queue.begin(), queue.end(), context_->random());
+    StableShuffle(queue.begin(), queue.end(), context_->random());
   } else {
     if (queue.size() > context_->NumVariables()) {
       // We do a radix-sort if there are more constraints than variables, it can
@@ -7561,7 +7561,7 @@ void CpModelPresolver::MaybePermuteVariablesRandomly(
   const int n = postsolve_mapping_->size();
   std::vector<int> perm(n);
   std::iota(perm.begin(), perm.end(), 0);
-  std::shuffle(perm.begin(), perm.end(), context_->random());
+  StableShuffle(perm.begin(), perm.end(), context_->random());
   for (int i = 0; i < context_->NumVariables(); ++i) {
     if (mapping[i] != -1) mapping[i] = perm[mapping[i]];
   }

--- a/ortools/sat/diffn_util.cc
+++ b/ortools/sat/diffn_util.cc
@@ -407,7 +407,7 @@ absl::Span<int> FilterBoxesAndRandomize(
     boxes[new_size++] = b;
   }
   if (new_size == 0) return {};
-  std::shuffle(&boxes[0], &boxes[0] + new_size, random);
+  StableShuffle(&boxes[0], &boxes[0] + new_size, random);
   return {&boxes[0], new_size};
 }
 

--- a/ortools/sat/linear_programming_constraint.cc
+++ b/ortools/sat/linear_programming_constraint.cc
@@ -1930,7 +1930,7 @@ void LinearProgrammingConstraint::AddMirCuts() {
   // entries we process. We randomize the base_rows so that on the next calls
   // we do not do exactly the same if we can't process many base row.
   int64_t dtime_num_entries = 0;
-  std::shuffle(base_rows.begin(), base_rows.end(), random_);
+  StableShuffle(base_rows.begin(), base_rows.end(), random_);
 
   std::vector<double> weights;
   util_intops::StrongVector<RowIndex, bool> used_rows;

--- a/ortools/sat/max_hs.cc
+++ b/ortools/sat/max_hs.cc
@@ -110,7 +110,7 @@ SatSolver::Status HittingSetOptimizer::FindMultipleCoresForMaxHs(
 
     // The order of assumptions do not matter.
     // Randomizing it should improve diversity.
-    std::shuffle(assumptions.begin(), assumptions.end(), *random_);
+    StableShuffle(assumptions.begin(), assumptions.end(), *random_);
 
     const SatSolver::Status result =
         ResetAndSolveIntegerProblem(assumptions, model_);

--- a/ortools/sat/sat_decision.cc
+++ b/ortools/sat/sat_decision.cc
@@ -231,7 +231,7 @@ void SatDecisionPolicy::FlipCurrentPolarity() {
 void SatDecisionPolicy::RandomizeCurrentPolarity() {
   const int num_variables = var_polarity_.size().value();
   for (BooleanVariable var; var < num_variables; ++var) {
-    var_polarity_.Set(var, std::uniform_int_distribution<int>(0, 1)(random_));
+    var_polarity_.Set(var, StableUniformIndex(random_, 2));
   }
 }
 
@@ -286,7 +286,7 @@ void SatDecisionPolicy::InitializeVariableOrdering() {
       std::reverse(tmp_variables_.begin(), tmp_variables_.end());
       break;
     case SatParameters::IN_RANDOM_ORDER:
-      std::shuffle(tmp_variables_.begin(), tmp_variables_.end(), random_);
+      StableShuffle(tmp_variables_.begin(), tmp_variables_.end(), random_);
       break;
   }
 
@@ -390,16 +390,14 @@ Literal SatDecisionPolicy::NextBranch() {
   // Choose the variable.
   BooleanVariable var;
   const double ratio = parameters_.random_branches_ratio();
-  auto zero_to_one = [this]() {
-    return std::uniform_real_distribution<double>()(random_);
-  };
+  auto zero_to_one = [this]() { return StableUniformDouble(random_); };
   if (ratio != 0.0 && zero_to_one() < ratio) {
     while (true) {
       // TODO(user): This may not be super efficient if almost all the
       // variables are assigned.
-      std::uniform_int_distribution<int> index_dist(0,
-                                                    var_ordering_.Size() - 1);
-      var = var_ordering_.QueueElement(index_dist(random_)).var;
+      const int index = static_cast<int>(
+          StableUniformIndex(random_, var_ordering_.Size()));
+      var = var_ordering_.QueueElement(index).var;
       if (!trail_.Assignment().VariableIsAssigned(var)) break;
       pq_need_update_for_var_at_trail_index_.Set(trail_.Info(var).trail_index);
       var_ordering_.Remove(var.value());
@@ -419,7 +417,7 @@ Literal SatDecisionPolicy::NextBranch() {
   // Choose its polarity (i.e. True of False).
   const double random_ratio = parameters_.random_polarity_ratio();
   if (random_ratio != 0.0 && zero_to_one() < random_ratio) {
-    return Literal(var, std::uniform_int_distribution<int>(0, 1)(random_));
+    return Literal(var, StableUniformIndex(random_, 2));
   }
 
   if (has_forced_polarity_[var]) return Literal(var, forced_polarity_[var]);

--- a/ortools/sat/util.cc
+++ b/ortools/sat/util.cc
@@ -829,7 +829,7 @@ class CliqueDecomposition {
     if (absl::Bernoulli(random_, 0.5)) {
       std::reverse(decomposition_.begin(), decomposition_.end());
     } else {
-      std::shuffle(decomposition_.begin(), decomposition_.end(), random_);
+      StableShuffle(decomposition_.begin(), decomposition_.end(), random_);
     }
 
     int out_index = 0;

--- a/ortools/sat/zero_half_cuts.cc
+++ b/ortools/sat/zero_half_cuts.cc
@@ -23,6 +23,7 @@
 #include "absl/types/span.h"
 #include "ortools/lp_data/lp_types.h"
 #include "ortools/sat/integer_base.h"
+#include "ortools/util/random_engine.h"
 #include "ortools/util/strong_integers.h"
 
 namespace operations_research {
@@ -239,7 +240,7 @@ ZeroHalfCutHelper::InterestingCandidates(absl::BitGenRef random) {
   // Process rows by increasing size, but randomize if same size.
   std::vector<int> to_process;
   for (int row = 0; row < rows_.size(); ++row) to_process.push_back(row);
-  std::shuffle(to_process.begin(), to_process.end(), random);
+  StableShuffle(to_process.begin(), to_process.end(), random);
   std::stable_sort(to_process.begin(), to_process.end(), [this](int a, int b) {
     return rows_[a].cols.size() < rows_[b].cols.size();
   });

--- a/ortools/util/BUILD.bazel
+++ b/ortools/util/BUILD.bazel
@@ -473,6 +473,20 @@ cc_library(
     hdrs = ["random_engine.h"],
     copts = ORTOOLS_DEFAULT_COPTS,
     linkopts = ORTOOLS_DEFAULT_LINKOPTS,
+    deps = ["@abseil-cpp//absl/random:bit_gen_ref"],
+)
+
+cc_test(
+    name = "random_engine_test",
+    size = "small",
+    srcs = ["random_engine_test.cc"],
+    copts = ORTOOLS_TEST_COPTS,
+    linkopts = ORTOOLS_DEFAULT_LINKOPTS,
+    deps = [
+        ":random_engine",
+        "//ortools/base:gmock_main",
+        "@abseil-cpp//absl/random:bit_gen_ref",
+    ],
 )
 
 cc_library(

--- a/ortools/util/random_engine.h
+++ b/ortools/util/random_engine.h
@@ -16,11 +16,107 @@
 #ifndef ORTOOLS_UTIL_RANDOM_ENGINE_H_
 #define ORTOOLS_UTIL_RANDOM_ENGINE_H_
 
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <iterator>
+#include <limits>
 #include <random>
+
+#include "absl/random/bit_gen_ref.h"
 
 namespace operations_research {
 
 using random_engine_t = std::mt19937_64;
+
+namespace random_internal {
+
+// Returns the high 64 bits of the 128-bit product of lhs and rhs.
+inline uint64_t MultiplyHigh64(uint64_t lhs, uint64_t rhs) {
+  const uint64_t lhs_low = static_cast<uint32_t>(lhs);
+  const uint64_t lhs_high = lhs >> 32;
+  const uint64_t rhs_low = static_cast<uint32_t>(rhs);
+  const uint64_t rhs_high = rhs >> 32;
+
+  const uint64_t low_low = lhs_low * rhs_low;
+  const uint64_t low_high = lhs_low * rhs_high;
+  const uint64_t high_low = lhs_high * rhs_low;
+  const uint64_t high_high = lhs_high * rhs_high;
+  const uint64_t carry =
+      (low_low >> 32) + static_cast<uint32_t>(low_high) +
+      static_cast<uint32_t>(high_low);
+  return high_high + (low_high >> 32) + (high_low >> 32) + (carry >> 32);
+}
+
+}  // namespace random_internal
+
+// Returns a uniformly distributed value in [0, exclusive_upper_bound). This
+// uses Lemire's nearly divisionless algorithm, which is also used by libstdc++.
+// Keeping the mapping explicit makes it independent from the standard library
+// while preserving the existing libstdc++ search sequence.
+inline uint64_t StableUniformIndex(absl::BitGenRef random,
+                                   uint64_t exclusive_upper_bound) {
+  assert(exclusive_upper_bound > 0);
+  const uint64_t rejection_threshold =
+      -exclusive_upper_bound % exclusive_upper_bound;
+  while (true) {
+    const uint64_t value = random();
+    const uint64_t low = value * exclusive_upper_bound;
+    if (low < rejection_threshold) continue;
+    return random_internal::MultiplyHigh64(value, exclusive_upper_bound);
+  }
+}
+
+// Returns a uniformly distributed double in [0.0, 1.0). This is the conversion
+// used by libstdc++ for a full-width 64-bit generator and is independent from
+// the standard library implementation.
+inline double StableUniformDouble(absl::BitGenRef random) {
+  constexpr double kInverseTwoToThe64 = 0x1.0p-64;
+  constexpr double kLargestValueBelowOne = 0x1.fffffffffffffp-1;
+  return std::min(static_cast<double>(random()) * kInverseTwoToThe64,
+                  kLargestValueBelowOne);
+}
+
+// A platform-independent shuffle that preserves libstdc++'s optimized shuffle
+// sequence for 64-bit generators. The paired swaps reduce random engine calls.
+template <typename RandomAccessIterator>
+void StableShuffle(RandomAccessIterator first, RandomAccessIterator last,
+                   absl::BitGenRef random) {
+  using Difference =
+      typename std::iterator_traits<RandomAccessIterator>::difference_type;
+  const Difference size = last - first;
+  if (size <= 1) return;
+
+  const uint64_t unsigned_size = static_cast<uint64_t>(size);
+  if (std::numeric_limits<uint64_t>::max() / unsigned_size >= unsigned_size) {
+    Difference i = 1;
+    if (unsigned_size % 2 == 0) {
+      std::iter_swap(first + i,
+                     first + static_cast<Difference>(
+                                 StableUniformIndex(random, 2)));
+      ++i;
+    }
+    while (i < size) {
+      const uint64_t first_range = static_cast<uint64_t>(i) + 1;
+      const uint64_t second_range = first_range + 1;
+      const uint64_t combined =
+          StableUniformIndex(random, first_range * second_range);
+      std::iter_swap(first + i,
+                     first + static_cast<Difference>(combined / second_range));
+      ++i;
+      std::iter_swap(first + i,
+                     first + static_cast<Difference>(combined % second_range));
+      ++i;
+    }
+    return;
+  }
+
+  for (Difference i = 1; i < size; ++i) {
+    const Difference selected = static_cast<Difference>(
+        StableUniformIndex(random, static_cast<uint64_t>(i) + 1));
+    std::iter_swap(first + i, first + selected);
+  }
+}
 
 }  // namespace operations_research
 

--- a/ortools/util/random_engine_test.cc
+++ b/ortools/util/random_engine_test.cc
@@ -13,8 +13,12 @@
 
 #include "ortools/util/random_engine.h"
 
+#include <cstdint>
+#include <numeric>
 #include <random>
+#include <vector>
 
+#include "absl/random/bit_gen_ref.h"
 #include "gtest/gtest.h"
 
 // This test is just here to make sure that a type has been selected that
@@ -25,3 +29,50 @@ TEST(RandomEngineCompileTest, TestIt) {
   ASSERT_LT(engine.min(), engine.max());
   EXPECT_LT(-1, std::uniform_int_distribution<int>(0, 1)(engine));
 }
+
+namespace operations_research {
+namespace {
+
+TEST(RandomEngineTest, StableUniformIndexHasGoldenSequence) {
+  random_engine_t engine(123456789);
+  absl::BitGenRef random(engine);
+
+  std::vector<uint64_t> values;
+  for (int i = 0; i < 10; ++i) {
+    values.push_back(StableUniformIndex(random, 17));
+  }
+
+  EXPECT_EQ(values,
+            (std::vector<uint64_t>{5, 4, 2, 0, 14, 5, 1, 5, 9, 14}));
+}
+
+TEST(RandomEngineTest, StableUniformDoubleHasGoldenSequence) {
+  random_engine_t engine(123456789);
+  absl::BitGenRef random(engine);
+
+  std::vector<double> values;
+  for (int i = 0; i < 5; ++i) {
+    values.push_back(StableUniformDouble(random));
+  }
+
+  EXPECT_EQ(values,
+            (std::vector<double>{0x1.653e9fc646472p-2,
+                                 0x1.114a7ccca34d7p-2,
+                                 0x1.17da032f8db6dp-3,
+                                 0x1.d3e02ed304ecfp-6,
+                                 0x1.bce4d24af5c82p-1}));
+}
+
+TEST(RandomEngineTest, StableShuffleHasGoldenPermutation) {
+  random_engine_t engine(123456789);
+  absl::BitGenRef random(engine);
+  std::vector<int> values(12);
+  std::iota(values.begin(), values.end(), 0);
+
+  StableShuffle(values.begin(), values.end(), random);
+
+  EXPECT_EQ(values, (std::vector<int>{6, 7, 1, 10, 5, 2, 4, 8, 9, 0, 11, 3}));
+}
+
+}  // namespace
+}  // namespace operations_research


### PR DESCRIPTION
## Problem

`std::mt19937_64` produces a specified engine sequence, but the mapping performed by `std::uniform_int_distribution`, `std::uniform_real_distribution`, and `std::shuffle` is implementation-defined. As a result, a fixed seed can select different GLOP pivots and CP-SAT branches on libstdc++ and MSVC STL, leading to different search trajectories and solutions.

## Change

- Add explicit platform-independent helpers for bounded integers, doubles in `[0, 1)`, and shuffling.
- Preserve the existing libstdc++ sequence, including its paired-swap shuffle optimization.
- Replace standard-library distributions and shuffles used by GLOP and CP-SAT search randomization.
- Add golden-sequence tests so Linux and native Windows must consume the same random values.

This intentionally preserves current Linux behavior while making native Windows follow the same sequence.

## Validation

- `cxx_util_random_engine_test`
- `cxx_glop_pricing_test`
- `cxx_sat_cp_model_solver_test`
- Native MSVC golden-sequence test
- Native Windows CP-SAT Python wheel smoke test
- Downstream deterministic scheduling regression repeated twice on native Windows and matched the WSL result exactly
