### PR TITLE
fix(set_cover): initialize thread_pool_ and remove stale ThreePhase declaration (fixes #5341)

### DIFF
--- a/ortools/set_cover/BUILD.bazel
+++ b/ortools/set_cover/BUILD.bazel
@@ -424,6 +424,7 @@ cc_test(
         ":set_cover_cc_proto",
         ":set_cover_heuristics",
         ":set_cover_invariant",
+        ":set_cover_lagrangian",
         ":set_cover_mip",
         ":set_cover_model",
         "//ortools/base:gmock_main",

--- a/ortools/set_cover/set_cover_lagrangian.cc
+++ b/ortools/set_cover/set_cover_lagrangian.cc
@@ -500,6 +500,9 @@ SetCoverLagrangian::ComputeLowerBound(const SubsetCostVector& costs,
                                       Cost upper_bound) {
   StopWatch stop_watch(&run_time_);
   Cost lower_bound = 0.0;
+  if (thread_pool_ == nullptr) {
+    UseNumThreads(params().num_threads);
+  }
   ElementCostVector multipliers = InitializeLagrangeMultipliers();
   double step_size = 0.1;               // [***] arbitrary, from [1].
   StepSizer step_sizer(20, step_size);  // [***] arbitrary, from [1].

--- a/ortools/set_cover/set_cover_lagrangian.h
+++ b/ortools/set_cover/set_cover_lagrangian.h
@@ -63,18 +63,21 @@ class SetCoverLagrangian
       : SubsetListBasedOptimizer(
             inv, SetCoverInvariant::ConsistencyLevel::kInconsistent,
             std::move(params)),
-        thread_pool_(nullptr) {}
+        thread_pool_(
+            std::make_unique<ThreadPool>(this->params().num_threads)) {}
 
   SetCoverLagrangian(SetCoverInvariant* inv, const absl::string_view name)
       : SubsetListBasedOptimizer(
             inv, SetCoverInvariant::ConsistencyLevel::kInconsistent,
-            std::make_unique<SetCoverLagrangianParams>()) {
+            std::make_unique<SetCoverLagrangianParams>()),
+        thread_pool_(
+            std::make_unique<ThreadPool>(this->params().num_threads)) {
     SetName(name);
-    params().class_name = "Lagrangian";
+    this->params().class_name = "Lagrangian";
   }
 
   SetCoverLagrangian& UseNumThreads(int num_threads) {
-    params().num_threads = num_threads;
+    this->params().num_threads = num_threads;
     thread_pool_ = std::make_unique<ThreadPool>(num_threads);
     return *this;
   }
@@ -144,9 +147,6 @@ class SetCoverLagrangian
   Cost ComputeGap(const SubsetCostVector& reduced_costs,
                   const SubsetBoolVector& solution,
                   const ElementCostVector& multipliers) const;
-
-  // Performs the three-phase algorithm.
-  void ThreePhase(Cost upper_bound);
 
   // Computes a lower bound on the optimal cost.
   // The returned value is the lower bound, the reduced costs, and the

--- a/ortools/set_cover/set_cover_lagrangian.h
+++ b/ortools/set_cover/set_cover_lagrangian.h
@@ -63,15 +63,14 @@ class SetCoverLagrangian
       : SubsetListBasedOptimizer(
             inv, SetCoverInvariant::ConsistencyLevel::kInconsistent,
             std::move(params)),
-        thread_pool_(
-            std::make_unique<ThreadPool>(this->params().num_threads)) {}
+        thread_pool_(std::make_unique<ThreadPool>(this->params().num_threads)) {
+  }
 
   SetCoverLagrangian(SetCoverInvariant* inv, const absl::string_view name)
       : SubsetListBasedOptimizer(
             inv, SetCoverInvariant::ConsistencyLevel::kInconsistent,
             std::make_unique<SetCoverLagrangianParams>()),
-        thread_pool_(
-            std::make_unique<ThreadPool>(this->params().num_threads)) {
+        thread_pool_(std::make_unique<ThreadPool>(this->params().num_threads)) {
     SetName(name);
     this->params().class_name = "Lagrangian";
   }

--- a/ortools/set_cover/set_cover_test.cc
+++ b/ortools/set_cover/set_cover_test.cc
@@ -143,7 +143,8 @@ TEST(SetCoverTest, LagrangianComputeLowerBoundDefaultThreadPool) {
   model.AddElementToLastSubset(0);
   SetCoverInvariant inv(&model);
 
-  // Verifies that ComputeLowerBound() works without calling UseNumThreads() first.
+  // Verifies that ComputeLowerBound() works without calling UseNumThreads()
+  // first.
   SetCoverLagrangian lagrangian(&inv);
   auto [lower_bound, reduced_costs, multipliers] =
       lagrangian.ComputeLowerBound(model.subset_costs(), 3.0);

--- a/ortools/set_cover/set_cover_test.cc
+++ b/ortools/set_cover/set_cover_test.cc
@@ -23,6 +23,7 @@
 #include "ortools/set_cover/set_cover.pb.h"
 #include "ortools/set_cover/set_cover_heuristics.h"
 #include "ortools/set_cover/set_cover_invariant.h"
+#include "ortools/set_cover/set_cover_lagrangian.h"
 #include "ortools/set_cover/set_cover_mip.h"
 #include "ortools/set_cover/set_cover_model.h"
 
@@ -127,6 +128,26 @@ TEST(SetCoverTest, MipErasePreviousSubsets) {
   mip.Optimize();
 
   EXPECT_THAT(inv.is_selected(), ElementsAre(true, false, false));
+}
+
+TEST(SetCoverTest, LagrangianComputeLowerBoundDefaultThreadPool) {
+  SetCoverModel model;
+  model.AddEmptySubset(1);
+  model.AddElementToLastSubset(0);
+  model.AddElementToLastSubset(1);
+  model.AddEmptySubset(1);
+  model.AddElementToLastSubset(1);
+  model.AddElementToLastSubset(2);
+  model.AddEmptySubset(1);
+  model.AddElementToLastSubset(2);
+  model.AddElementToLastSubset(0);
+  SetCoverInvariant inv(&model);
+
+  // Verifies that ComputeLowerBound() works without calling UseNumThreads() first.
+  SetCoverLagrangian lagrangian(&inv);
+  auto [lower_bound, reduced_costs, multipliers] =
+      lagrangian.ComputeLowerBound(model.subset_costs(), 3.0);
+  EXPECT_GE(lower_bound, 0.0);
 }
 
 }  // namespace


### PR DESCRIPTION
### Description

Fixes #5341.

This PR addresses two issues in `ortools/set_cover/set_cover_lagrangian`:

1. **Remove stale `ThreePhase` declaration**:
   - `set_cover_lagrangian.h` declared `void ThreePhase(Cost upper_bound);` with no corresponding definition in `ortools/set_cover` (the three-phase algorithm was migrated to `set_cover_cft.cc` as `RunThreePhase`).
   - Calling or binding `&SetCoverLagrangian::ThreePhase` leads to link-time or runtime symbol import errors (`undefined symbol: _ZN19operations_research18SetCoverLagrangian10ThreePhaseEd`). The stale declaration is removed.

2. **Initialize `thread_pool_` to prevent SIGSEGV in `ComputeLowerBound`**:
   - Previously, `thread_pool_` was initialized to `nullptr` in constructors unless `UseNumThreads()` was explicitly called prior to `ComputeLowerBound()`. Uninitialized `thread_pool_` dereferences resulted in a segmentation fault when parallel methods scheduled tasks.
   - Initialized `thread_pool_` with `this->params().num_threads` in constructors, and added a defensive guard in `ComputeLowerBound()` ensuring `thread_pool_` is initialized if null.

### Testing
- Added regression test `SetCoverTest.LagrangianComputeLowerBoundDefaultThreadPool` in `ortools/set_cover/set_cover_test.cc` verifying that `ComputeLowerBound()` executes successfully on a fresh `SetCoverLagrangian` without requiring `UseNumThreads()`.
- Updated `ortools/set_cover/BUILD.bazel` to include `:set_cover_lagrangian` in `set_cover_test` dependencies.
