### PR TITLE
Fix generated proto exports in Windows shared builds

### DIFF
--- a/cmake/cpp.cmake
+++ b/cmake/cpp.cmake
@@ -563,7 +563,18 @@ function(generate_proto_library)
     ${PROJECT_BINARY_DIR}
     #$<TARGET_PROPERTY:protobuf::libprotobuf,INTERFACE_INCLUDE_DIRECTORIES>
   )
-  target_compile_definitions(${PROTO_NAME}_proto PUBLIC ${OR_TOOLS_COMPILE_DEFINITIONS})
+  # OR_TOOLS_COMPILE_DEFINITIONS contains the import definition used by
+  # consumers of the generated proto library. Do not also pass it when
+  # compiling the proto objects themselves: MSVC otherwise sees both
+  # dllimport and dllexport, with dllimport winning because of command-line
+  # ordering, and rejects definitions of generated static data members.
+  set(PROTO_COMPILE_DEFINITIONS ${OR_TOOLS_COMPILE_DEFINITIONS})
+  if(MSVC AND BUILD_SHARED_LIBS)
+    list(FILTER PROTO_COMPILE_DEFINITIONS EXCLUDE REGEX
+         "^OR_${PROTO_UPPER_NAME}_PROTO_DLL=")
+  endif()
+  target_compile_definitions(${PROTO_NAME}_proto PUBLIC
+                             ${PROTO_COMPILE_DEFINITIONS})
   if(MSVC AND BUILD_SHARED_LIBS)
    target_compile_definitions(${PROTO_NAME}_proto INTERFACE "OR_${PROTO_UPPER_NAME}_PROTO_DLL=__declspec(dllimport)")
    target_compile_definitions(${PROTO_NAME}_proto PRIVATE "OR_${PROTO_UPPER_NAME}_PROTO_DLL=__declspec(dllexport)")


### PR DESCRIPTION
## Problem

When generated proto object libraries are compiled as part of a shared MSVC build, `OR_TOOLS_COMPILE_DEFINITIONS` can provide the consumer-side `dllimport` definition while the target also adds its private `dllexport` definition. Both definitions then appear on the compiler command line. If `dllimport` wins by command-line ordering, MSVC rejects definitions of generated static data members with C2491.

## Change

Filter the current generated proto target's consumer-side import macro out of the common compile definitions before applying the target's explicit interface/private import/export definitions.

Non-MSVC and static builds are unchanged.

## Validation

- Configured and built a native Windows shared OR-Tools Python wheel with MSVC.
- Verified generated proto compilation contains only the target's `dllexport` definition.
- Successfully linked `ortools.dll` and all Python extension modules.
- Imported MathOpt protobuf modules and solved a CP-SAT smoke model from the resulting wheel.
