### PR TITLE
Add Windows ARM64 Python build

### DIFF
--- a/.github/workflows/arm64_windows_cmake_python.yml
+++ b/.github/workflows/arm64_windows_cmake_python.yml
@@ -1,0 +1,107 @@
+# ref: https://github.com/actions/runner-images
+name: arm64 Windows CMake Python
+
+on:
+  push:
+    branches:
+      - ci
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: true
+
+# Building using the github runner environment directly.
+jobs:
+  native:
+    strategy:
+      matrix:
+        cmake: [
+          {name: "VS2026", generator: "Visual Studio 18 2026", config: Release},
+        ]
+        # note: CPython does not ship a win-arm64 build before 3.11
+        python: [
+          #{version: "3.11", dir: Python311},
+          #{version: "3.12", dir: Python312},
+          {version: "3.13", dir: Python313},
+          {version: "3.14", dir: Python314},
+        ]
+      fail-fast: false
+    name: arm64•Windows•CMake(${{matrix.cmake.name}})•Python-${{matrix.python.version}}
+    runs-on: windows-11-vs2026-arm
+    env:
+      deps_src_key: arm64_windows_python_deps_src
+      deps_build_key: arm64_windows_python_deps_build_${{matrix.cmake.config}}
+      CTEST_OUTPUT_ON_FAILURE: 1
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/remote_cache
+        with:
+          credentials_json: '${{secrets.GCP_BUCKET_API_KEY}}'
+          set_cmake_sccache_launcher: true
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{matrix.python.version}}
+          architecture: arm64
+      - name: Install python3
+        run: python3 -m pip install --user mypy-protobuf absl-py setuptools wheel numpy pandas
+      - name: Add Python binaries to path
+        run: >
+          echo "$((Get-Item ~).FullName)/AppData/Roaming/Python/${{matrix.python.dir}}/Scripts" |
+          Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      # CONFIGURING CACHES
+      - name: Cache CMake dependency source code
+        uses: actions/cache@v6
+        with:
+          key: ${{env.deps_src_key}}-${{hashFiles('CMakeLists.txt', 'cmake/**')}}
+          path: ${{github.workspace}}/build/_deps/*-src
+      - name: Cache CMake dependency build
+        uses: actions/cache@v6
+        with:
+          key: ${{env.deps_build_key}}-${{hashFiles('CMakeLists.txt', 'cmake/**')}}
+          path: |
+            ${{github.workspace}}/build/_deps/*-build
+            ${{github.workspace}}/build/_deps/*-subbuild
+
+      - name: Check CMake
+        run: |
+          cmake --version
+          cmake -G || true
+      - name: Configure
+        run: >
+          cmake -S. -Bbuild
+          -G "${{matrix.cmake.generator}}"
+          -A ARM64
+          -DCMAKE_CONFIGURATION_TYPES=${{matrix.cmake.config}}
+          -DBUILD_CXX_SAMPLES=OFF -DBUILD_CXX_EXAMPLES=OFF
+          -DBUILD_PYTHON=ON
+      - id: num_cores
+        uses: ./.github/actions/num_cores
+      - name: Build
+        run: >
+          cmake --build build
+          --config ${{matrix.cmake.config}}
+          --target ALL_BUILD
+          -j${{ steps.num_cores.outputs.cores }}
+          -v
+      - name: Test
+        run: >
+          cmake --build build
+          --config ${{matrix.cmake.config}}
+          --target RUN_TESTS
+          -j${{ steps.num_cores.outputs.cores }}
+          -v
+      - name: Install
+        run: >
+          cmake --build build
+          --config ${{matrix.cmake.config}}
+          --target INSTALL
+          -v
+
+  arm64_windows_cmake_python:
+    runs-on: ubuntu-latest
+    needs: native
+    steps:
+      - uses: actions/checkout@v7

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -6,6 +6,7 @@
 | arm64 MacOS   | [![Status][arm64_macos_cpp_svg]][arm64_macos_cpp_link] | [![Status][arm64_macos_python_svg]][arm64_macos_python_link] | [![Status][arm64_macos_java_svg]][arm64_macos_java_link] | [![Status][arm64_macos_dotnet_svg]][arm64_macos_dotnet_link] |
 | amd64 MacOS   | [![Status][amd64_macos_cpp_svg]][amd64_macos_cpp_link] | [![Status][amd64_macos_python_svg]][amd64_macos_python_link] | [![Status][amd64_macos_java_svg]][amd64_macos_java_link] | [![Status][amd64_macos_dotnet_svg]][amd64_macos_dotnet_link] |
 | amd64 Windows | [![Status][windows_cpp_svg]][windows_cpp_link] | [![Status][windows_python_svg]][windows_python_link] | [![Status][windows_java_svg]][windows_java_link] | [![Status][windows_dotnet_svg]][windows_dotnet_link] |
+| arm64 Windows | | [![Status][arm64_windows_python_svg]][arm64_windows_python_link] | | |
 
 [linux_cpp_svg]: ./../../../actions/workflows/amd64_linux_cmake_cpp.yml/badge.svg?branch=main
 [linux_cpp_link]: ./../../../actions/workflows/amd64_linux_cmake_cpp.yml
@@ -42,6 +43,9 @@
 [windows_java_link]: ./../../../actions/workflows/amd64_windows_cmake_java.yml
 [windows_dotnet_svg]: ./../../../actions/workflows/amd64_windows_cmake_dotnet.yml/badge.svg?branch=main
 [windows_dotnet_link]: ./../../../actions/workflows/amd64_windows_cmake_dotnet.yml
+
+[arm64_windows_python_svg]: ./../../../actions/workflows/arm64_windows_cmake_python.yml/badge.svg?branch=main
+[arm64_windows_python_link]: ./../../../actions/workflows/arm64_windows_cmake_python.yml
 
 Dockers:
 \[AlmaLinux, Alpine, Archlinux, Debian, Fedora, OpenSuse, RockyLinux, Ubuntu\]x

--- a/cmake/docs/python.md
+++ b/cmake/docs/python.md
@@ -1,6 +1,6 @@
-| amd64 Linux | arm64 macOS | amd64 macOS | amd64 Windows |
-| :---: | :---: | :---: | :---: |
-| [![Status][linux_python_svg]][linux_python_link] | [![Status][arm64_macos_python_svg]][arm64_macos_python_link] | [![Status][amd64_macos_python_svg]][amd64_macos_python_link] | [![Status][windows_python_svg]][windows_python_link] |
+| amd64 Linux | arm64 macOS | amd64 macOS | amd64 Windows | arm64 Windows |
+| :---: | :---: | :---: | :---: | :---: |
+| [![Status][linux_python_svg]][linux_python_link] | [![Status][arm64_macos_python_svg]][arm64_macos_python_link] | [![Status][amd64_macos_python_svg]][amd64_macos_python_link] | [![Status][windows_python_svg]][windows_python_link] | [![Status][arm64_windows_python_svg]][arm64_windows_python_link] |
 
 [linux_python_svg]: ./../../../../actions/workflows/amd64_linux_cmake_python.yml/badge.svg?branch=main
 [linux_python_link]: ./../../../../actions/workflows/amd64_linux_cmake_python.yml
@@ -10,6 +10,8 @@
 [amd64_macos_python_link]: ./../../../../actions/workflows/amd64_macos_cmake__python.yml
 [windows_python_svg]: ./../../../../actions/workflows/amd64_windows_cmake_python.yml/badge.svg?branch=main
 [windows_python_link]: ./../../../../actions/workflows/amd64_windows_cmake_python.yml
+[arm64_windows_python_svg]: ./../../../../actions/workflows/arm64_windows_cmake_python.yml/badge.svg?branch=main
+[arm64_windows_python_link]: ./../../../../actions/workflows/arm64_windows_cmake_python.yml
 
 # Introduction
 

--- a/ortools/graph_base/generic_graph_test.cc
+++ b/ortools/graph_base/generic_graph_test.cc
@@ -121,13 +121,13 @@ TEST(GenericGraphTest, BuilderAndGraphAreMovable) {
 TEST(GenericGraphDeathTest, AddMoreNodesThanReserved) {
   GenericGraph<char>::Builder builder(/*num_nodes=*/2, /*num_edges=*/3);
   builder.AddEdge('a', 'b');
