### PR TITLE
[ci] Increase maximum bazel-remote concurrent connections

### DIFF
--- a/.github/actions/remote_cache/action.yml
+++ b/.github/actions/remote_cache/action.yml
@@ -41,5 +41,7 @@ runs:
         echo "Installing remote cache in workspace 'user.bazelrc'"
         # Compresses blobs locally before uploading them to GCS and decompresses them upon download.
         echo "common --remote_cache_compression=true" >> ./user.bazelrc
+        # Increase maximum concurrent connections from 100 to 200.
+        echo "common --remote_max_connections=200" >> ./user.bazelrc
         echo "common --google_default_credentials" >> ./user.bazelrc
         echo "common --remote_cache=https://storage.googleapis.com/or-tools-github-remote-caching" >> ./user.bazelrc


### PR DESCRIPTION
The github CI workers are small machines so this change does not have measurable effects but on machines with more cores this hides the network latency and speed up incremental builds.