### PR TITLE
fix(linear_solver): map MPSolverResponseStatus to ResultStatus safely (fixes #5372)

### DIFF
--- a/ortools/linear_solver/BUILD.bazel
+++ b/ortools/linear_solver/BUILD.bazel
@@ -836,6 +836,19 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "linear_solver_test",
+    srcs = ["linear_solver_test.cc"],
+    copts = ORTOOLS_TEST_COPTS,
+    linkopts = ORTOOLS_DEFAULT_LINKOPTS,
+    deps = [
+        ":linear_solver",
+        ":linear_solver_cc_proto",
+        "//ortools/base:gmock_main",
+        "@abseil-cpp//absl/status",
+    ],
+)
+
 cc_library(
     name = "solve_mp_model",
     srcs = ["solve_mp_model.cc"],

--- a/ortools/linear_solver/CMakeLists.txt
+++ b/ortools/linear_solver/CMakeLists.txt
@@ -142,4 +142,9 @@ if(BUILD_CXX_TESTING)
 
     add_test(NAME cxx_unittests_xpress_interface COMMAND test_xprs_interface)
   endif()
+
+  add_executable(linear_solver_test linear_solver_test.cc)
+  target_compile_features(linear_solver_test PRIVATE cxx_std_17)
+  target_link_libraries(linear_solver_test PRIVATE ortools::ortools GTest::gtest_main)
+  add_test(NAME cxx_unittests_linear_solver COMMAND linear_solver_test)
 endif ()

--- a/ortools/linear_solver/highs_interface.cc
+++ b/ortools/linear_solver/highs_interface.cc
@@ -150,7 +150,7 @@ MPSolver::ResultStatus HighsInterface::Solve(const MPSolverParameters& param) {
 
   // The solution must be marked as synchronized even when no solution exists.
   sync_status_ = SOLUTION_SYNCHRONIZED;
-  result_status_ = static_cast<MPSolver::ResultStatus>(response->status());
+  result_status_ = MPSolverResponseStatusToResultStatus(response->status());
 
   if (response->status() == MPSOLVER_FEASIBLE ||
       response->status() == MPSOLVER_OPTIMAL) {

--- a/ortools/linear_solver/linear_solver.cc
+++ b/ortools/linear_solver/linear_solver.cc
@@ -809,7 +809,35 @@ MPSolverResponseStatus MPSolver::LoadModelFromProtoInternal(
   return MPSOLVER_MODEL_IS_VALID;
 }
 
-namespace {
+MPSolver::ResultStatus MPSolverResponseStatusToResultStatus(
+    MPSolverResponseStatus status) {
+  switch (status) {
+    case MPSOLVER_OPTIMAL:
+      return MPSolver::OPTIMAL;
+    case MPSOLVER_FEASIBLE:
+      return MPSolver::FEASIBLE;
+    case MPSOLVER_INFEASIBLE:
+      return MPSolver::INFEASIBLE;
+    case MPSOLVER_UNBOUNDED:
+      return MPSolver::UNBOUNDED;
+    case MPSOLVER_ABNORMAL:
+      return MPSolver::ABNORMAL;
+    case MPSOLVER_MODEL_INVALID:
+    case MPSOLVER_MODEL_INVALID_SOLUTION_HINT:
+    case MPSOLVER_MODEL_INVALID_SOLVER_PARAMETERS:
+    case MPSOLVER_SOLVER_TYPE_UNAVAILABLE:
+    case MPSOLVER_INCOMPATIBLE_OPTIONS:
+      return MPSolver::MODEL_INVALID;
+    case MPSOLVER_NOT_SOLVED:
+    case MPSOLVER_MODEL_IS_VALID:
+      return MPSolver::NOT_SOLVED;
+    case MPSOLVER_CANCELLED_BY_USER:
+    case MPSOLVER_UNKNOWN_STATUS:
+    default:
+      return MPSolver::ABNORMAL;
+  }
+}
+
 MPSolverResponseStatus ResultStatusToMPSolverResponseStatus(
     MPSolver::ResultStatus status) {
   switch (status) {
@@ -830,7 +858,6 @@ MPSolverResponseStatus ResultStatusToMPSolverResponseStatus(
   }
   return MPSOLVER_UNKNOWN_STATUS;
 }
-}  // namespace
 
 void MPSolver::FillSolutionResponseProto(MPSolutionResponse* response) const {
   CHECK(response != nullptr);
@@ -1150,7 +1177,8 @@ void MPSolver::ExportModelToProto(MPModelProto* output_model) const {
 
 absl::Status MPSolver::LoadSolutionFromProto(const MPSolutionResponse& response,
                                              double tolerance) {
-  interface_->result_status_ = static_cast<ResultStatus>(response.status());
+  interface_->result_status_ =
+      MPSolverResponseStatusToResultStatus(response.status());
   if (response.status() != MPSOLVER_OPTIMAL &&
       response.status() != MPSOLVER_FEASIBLE) {
     return absl::InvalidArgumentError(absl::StrCat(

--- a/ortools/linear_solver/linear_solver.h
+++ b/ortools/linear_solver/linear_solver.h
@@ -1624,6 +1624,17 @@ class
 // see the RPC error itself (error code + error message).
 bool MPSolverResponseStatusIsRpcError(MPSolverResponseStatus status);
 
+// Converts an MPSolverResponseStatus to an MPSolver::ResultStatus safely.
+// Unmapped or unknown statuses (such as MPSOLVER_UNKNOWN_STATUS or
+// MPSOLVER_CANCELLED_BY_USER) are mapped to MPSolver::ABNORMAL to prevent
+// out-of-range enum values in client bindings (Java, .NET, etc.).
+MPSolver::ResultStatus MPSolverResponseStatusToResultStatus(
+    MPSolverResponseStatus status);
+
+// Converts an MPSolver::ResultStatus to an MPSolverResponseStatus.
+MPSolverResponseStatus ResultStatusToMPSolverResponseStatus(
+    MPSolver::ResultStatus status);
+
 // This class wraps the actual mathematical programming solvers. Each
 // solver (GLOP, CLP, CBC, GLPK, SCIP) has its own interface class that
 // derives from this abstract class. This class is never directly

--- a/ortools/linear_solver/linear_solver_test.cc
+++ b/ortools/linear_solver/linear_solver_test.cc
@@ -1,0 +1,97 @@
+﻿// Copyright 2010-2025 Google LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ortools/linear_solver/linear_solver.h"
+
+#include "absl/status/status.h"
+#include "gtest/gtest.h"
+#include "ortools/base/gmock.h"
+#include "ortools/linear_solver/linear_solver.pb.h"
+
+namespace operations_research {
+namespace {
+
+TEST(LinearSolverTest, MPSolverResponseStatusToResultStatusMapping) {
+  EXPECT_EQ(MPSolverResponseStatusToResultStatus(MPSOLVER_OPTIMAL),
+            MPSolver::OPTIMAL);
+  EXPECT_EQ(MPSolverResponseStatusToResultStatus(MPSOLVER_FEASIBLE),
+            MPSolver::FEASIBLE);
+  EXPECT_EQ(MPSolverResponseStatusToResultStatus(MPSOLVER_INFEASIBLE),
+            MPSolver::INFEASIBLE);
+  EXPECT_EQ(MPSolverResponseStatusToResultStatus(MPSOLVER_UNBOUNDED),
+            MPSolver::UNBOUNDED);
+  EXPECT_EQ(MPSolverResponseStatusToResultStatus(MPSOLVER_ABNORMAL),
+            MPSolver::ABNORMAL);
+  EXPECT_EQ(MPSolverResponseStatusToResultStatus(MPSOLVER_MODEL_INVALID),
+            MPSolver::MODEL_INVALID);
+  EXPECT_EQ(MPSolverResponseStatusToResultStatus(
+                MPSOLVER_MODEL_INVALID_SOLUTION_HINT),
+            MPSolver::MODEL_INVALID);
+  EXPECT_EQ(MPSolverResponseStatusToResultStatus(
+                MPSOLVER_MODEL_INVALID_SOLVER_PARAMETERS),
+            MPSolver::MODEL_INVALID);
+  EXPECT_EQ(MPSolverResponseStatusToResultStatus(
+                MPSOLVER_SOLVER_TYPE_UNAVAILABLE),
+            MPSolver::MODEL_INVALID);
+  EXPECT_EQ(MPSolverResponseStatusToResultStatus(
+                MPSOLVER_INCOMPATIBLE_OPTIONS),
+            MPSolver::MODEL_INVALID);
+  EXPECT_EQ(MPSolverResponseStatusToResultStatus(MPSOLVER_NOT_SOLVED),
+            MPSolver::NOT_SOLVED);
+  EXPECT_EQ(MPSolverResponseStatusToResultStatus(MPSOLVER_MODEL_IS_VALID),
+            MPSolver::NOT_SOLVED);
+
+  // Verifies that unknown or unmapped response statuses (such as
+  // MPSOLVER_UNKNOWN_STATUS = 99 or MPSOLVER_CANCELLED_BY_USER = 98) safely map
+  // to ABNORMAL rather than leaking raw integer values into client wrappers.
+  EXPECT_EQ(MPSolverResponseStatusToResultStatus(MPSOLVER_CANCELLED_BY_USER),
+            MPSolver::ABNORMAL);
+  EXPECT_EQ(MPSolverResponseStatusToResultStatus(MPSOLVER_UNKNOWN_STATUS),
+            MPSolver::ABNORMAL);
+  EXPECT_EQ(MPSolverResponseStatusToResultStatus(
+                static_cast<MPSolverResponseStatus>(999)),
+            MPSolver::ABNORMAL);
+}
+
+TEST(LinearSolverTest, ResultStatusToMPSolverResponseStatusMapping) {
+  EXPECT_EQ(ResultStatusToMPSolverResponseStatus(MPSolver::OPTIMAL),
+            MPSOLVER_OPTIMAL);
+  EXPECT_EQ(ResultStatusToMPSolverResponseStatus(MPSolver::FEASIBLE),
+            MPSOLVER_FEASIBLE);
+  EXPECT_EQ(ResultStatusToMPSolverResponseStatus(MPSolver::INFEASIBLE),
+            MPSOLVER_INFEASIBLE);
+  EXPECT_EQ(ResultStatusToMPSolverResponseStatus(MPSolver::UNBOUNDED),
+            MPSOLVER_UNBOUNDED);
+  EXPECT_EQ(ResultStatusToMPSolverResponseStatus(MPSolver::ABNORMAL),
+            MPSOLVER_ABNORMAL);
+  EXPECT_EQ(ResultStatusToMPSolverResponseStatus(MPSolver::MODEL_INVALID),
+            MPSOLVER_MODEL_INVALID);
+  EXPECT_EQ(ResultStatusToMPSolverResponseStatus(MPSolver::NOT_SOLVED),
+            MPSOLVER_NOT_SOLVED);
+}
+
+TEST(LinearSolverTest, LoadSolutionFromProtoWithUnknownStatus) {
+  MPSolver solver("test", MPSolver::GLOP_LINEAR_PROGRAMMING);
+  MPSolutionResponse response;
+  response.set_status(MPSOLVER_UNKNOWN_STATUS);
+
+  const absl::Status status = solver.LoadSolutionFromProto(response);
+  EXPECT_FALSE(status.ok());
+
+  MPSolutionResponse out_response;
+  solver.FillSolutionResponseProto(&out_response);
+  EXPECT_EQ(out_response.status(), MPSOLVER_ABNORMAL);
+}
+
+}  // namespace
+}  // namespace operations_research

--- a/ortools/linear_solver/pdlp_interface.cc
+++ b/ortools/linear_solver/pdlp_interface.cc
@@ -167,7 +167,7 @@ MPSolver::ResultStatus PdlpInterface::Solve(const MPSolverParameters& param) {
     // to return a proper status, and is not convertible to an MPSolver status.
     result_status_ = MPSolver::NOT_SOLVED;
   } else {
-    result_status_ = static_cast<MPSolver::ResultStatus>(response->status());
+    result_status_ = MPSolverResponseStatusToResultStatus(response->status());
   }
   if (response->has_solver_specific_info()) {
     if (!solve_log_.ParseFromString(response->solver_specific_info())) {

--- a/ortools/linear_solver/sat_interface.cc
+++ b/ortools/linear_solver/sat_interface.cc
@@ -146,32 +146,7 @@ MPSolver::ResultStatus SatInterface::Solve(const MPSolverParameters& param) {
 
   // The solution must be marked as synchronized even when no solution exists.
   sync_status_ = SOLUTION_SYNCHRONIZED;
-  switch (response.status()) {
-    case MPSOLVER_OPTIMAL:
-      result_status_ = MPSolver::OPTIMAL;
-      break;
-    case MPSOLVER_FEASIBLE:
-      result_status_ = MPSolver::FEASIBLE;
-      break;
-    case MPSOLVER_INFEASIBLE:
-      result_status_ = MPSolver::INFEASIBLE;
-      break;
-    case MPSOLVER_UNBOUNDED:
-      result_status_ = MPSolver::UNBOUNDED;
-      break;
-    case MPSOLVER_ABNORMAL:
-      result_status_ = MPSolver::ABNORMAL;
-      break;
-    case MPSOLVER_MODEL_INVALID:
-      result_status_ = MPSolver::MODEL_INVALID;
-      break;
-    case MPSOLVER_NOT_SOLVED:
-      result_status_ = MPSolver::NOT_SOLVED;
-      break;
-    default:
-      result_status_ = MPSolver::ABNORMAL;
-      break;
-  }
+  result_status_ = MPSolverResponseStatusToResultStatus(response.status());
 
   if (response.status() == MPSOLVER_FEASIBLE ||
       response.status() == MPSOLVER_OPTIMAL) {


### PR DESCRIPTION
### Description

Fixes #5372.

When solvers (such as HiGHS, PDLP, or SAT) terminate due to a limit or non-standard condition without a primal solution, or when an unknown status is returned, the response proto contains statuses such as `MPSOLVER_UNKNOWN_STATUS` (value 99), `MPSOLVER_CANCELLED_BY_USER` (value 98), or model invalid parameter codes (84, 85, etc.).

Previously:
- `MPSolver::LoadSolutionFromProto`: `interface_->result_status_ = static_cast<ResultStatus>(response.status());`
- `HighsInterface::Solve`: `result_status_ = static_cast<MPSolver::ResultStatus>(response->status());`
- `PdlpInterface::Solve`: `result_status_ = static_cast<MPSolver::ResultStatus>(response->status());`

Casting `MPSolverResponseStatus` directly into `MPSolver::ResultStatus` causes out-of-range integer values (e.g. 99) to be assigned to `result_status_`. When queried via SWIG in Java (or .NET), this throws an unhandled exception:
```
java.lang.IllegalArgumentException: No enum class com.google.ortools.linearsolver.MPSolver$ResultStatus with value 99
    at com.google.ortools.linearsolver.MPSolver$ResultStatus.swigToEnum(MPSolver.java:760)
    at com.google.ortools.linearsolver.MPSolver.solve(MPSolver.java:326)
```

### Changes
1. **Public Conversion Utility**: Declared and implemented `MPSolverResponseStatusToResultStatus` in `linear_solver.h` / `linear_solver.cc`.
   - Explicitly maps standard statuses (`OPTIMAL`, `FEASIBLE`, `INFEASIBLE`, `UNBOUNDED`, `ABNORMAL`, `MODEL_INVALID`, `NOT_SOLVED`).
   - Extended validation/options errors (`MPSOLVER_MODEL_INVALID_*`, `MPSOLVER_SOLVER_TYPE_UNAVAILABLE`, `MPSOLVER_INCOMPATIBLE_OPTIONS`) map to `MODEL_INVALID`.
   - Unknown/unhandled statuses (`MPSOLVER_UNKNOWN_STATUS`, `MPSOLVER_CANCELLED_BY_USER`, default) safely map to `MPSolver::ABNORMAL` instead of leaking out-of-range enum values.
2. **Standardized Interfaces**:
   - `MPSolver::LoadSolutionFromProto`, `HighsInterface::Solve`, `PdlpInterface::Solve`, and `SatInterface::Solve` now all route through `MPSolverResponseStatusToResultStatus`.
3. **Unit Tests**:
   - Added `ortools/linear_solver/linear_solver_test.cc` verifying bidirectional conversions, unmapped status handling, and `LoadSolutionFromProto` behavior on unknown status values.
   - Updated `ortools/linear_solver/BUILD.bazel` and `CMakeLists.txt` to register `linear_solver_test`.