-  if constexpr (DEBUG_MODE) {
-    EXPECT_DEATH(builder.AddEdge('c', 'a'), "const_capacities");
-  } else {
-    builder.AddEdge('c', 'a');
-    EXPECT_THAT(std::move(builder).Build().AllNodes(),
-                ElementsAre('a', 'b', 'c'));
-  }
+#ifndef NDEBUG
+  EXPECT_DEATH(builder.AddEdge('c', 'a'), "const_capacities");
+#else
+  builder.AddEdge('c', 'a');
+  EXPECT_THAT(std::move(builder).Build().AllNodes(),
+              ElementsAre('a', 'b', 'c'));
+#endif
 }
 
 TEST(GenericGraphDeathTest, AddMoreEdgesThanReserved) {

--- a/patches/scip-v10.0.3.patch
+++ b/patches/scip-v10.0.3.patch
@@ -107,3 +107,18 @@ index c6ce7283..6b6b1fc8 100644
  install(FILES "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/scip-config.cmake"
                ${PROJECT_BINARY_DIR}/scip-config-version.cmake
          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/scip)
+diff --git a/src/scip/intervalarith.c b/src/scip/intervalarith.c
+index 7d53fb9..ce81c4b 100644
+--- a/src/scip/intervalarith.c
++++ b/src/scip/intervalarith.c
+@@ -301,8 +301,9 @@ double negate(
+ 
+ /* cl or icl compiler on 32bit windows or icl compiler on 64bit windows
+  * cl on 64bit windows does not seem to support inline assembler
++ * cl on arm windows does not support inline assembler at all
+  */
+-#elif defined(_MSC_VER) && (defined(__INTEL_COMPILER) || !defined(_M_X64))
++#elif defined(_MSC_VER) && !defined(_M_ARM) && !defined(_M_ARM64) && !defined(_M_ARM64EC) && (defined(__INTEL_COMPILER) || !defined(_M_X64))
+ 
+ /** gets the negation of a double
+  * Do this in a way that the compiler does not "optimize" it away, which usually does not considers rounding modes.


### PR DESCRIPTION
As the title says -- mostly just a copy of the existing AMD64 workflow, but with some minor changes for MSVC ARM64.

I have tested these on my fork and the build passes. 