### PR TITLE
Add s390x build support

### DIFF
--- a/cmake/cpp.cmake
+++ b/cmake/cpp.cmake
@@ -137,6 +137,10 @@ else()
   )
 endif()
 
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "s390x")
+  list(APPEND OR_TOOLS_COMPILE_OPTIONS "-fpermissive")
+endif()
+
 ################
 ##  C++ Test  ##
 ################


### PR DESCRIPTION
This PR adds support to build or-tools python package for IBM Z (arch: s390x) system.

TODO: Add documentation + ensure s390x python wheel is built & uploaded to pypi.